### PR TITLE
Fix clang-tidy errors in master

### DIFF
--- a/source/host_resolver.c
+++ b/source/host_resolver.c
@@ -184,7 +184,8 @@ static inline void process_records(struct aws_allocator *allocator, struct aws_l
                     aws_lru_cache_remove(failed_records, lru_element->address);
                     break;
                 }
-                else if (to_add) {
+                
+                if (to_add) {
                     aws_mem_release(allocator, to_add);
                 }
             }
@@ -257,9 +258,8 @@ static int resolver_record_connection_failure(struct aws_host_resolver *resolver
         return AWS_OP_ERR;
 
     }
-    else {
-        aws_rw_lock_runlock(&default_host_resolver->host_lock);
-    }
+
+    aws_rw_lock_runlock(&default_host_resolver->host_lock);
 
     return AWS_OP_SUCCESS;
 }
@@ -535,18 +535,18 @@ static inline int create_and_init_host_entry(struct aws_host_resolver *resolver,
         on_host_value_removed(new_host_entry);
         aws_rw_lock_wunlock(&default_host_resolver->host_lock);
         return AWS_OP_SUCCESS;
-    } else {
-        host_entry = new_host_entry;
-        host_entry->keep_active = true;
-
-        if (AWS_UNLIKELY(aws_lru_cache_put(&default_host_resolver->host_table, host_string_copy, host_entry))) {
-            goto setup_host_entry_error;
-        }
-
-        aws_thread_launch(&new_host_entry->resolver_thread, resolver_thread_fn, host_entry, NULL);
-        aws_rw_lock_wunlock(&default_host_resolver->host_lock);
-        return AWS_OP_SUCCESS;
     }
+    
+    host_entry = new_host_entry;
+    host_entry->keep_active = true;
+
+    if (AWS_UNLIKELY(aws_lru_cache_put(&default_host_resolver->host_table, host_string_copy, host_entry))) {
+        goto setup_host_entry_error;
+    }
+
+    aws_thread_launch(&new_host_entry->resolver_thread, resolver_thread_fn, host_entry, NULL);
+    aws_rw_lock_wunlock(&default_host_resolver->host_lock);
+    return AWS_OP_SUCCESS;
 
 setup_host_entry_error:
     if (host_string_copy) {

--- a/source/posix/host_resolver.c
+++ b/source/posix/host_resolver.c
@@ -22,6 +22,8 @@
 
 int aws_default_dns_resolve(struct aws_allocator *allocator, const struct aws_string *host_name,
                         struct aws_array_list *output_addresses, void *user_data) {
+                            
+    (void)user_data;
     struct addrinfo *result = NULL;
     struct addrinfo *iter = NULL;
     /* max string length for ipv6. */

--- a/tests/default_host_resolver_test.c
+++ b/tests/default_host_resolver_test.c
@@ -21,8 +21,6 @@
 #include <aws/common/condition_variable.h>
 #include <aws/common/thread.h>
 
-#include <mock_dns_resolver.c>
-
 static const uint64_t FORCE_RESOLVE_SLEEP_TIME = 1500000000;
 
 struct default_host_callback_data {
@@ -44,6 +42,11 @@ static void s_default_host_resolved_test_callback(struct aws_host_resolver *reso
                                                   const struct aws_string *host_name,
                                                   int err_code, const struct aws_array_list *host_addresses,
                                                   void *user_data) {
+
+    (void)resolver;
+    (void)host_name;
+    (void)err_code;
+
     struct default_host_callback_data *callback_data = user_data;
 
     struct aws_host_address *host_address = NULL;
@@ -70,7 +73,8 @@ static void s_default_host_resolved_test_callback(struct aws_host_resolver *reso
     aws_condition_variable_notify_one(&callback_data->condition_variable);
 }
 
-static int s_test_default_with_ipv6_lookup_fn(struct aws_allocator *allocator, void *user_data) {
+static int s_test_default_with_ipv6_lookup_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
     struct aws_host_resolver resolver;
 
     ASSERT_SUCCESS(aws_host_resolver_default_init(&resolver, allocator, 10));
@@ -124,7 +128,8 @@ static int s_test_default_with_ipv6_lookup_fn(struct aws_allocator *allocator, v
 AWS_TEST_CASE(test_default_with_ipv6_lookup, s_test_default_with_ipv6_lookup_fn)
 
 /* just FYI, this test assumes that "s3.us-east-1.amazonaws.com" does not return IPv6 addresses. */
-static int s_test_default_with_ipv4_only_lookup_fn(struct aws_allocator *allocator, void *user_data) {
+static int s_test_default_with_ipv4_only_lookup_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
     struct aws_host_resolver resolver;
 
     ASSERT_SUCCESS(aws_host_resolver_default_init(&resolver, allocator, 10));
@@ -179,7 +184,8 @@ AWS_TEST_CASE(test_default_with_ipv4_only_lookup, s_test_default_with_ipv4_only_
  * The third assumption is that this test runs in less than one second after the first background resolve.
  * The fourth assumption is that S3 does not return multiple addresses per A or AAAA record.
  * If any of these assumptions ever change, this test will likely be broken, but I don't know of a better way to test this end-to-end. */
-static int s_test_default_with_multiple_lookups_fn(struct aws_allocator *allocator, void *user_data) {
+static int s_test_default_with_multiple_lookups_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
     struct aws_host_resolver resolver;
 
     ASSERT_SUCCESS(aws_host_resolver_default_init(&resolver, allocator, 10));
@@ -266,7 +272,8 @@ static int s_test_default_with_multiple_lookups_fn(struct aws_allocator *allocat
 
 AWS_TEST_CASE(test_default_with_multiple_lookups, s_test_default_with_multiple_lookups_fn)
 
-static int s_test_resolver_ttls_fn(struct aws_allocator *allocator, void *user_data) {
+static int s_test_resolver_ttls_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
     struct aws_host_resolver resolver;
 
     ASSERT_SUCCESS(aws_host_resolver_default_init(&resolver, allocator, 10));
@@ -427,7 +434,8 @@ static int s_test_resolver_ttls_fn(struct aws_allocator *allocator, void *user_d
 
 AWS_TEST_CASE(test_resolver_ttls, s_test_resolver_ttls_fn)
 
-static int s_test_resolver_connect_failure_recording_fn(struct aws_allocator *allocator, void *user_data) {
+static int s_test_resolver_connect_failure_recording_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
     struct aws_host_resolver resolver;
 
     ASSERT_SUCCESS(aws_host_resolver_default_init(&resolver, allocator, 10));
@@ -600,7 +608,8 @@ static int s_test_resolver_connect_failure_recording_fn(struct aws_allocator *al
 
 AWS_TEST_CASE(test_resolver_connect_failure_recording, s_test_resolver_connect_failure_recording_fn)
 
-static int s_test_resolver_ttl_refreshes_on_resolve_fn(struct aws_allocator *allocator, void *user_data) {
+static int s_test_resolver_ttl_refreshes_on_resolve_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
     struct aws_host_resolver resolver;
 
     ASSERT_SUCCESS(aws_host_resolver_default_init(&resolver, allocator, 10));

--- a/tests/main.c
+++ b/tests/main.c
@@ -26,6 +26,9 @@
 #include <read_write_test_handler.c>
 
 #include <channel_test.c>
+
+#include <mock_dns_resolver.c>
+
 #include <default_host_resolver_test.c>
 
 static int s_run_tests(int argc, char *argv[]) {

--- a/tests/mock_dns_resolver.c
+++ b/tests/mock_dns_resolver.c
@@ -1,5 +1,3 @@
-#ifndef MOCK_DNS_RESOLVER_H
-#define MOCK_DNS_RESOLVER_H
 /*
 * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
 *
@@ -52,6 +50,9 @@ static int mock_dns_resolver_append_address_list(struct mock_dns_resolver *resol
 }
 
 static int mock_dns_resolve(struct aws_allocator *allocator, const struct aws_string *host_name, struct aws_array_list *output_addresses, void *user_data) {
+
+    (void)allocator;
+    (void)host_name;
     struct mock_dns_resolver *mock_resolver = user_data;
 
     if (mock_resolver->resolve_count == mock_resolver->max_resolves) {
@@ -77,5 +78,3 @@ static int mock_dns_resolve(struct aws_allocator *allocator, const struct aws_st
 
     return AWS_OP_SUCCESS;
 }
-
-#endif


### PR DESCRIPTION
We really need to set up continuous integration 😬 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
