### PR TITLE
fix wrong parameter order in calls to aws_timestamp_convert()

### DIFF
--- a/source/linux/epoll_event_loop.c
+++ b/source/linux/epoll_event_loop.c
@@ -499,7 +499,7 @@ static void s_main_loop(void *args) {
         } else {
             /* Translate timestamp (in nanoseconds) to timeout (in milliseconds) */
             uint64_t timeout_ns = (next_run_time_ns > now_ns) ? (next_run_time_ns - now_ns) : 0;
-            uint64_t timeout_ms64 = aws_timestamp_convert(AWS_TIMESTAMP_NANOS, AWS_TIMESTAMP_MILLIS, timeout_ns, NULL);
+            uint64_t timeout_ms64 = aws_timestamp_convert(timeout_ns, AWS_TIMESTAMP_NANOS, AWS_TIMESTAMP_MILLIS, NULL);
             timeout = timeout_ms64 > INT_MAX ? INT_MAX : (int)timeout_ms64;
         }
     }

--- a/source/windows/iocp/iocp_event_loop.c
+++ b/source/windows/iocp/iocp_event_loop.c
@@ -531,7 +531,7 @@ static void s_event_thread_main(void *user_data) {
         } else {
             /* Translate timestamp (in nanoseconds) to timeout (in milliseconds) */
             uint64_t timeout_ns = (next_run_time_ns > now_ns) ? (next_run_time_ns - now_ns) : 0;
-            uint64_t timeout_ms64 = aws_timestamp_convert(AWS_TIMESTAMP_NANOS, AWS_TIMESTAMP_MILLIS, timeout_ns, NULL);
+            uint64_t timeout_ms64 = aws_timestamp_convert(timeout_ns, AWS_TIMESTAMP_NANOS, AWS_TIMESTAMP_MILLIS, NULL);
             timeout_ms = timeout_ms64 > MAXDWORD ? MAXDWORD : (DWORD)timeout_ms64;
         }
     }


### PR DESCRIPTION
whoopsie doopsie

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
