### PR TITLE
Ability specify branch/changeset/tag of a codebuild dependency

### DIFF
--- a/codebuild/common-linux.sh
+++ b/codebuild/common-linux.sh
@@ -27,7 +27,7 @@ cd ../
 
 mkdir install
 
-install_library s2n
+install_library s2n 98225d7
 install_library aws-c-common
 
 cd aws-c-io


### PR DESCRIPTION
s2n is fixed now, but yesterday it was broken and blocking a PR.
If I had this, I could have set "cc339f5^" to pull a working commit.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
