### PR TITLE
replace aws_channel_init() with aws_channel_new()

### DIFF
--- a/include/aws/io/channel.h
+++ b/include/aws/io/channel.h
@@ -131,7 +131,8 @@ struct aws_channel *aws_channel_new(
     struct aws_channel_creation_callbacks *callbacks);
 
 /**
- * Destroy the channel, along with all slots and handlers. Must be called after shutdown has completed.
+ * Destroy the channel, along with all slots and handlers.
+ * Must be called after shutdown has completed.
  * Can be called from any thread assuming 'aws_channel_shutdown()' has completed.
  */
 AWS_IO_API

--- a/include/aws/io/channel.h
+++ b/include/aws/io/channel.h
@@ -25,41 +25,15 @@ enum aws_channel_direction {
 };
 
 struct aws_channel;
+struct aws_channel_slot;
+struct aws_channel_handler;
 struct aws_event_loop;
 struct aws_event_loop_local_object;
-struct aws_io_message;
-struct aws_task;
-struct aws_message_pool;
 
 typedef void(aws_channel_on_setup_completed_fn)(struct aws_channel *channel, int error_code, void *user_data);
 
 /* Callback called when a channel is completely shutdown. error_code refers to the reason the channel was closed. */
 typedef void(aws_channel_on_shutdown_completed_fn)(struct aws_channel *channel, int error_code, void *user_data);
-
-enum aws_channel_state {
-    AWS_CHANNEL_SETTING_UP,
-    AWS_CHANNEL_ACTIVE,
-    AWS_CHANNEL_SHUTTING_DOWN,
-    AWS_CHANNEL_SHUT_DOWN,
-};
-
-struct aws_shutdown_notification_task {
-    struct aws_task task;
-    int error_code;
-    struct aws_channel_slot *slot;
-    bool shutdown_immediately;
-};
-
-struct aws_channel {
-    struct aws_allocator *alloc;
-    struct aws_event_loop *loop;
-    struct aws_channel_slot *first;
-    struct aws_message_pool *msg_pool;
-    enum aws_channel_state channel_state;
-    struct aws_shutdown_notification_task shutdown_notify_task;
-    aws_channel_on_shutdown_completed_fn *on_shutdown_completed;
-    void *shutdown_user_data;
-};
 
 struct aws_channel_creation_callbacks {
     aws_channel_on_setup_completed_fn *on_setup_completed;
@@ -67,8 +41,6 @@ struct aws_channel_creation_callbacks {
     void *setup_user_data;
     void *shutdown_user_data;
 };
-
-struct aws_channel_handler;
 
 struct aws_channel_slot {
     struct aws_allocator *alloc;
@@ -148,23 +120,22 @@ extern "C" {
 #endif
 
 /**
- * Initializes the channel, with event loop to use for IO and tasks. callbacks->on_setup_completed will be invoked when
+ * Allocates new channel, with event loop to use for IO and tasks. callbacks->on_setup_completed will be invoked when
  * the setup process is finished It will be executed in the event loop's thread. callbacks is copied. Unless otherwise
  * specified all functions for channels and channel slots must be executed within that channel's event-loop's thread.
  */
 AWS_IO_API
-int aws_channel_init(
-    struct aws_channel *channel,
+struct aws_channel *aws_channel_new(
     struct aws_allocator *alloc,
     struct aws_event_loop *event_loop,
     struct aws_channel_creation_callbacks *callbacks);
 
 /**
- * Cleans up all slots and handlers. Must be called after shutdown has completed. Can be called from any thread assuming
- * 'aws_channel_shutdown()' has completed.
+ * Destroy the channel, along with all slots and handlers. Must be called after shutdown has completed.
+ * Can be called from any thread assuming 'aws_channel_shutdown()' has completed.
  */
 AWS_IO_API
-void aws_channel_clean_up(struct aws_channel *channel);
+void aws_channel_destroy(struct aws_channel *channel);
 
 /**
  * Initiates shutdown of the channel. Shutdown will begin with the left-most slot. Each handler will invoke

--- a/source/channel.c
+++ b/source/channel.c
@@ -186,9 +186,15 @@ static void s_cleanup_slot(struct aws_channel_slot *slot) {
 
 void aws_channel_destroy(struct aws_channel *channel) {
 
-    channel->channel_state = AWS_CHANNEL_SHUT_DOWN;
-
     struct aws_channel_slot *current = channel->first;
+
+    if (!current || !current->handler) {
+        /* Allow channels with no valid slots to shutdown process */
+        channel->channel_state = AWS_CHANNEL_SHUT_DOWN;
+    }
+
+    assert(channel->channel_state == AWS_CHANNEL_SHUT_DOWN);
+
     while (current) {
         struct aws_channel_slot *tmp = current->adj_right;
         s_cleanup_slot(current);

--- a/source/socket_channel_handler.c
+++ b/source/socket_channel_handler.c
@@ -33,7 +33,6 @@ struct socket_handler {
     struct aws_task read_task_storage;
     struct aws_task shutdown_task_storage;
     int shutdown_err_code;
-    struct aws_io_message *current_write_message;
     bool shutdown_in_progress;
 };
 
@@ -68,17 +67,7 @@ static void s_on_socket_write_complete(
             message->on_completion(channel, message, error_code, message->user_data);
         }
 
-        /* this isn't the simplest way to handle this BUT in order to keep the contract of "release your message
-         * if the channel says the message send fails", we need to not release it if we failed to send AND
-         * we told the caller that we failed. */
-        struct socket_handler *handler = channel->first->handler->impl;
-        if (!error_code || handler->current_write_message != message) {
-            aws_channel_release_message_to_pool(channel, message);
-        }
-
-        if (handler->current_write_message == message) {
-            handler->current_write_message = NULL;
-        }
+        aws_channel_release_message_to_pool(channel, message);
 
         if (error_code) {
             aws_channel_shutdown(channel, error_code);
@@ -93,19 +82,11 @@ static int s_socket_process_write_message(
     (void)slot;
     struct socket_handler *socket_handler = handler->impl;
 
-    /* you'll see why we do this in a sec. */
-    assert(message->owning_channel->first->handler->impl == socket_handler);
-
     struct aws_byte_cursor cursor = aws_byte_cursor_from_buf(&message->message_data);
-    /* this isn't the simplest way to handle this BUT in order to keep the contract of "release your message
-     * if the channel says the message send fails", we need to not release it if we failed to send AND
-     * we told the caller that we failed. */
-    socket_handler->current_write_message = message;
     if (aws_socket_write(socket_handler->socket, &cursor, s_on_socket_write_complete, message)) {
         return AWS_OP_ERR;
     }
 
-    socket_handler->current_write_message = NULL;
     return AWS_OP_SUCCESS;
 }
 
@@ -292,7 +273,6 @@ struct aws_channel_handler *aws_socket_handler_new(
     /* make sure something has assigned this socket to an event loop, in client mode this will already have occurred.
        In server mode, someone should have assigned it before calling us.*/
     assert(aws_socket_get_event_loop(socket));
-    assert(aws_socket_get_event_loop(socket) == slot->channel->loop);
 
     struct aws_channel_handler *handler = NULL;
 
@@ -309,7 +289,6 @@ struct aws_channel_handler *aws_socket_handler_new(
     impl->read_task_storage.fn = NULL;
     impl->read_task_storage.arg = NULL;
     impl->shutdown_in_progress = false;
-    impl->current_write_message = NULL;
 
     handler->alloc = allocator;
     handler->impl = impl;


### PR DESCRIPTION
Channel's can't just vanish, we'll need to move to some kind of ref-counting scheme, so in preparation...

- Replace _init() and _clean_up() with _new() and _destroy().
- Move channel struct declaration to .C file, since it doesn't need to be public anymore.
- Remove some asserts 😞 that were checking against aws_channel's internal members (which are now private). I can put in query functions if we thinks these asserts (mostly in unit tests) are still valuable.
- Fix aws_socket_write() so that, if it returns AWS_OP_ERROR, then the write callback is not ALSO invoked with an error code.
    - Remove hacks in socket_channel_handler which were working around the previous behavior.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
