### PR TITLE
Removed tls_ctx from bootstrap and moved it into tls_connection_options.

### DIFF
--- a/include/aws/io/channel_bootstrap.h
+++ b/include/aws/io/channel_bootstrap.h
@@ -75,7 +75,6 @@ struct aws_client_bootstrap {
     struct aws_event_loop_group *event_loop_group;
     struct aws_host_resolver *host_resolver;
     struct aws_host_resolution_config host_resolver_config;
-    struct aws_tls_ctx *tls_ctx;
     aws_channel_on_protocol_negotiated_fn *on_protocol_negotiated;
     bool owns_resolver;
 };
@@ -126,7 +125,6 @@ typedef void(aws_server_bootsrap_on_accept_channel_shutdown_fn)(
 struct aws_server_bootstrap {
     struct aws_allocator *allocator;
     struct aws_event_loop_group *event_loop_group;
-    struct aws_tls_ctx *tls_ctx;
     aws_channel_on_protocol_negotiated_fn *on_protocol_negotiated;
 };
 
@@ -152,12 +150,6 @@ AWS_IO_API int aws_client_bootstrap_init(
  * calling this if you don't want a memory leak.
  */
 AWS_IO_API void aws_client_bootstrap_clean_up(struct aws_client_bootstrap *bootstrap);
-
-/**
- * Sets the TLS context for use with `aws_client_bootstrap_new_tls_socket_channel`. This function must be called before
- * calling `aws_client_bootstrap_new_tls_socket_channel`
- */
-AWS_IO_API int aws_client_bootstrap_set_tls_ctx(struct aws_client_bootstrap *bootstrap, struct aws_tls_ctx *ctx);
 
 /**
  * When using TLS, if ALPN is used, this callback will be invoked from the channel. The returned handler will be added
@@ -223,12 +215,6 @@ AWS_IO_API int aws_server_bootstrap_init(
  * calling this if you don't want a memory leak.
  */
 AWS_IO_API void aws_server_bootstrap_clean_up(struct aws_server_bootstrap *bootstrap);
-
-/**
- * Sets the TLS context for use with `aws_server_bootstrap_new_tls_socket_listener`. This function must be called before
- * calling, `aws_server_bootstrap_new_tls_socket_listener`
- */
-AWS_IO_API int aws_server_bootstrap_set_tls_ctx(struct aws_server_bootstrap *bootstrap, struct aws_tls_ctx *ctx);
 
 /**
  * When using TLS, if ALPN is used, this callback will be invoked from the channel. The returned handler will be added

--- a/include/aws/io/tls_channel_handler.h
+++ b/include/aws/io/tls_channel_handler.h
@@ -83,16 +83,7 @@ struct aws_tls_connection_options {
     aws_tls_on_data_read_fn *on_data_read;
     aws_tls_on_error_fn *on_error;
     void *user_data;
-    /**
-     * default is true for clients and false for servers.
-     * You should not change this default for clients unless
-     * you're testing and don't want to fool around with CA trust stores.
-     * Before you release to production, you'll want to turn this back on
-     * and add your custom CA to the aws_tls_ctx_options.
-     *
-     * If you set this in server mode, it enforces client authentication.
-     */
-    bool verify_peer;
+    struct aws_tls_ctx *ctx;
     bool advertise_alpn_message;
 };
 
@@ -197,9 +188,9 @@ AWS_IO_API void aws_tls_ctx_options_override_default_trust_store(
     const char *ca_path,
     const char *ca_file);
 
-AWS_IO_API void aws_tls_connection_options_init_from_ctx_options(
+AWS_IO_API void aws_tls_connection_options_init_from_ctx(
     struct aws_tls_connection_options *conn_options,
-    const struct aws_tls_ctx_options *ctx_options);
+    struct aws_tls_ctx *ctx_options);
 
 AWS_IO_API void aws_tls_connection_options_set_callbacks(
     struct aws_tls_connection_options *conn_options,
@@ -215,9 +206,6 @@ AWS_IO_API void aws_tls_connection_options_set_server_name(
 AWS_IO_API void aws_tls_connection_options_set_alpn_list(
     struct aws_tls_connection_options *conn_options,
     const char *alpn_list);
-AWS_IO_API void aws_tls_connection_options_set_verify_peer(
-    struct aws_tls_connection_options *conn_options,
-    bool verify_peer);
 
 /********************************* TLS context and state management *********************************/
 /**
@@ -250,7 +238,6 @@ AWS_IO_API bool aws_tls_is_alpn_available(void);
  */
 AWS_IO_API struct aws_channel_handler *aws_tls_client_handler_new(
     struct aws_allocator *allocator,
-    struct aws_tls_ctx *ctx,
     struct aws_tls_connection_options *options,
     struct aws_channel_slot *slot);
 
@@ -261,7 +248,6 @@ AWS_IO_API struct aws_channel_handler *aws_tls_client_handler_new(
  */
 AWS_IO_API struct aws_channel_handler *aws_tls_server_handler_new(
     struct aws_allocator *allocator,
-    struct aws_tls_ctx *ctx,
     struct aws_tls_connection_options *options,
     struct aws_channel_slot *slot);
 

--- a/include/aws/io/tls_channel_handler.h
+++ b/include/aws/io/tls_channel_handler.h
@@ -190,7 +190,7 @@ AWS_IO_API void aws_tls_ctx_options_override_default_trust_store(
 
 AWS_IO_API void aws_tls_connection_options_init_from_ctx(
     struct aws_tls_connection_options *conn_options,
-    struct aws_tls_ctx *ctx_options);
+    struct aws_tls_ctx *ctx);
 
 AWS_IO_API void aws_tls_connection_options_set_callbacks(
     struct aws_tls_connection_options *conn_options,

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -232,9 +232,7 @@ static inline int s_setup_client_tls(struct client_connection_args *connection_a
     }
 
     struct aws_channel_handler *tls_handler = aws_tls_client_handler_new(
-        connection_args->bootstrap->allocator,
-        &connection_args->channel_data.tls_options,
-        tls_slot);
+        connection_args->bootstrap->allocator, &connection_args->channel_data.tls_options, tls_slot);
 
     if (!tls_handler) {
         aws_mem_release(connection_args->bootstrap->allocator, (void *)tls_slot);
@@ -729,10 +727,8 @@ static inline int s_setup_server_tls(struct server_connection_args *connection_a
         return AWS_OP_ERR;
     }
 
-    tls_handler = aws_tls_server_handler_new(
-        connection_args->bootstrap->allocator,
-        &connection_args->tls_options,
-        tls_slot);
+    tls_handler =
+        aws_tls_server_handler_new(connection_args->bootstrap->allocator, &connection_args->tls_options, tls_slot);
 
     if (!tls_handler) {
         aws_mem_release(connection_args->bootstrap->allocator, tls_slot);

--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -715,14 +715,14 @@ struct aws_channel_handler *aws_tls_client_handler_new(
     struct aws_allocator *allocator,
     struct aws_tls_connection_options *options,
     struct aws_channel_slot *slot) {
-    return s_tls_handler_new(allocator, ctx, options, slot, kSSLClientSide);
+    return s_tls_handler_new(allocator, options, slot, kSSLClientSide);
 }
 
 struct aws_channel_handler *aws_tls_server_handler_new(
     struct aws_allocator *allocator,
     struct aws_tls_connection_options *options,
     struct aws_channel_slot *slot) {
-    return s_tls_handler_new(allocator, ctx, options, slot, kSSLServerSide);
+    return s_tls_handler_new(allocator, options, slot, kSSLServerSide);
 }
 
 static struct aws_tls_ctx *s_tls_ctx_new(struct aws_allocator *alloc, struct aws_tls_ctx_options *options) {

--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -587,11 +587,11 @@ struct secure_transport_ctx {
 
 static struct aws_channel_handler *s_tls_handler_new(
     struct aws_allocator *allocator,
-    struct aws_tls_ctx *ctx,
     struct aws_tls_connection_options *options,
     struct aws_channel_slot *slot,
     SSLProtocolSide protocol_side) {
-    struct secure_transport_ctx *secure_transport_ctx = ctx->impl;
+    assert(options->ctx);
+    struct secure_transport_ctx *secure_transport_ctx = options->ctx->impl;
 
     struct secure_transport_handler *secure_transport_handler =
         (struct secure_transport_handler *)aws_mem_acquire(allocator, sizeof(struct secure_transport_handler));
@@ -713,7 +713,6 @@ cleanup_st_handler:
 
 struct aws_channel_handler *aws_tls_client_handler_new(
     struct aws_allocator *allocator,
-    struct aws_tls_ctx *ctx,
     struct aws_tls_connection_options *options,
     struct aws_channel_slot *slot) {
     return s_tls_handler_new(allocator, ctx, options, slot, kSSLClientSide);
@@ -721,7 +720,6 @@ struct aws_channel_handler *aws_tls_client_handler_new(
 
 struct aws_channel_handler *aws_tls_server_handler_new(
     struct aws_allocator *allocator,
-    struct aws_tls_ctx *ctx,
     struct aws_tls_connection_options *options,
     struct aws_channel_slot *slot) {
     return s_tls_handler_new(allocator, ctx, options, slot, kSSLServerSide);

--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -111,4 +111,3 @@ void aws_tls_connection_options_set_server_name(
 void aws_tls_connection_options_set_alpn_list(struct aws_tls_connection_options *conn_options, const char *alpn_list) {
     conn_options->alpn_list = alpn_list;
 }
-

--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -81,13 +81,13 @@ void aws_tls_ctx_options_override_default_trust_store(
     options->ca_file = ca_file;
 }
 
-void aws_tls_connection_options_init_from_ctx_options(
+void aws_tls_connection_options_init_from_ctx(
     struct aws_tls_connection_options *conn_options,
-    const struct aws_tls_ctx_options *ctx_options) {
+    struct aws_tls_ctx *ctx) {
     AWS_ZERO_STRUCT(*conn_options);
     /* the assumption here, is that if it was set in the context, we WANT it to be NULL here unless it's different.
      * so only set verify peer at this point. */
-    conn_options->verify_peer = ctx_options->verify_peer;
+    conn_options->ctx = ctx;
 }
 
 void aws_tls_connection_options_set_callbacks(
@@ -112,6 +112,3 @@ void aws_tls_connection_options_set_alpn_list(struct aws_tls_connection_options 
     conn_options->alpn_list = alpn_list;
 }
 
-void aws_tls_connection_options_set_verify_peer(struct aws_tls_connection_options *conn_options, bool verify_peer) {
-    conn_options->verify_peer = verify_peer;
-}

--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -88,6 +88,7 @@ struct secure_channel_handler {
     struct aws_byte_buf buffered_read_out_data_buf;
     struct aws_channel_task sequential_task_storage;
     bool negotiation_finished;
+    bool verify_peer;
 };
 
 bool aws_tls_is_alpn_available(void) {
@@ -341,7 +342,7 @@ static int s_do_server_side_negotiation_step_1(struct aws_channel_handler *handl
     sc_handler->ctx_req = ASC_REQ_SEQUENCE_DETECT | ASC_REQ_REPLAY_DETECT | ASC_REQ_CONFIDENTIALITY |
                           ASC_REQ_ALLOCATE_MEMORY | ASC_REQ_STREAM;
 
-    if (sc_handler->options.verify_peer) {
+    if (sc_handler->verify_peer) {
         sc_handler->ctx_req |= ASC_REQ_MUTUAL_AUTH;
     }
 
@@ -1333,6 +1334,7 @@ static struct aws_channel_handler *s_tls_handler_new(
     sc_handler->buffered_read_out_data_buf =
         aws_byte_buf_from_array(sc_handler->buffered_read_out_data, sizeof(sc_handler->buffered_read_out_data));
     sc_handler->buffered_read_out_data_buf.len = 0;
+    sc_handler->verify_peer = sc_ctx->options.verify_peer;
 
     return &sc_handler->handler;
 }
@@ -1341,7 +1343,7 @@ struct aws_channel_handler *aws_tls_client_handler_new(
     struct aws_tls_connection_options *options,
     struct aws_channel_slot *slot) {
 
-    return s_tls_handler_new(allocator, ctx, options, slot, true);
+    return s_tls_handler_new(allocator, options, slot, true);
 }
 
 struct aws_channel_handler *aws_tls_server_handler_new(
@@ -1349,7 +1351,7 @@ struct aws_channel_handler *aws_tls_server_handler_new(
     struct aws_tls_connection_options *options,
     struct aws_channel_slot *slot) {
 
-    return s_tls_handler_new(allocator, ctx, options, slot, false);
+    return s_tls_handler_new(allocator, options, slot, false);
 }
 
 void aws_tls_ctx_destroy(struct aws_tls_ctx *ctx) {

--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -1274,10 +1274,10 @@ static struct aws_channel_handler_vtable s_handler_vtable = {
 
 static struct aws_channel_handler *s_tls_handler_new(
     struct aws_allocator *alloc,
-    struct aws_tls_ctx *ctx,
     struct aws_tls_connection_options *options,
     struct aws_channel_slot *slot,
     bool is_client_mode) {
+    assert(options->ctx);
 
     struct secure_channel_handler *sc_handler = aws_mem_acquire(alloc, sizeof(struct secure_channel_handler));
 
@@ -1290,7 +1290,7 @@ static struct aws_channel_handler *s_tls_handler_new(
     sc_handler->handler.impl = sc_handler;
     sc_handler->handler.vtable = &s_handler_vtable;
 
-    struct secure_channel_ctx *sc_ctx = ctx->impl;
+    struct secure_channel_ctx *sc_ctx = options->ctx->impl;
 
     unsigned long credential_use = SECPKG_CRED_INBOUND;
     if (is_client_mode) {
@@ -1338,7 +1338,6 @@ static struct aws_channel_handler *s_tls_handler_new(
 }
 struct aws_channel_handler *aws_tls_client_handler_new(
     struct aws_allocator *allocator,
-    struct aws_tls_ctx *ctx,
     struct aws_tls_connection_options *options,
     struct aws_channel_slot *slot) {
 
@@ -1347,7 +1346,6 @@ struct aws_channel_handler *aws_tls_client_handler_new(
 
 struct aws_channel_handler *aws_tls_server_handler_new(
     struct aws_allocator *allocator,
-    struct aws_tls_ctx *ctx,
     struct aws_tls_connection_options *options,
     struct aws_channel_slot *slot) {
 

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -304,11 +304,11 @@ static int s_tls_channel_echo_and_backpressure_test_fn(struct aws_allocator *all
     };
 
     struct aws_tls_connection_options tls_server_conn_options;
-    aws_tls_connection_options_init_from_ctx_options(&tls_server_conn_options, &server_ctx_options);
+    aws_tls_connection_options_init_from_ctx(&tls_server_conn_options, server_ctx);
     aws_tls_connection_options_set_callbacks(&tls_server_conn_options, s_tls_on_negotiated, NULL, NULL, &incoming_args);
 
     struct aws_tls_connection_options tls_client_conn_options;
-    aws_tls_connection_options_init_from_ctx_options(&tls_client_conn_options, &client_ctx_options);
+    aws_tls_connection_options_init_from_ctx(&tls_client_conn_options, client_ctx);
     aws_tls_connection_options_set_alpn_list(&tls_client_conn_options, "h2;http/1.1");
     aws_tls_connection_options_set_callbacks(&tls_client_conn_options, s_tls_on_negotiated, NULL, NULL, &outgoing_args);
     aws_tls_connection_options_set_server_name(&tls_client_conn_options, "localhost");
@@ -328,7 +328,6 @@ static int s_tls_channel_echo_and_backpressure_test_fn(struct aws_allocator *all
 
     struct aws_server_bootstrap server_bootstrap;
     ASSERT_SUCCESS(aws_server_bootstrap_init(&server_bootstrap, allocator, &el_group));
-    ASSERT_SUCCESS(aws_server_bootstrap_set_tls_ctx(&server_bootstrap, server_ctx));
 
     struct aws_socket *listener = aws_server_bootstrap_new_tls_socket_listener(
         &server_bootstrap,
@@ -343,7 +342,6 @@ static int s_tls_channel_echo_and_backpressure_test_fn(struct aws_allocator *all
 
     struct aws_client_bootstrap client_bootstrap;
     ASSERT_SUCCESS(aws_client_bootstrap_init(&client_bootstrap, allocator, &el_group, NULL, NULL));
-    ASSERT_SUCCESS(aws_client_bootstrap_set_tls_ctx(&client_bootstrap, client_ctx));
 
     ASSERT_SUCCESS(aws_mutex_lock(&mutex));
 
@@ -472,7 +470,7 @@ static int s_verify_negotiation_fails(struct aws_allocator *allocator, const str
     struct aws_tls_ctx *client_ctx = aws_tls_client_ctx_new(allocator, &client_ctx_options);
 
     struct aws_tls_connection_options tls_client_conn_options;
-    aws_tls_connection_options_init_from_ctx_options(&tls_client_conn_options, &client_ctx_options);
+    aws_tls_connection_options_init_from_ctx(&tls_client_conn_options, client_ctx);
     aws_tls_connection_options_set_callbacks(&tls_client_conn_options, s_tls_on_negotiated, NULL, NULL, NULL);
     aws_tls_connection_options_set_server_name(&tls_client_conn_options, (const char *)aws_string_bytes(host_name));
 
@@ -499,7 +497,6 @@ static int s_verify_negotiation_fails(struct aws_allocator *allocator, const str
 
     struct aws_client_bootstrap client_bootstrap;
     ASSERT_SUCCESS((aws_client_bootstrap_init(&client_bootstrap, allocator, &el_group, NULL, NULL)));
-    ASSERT_SUCCESS(aws_client_bootstrap_set_tls_ctx(&client_bootstrap, client_ctx));
 
     ASSERT_SUCCESS(aws_client_bootstrap_new_tls_socket_channel(
         &client_bootstrap,
@@ -639,7 +636,7 @@ static int s_verify_good_host(struct aws_allocator *allocator, const struct aws_
     struct aws_tls_ctx *client_ctx = aws_tls_client_ctx_new(allocator, &client_ctx_options);
 
     struct aws_tls_connection_options tls_client_conn_options;
-    aws_tls_connection_options_init_from_ctx_options(&tls_client_conn_options, &client_ctx_options);
+    aws_tls_connection_options_init_from_ctx(&tls_client_conn_options, client_ctx);
     aws_tls_connection_options_set_callbacks(&tls_client_conn_options, s_tls_on_negotiated, NULL, NULL, &outgoing_args);
     aws_tls_connection_options_set_server_name(&tls_client_conn_options, (const char *)aws_string_bytes(host_name));
     aws_tls_connection_options_set_alpn_list(&tls_client_conn_options, "h2;http/1.1");
@@ -654,7 +651,6 @@ static int s_verify_good_host(struct aws_allocator *allocator, const struct aws_
 
     struct aws_client_bootstrap client_bootstrap;
     ASSERT_SUCCESS((aws_client_bootstrap_init(&client_bootstrap, allocator, &el_group, NULL, NULL)));
-    ASSERT_SUCCESS(aws_client_bootstrap_set_tls_ctx(&client_bootstrap, client_ctx));
 
     ASSERT_SUCCESS(aws_client_bootstrap_new_tls_socket_channel(
         &client_bootstrap,


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
