### PR TITLE
Added refcount to connection args in channel bootstrap + unit test fo…

### DIFF
--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -176,12 +176,12 @@ struct client_connection_args {
     uint32_t ref_count;
 };
 
-void s_connection_args_acquire(struct client_connection_args* args) {
+void s_connection_args_acquire(struct client_connection_args *args) {
     assert(args);
     args->ref_count++;
 }
 
-void s_connection_args_release(struct client_connection_args* args) {
+void s_connection_args_release(struct client_connection_args *args) {
     assert(args);
     if (--args->ref_count == 0) {
         if (args->host_name) {

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -328,6 +328,7 @@ static void s_on_client_channel_on_setup_completed(struct aws_channel *channel, 
         } else {
             connection_args->setup_callback(
                 connection_args->bootstrap, AWS_OP_SUCCESS, channel, connection_args->user_data);
+            s_connection_args_release(connection_args);
         }
 
         return;
@@ -409,9 +410,9 @@ static void s_on_client_connection_established(struct aws_socket *socket, int er
 
         if (connection_args->failed_count == connection_args->addresses_count) {
             connection_args->setup_callback(connection_args->bootstrap, error_code, NULL, connection_args->user_data);
-            s_connection_args_release(connection_args);
         }
     }
+    s_connection_args_release(connection_args);
 }
 
 static void s_on_host_resolved(
@@ -432,9 +433,10 @@ static void s_on_host_resolved(
             aws_event_loop_group_get_next_loop(client_connection_args->bootstrap->event_loop_group);
         client_connection_args->addresses_count = (uint8_t)host_addresses_len;
 
-        /* retain args, only need 1 ref, as only 1 connect will succeed and release */
-        s_connection_args_acquire(client_connection_args);
         for (size_t i = 0; i < host_addresses_len; ++i) {
+            /* retain args, need 1 ref per socket, released in s_on_client_connection_established */
+            s_connection_args_acquire(client_connection_args);
+
             struct aws_host_address *host_address_ptr = NULL;
             aws_array_list_get_at(host_addresses, (void *)&host_address_ptr, i);
 
@@ -506,6 +508,7 @@ static inline int s_new_client_channel(
     }
 
     AWS_ZERO_STRUCT(*client_connection_args);
+    s_connection_args_acquire(client_connection_args);
     client_connection_args->user_data = user_data;
     client_connection_args->bootstrap = bootstrap;
     client_connection_args->setup_callback = setup_callback;

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -183,6 +183,7 @@ void s_connection_args_acquire(struct client_connection_args *args) {
 
 void s_connection_args_release(struct client_connection_args *args) {
     assert(args);
+    assert(args->ref_count > 0);
     if (--args->ref_count == 0) {
         if (args->host_name) {
             aws_string_destroy(args->host_name);
@@ -587,6 +588,7 @@ static inline int s_new_client_channel(
 
         struct aws_event_loop *connect_loop = aws_event_loop_group_get_next_loop(bootstrap->event_loop_group);
 
+        s_connection_args_acquire(client_connection_args);
         if (aws_socket_connect(
                 outgoing_socket, &endpoint, connect_loop, s_on_client_connection_established, client_connection_args)) {
             aws_socket_clean_up(outgoing_socket);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -64,6 +64,7 @@ add_test_case(channel_refcount_delays_clean_up)
 add_test_case(channel_tasks_run)
 add_test_case(channel_rejects_post_shutdown_tasks)
 add_test_case(channel_cancels_pending_tasks)
+add_test_case(channel_connect_some_hosts_timeout)
 
 if (NOT WIN32)
     add_test_case(channel_message_passing)

--- a/tests/channel_test.c
+++ b/tests/channel_test.c
@@ -763,7 +763,7 @@ static int s_test_channel_connect_some_hosts_timeout(struct aws_allocator *alloc
 
     struct aws_mutex mutex = AWS_MUTEX_INIT;
 
-    /* resolve amazon.com and hard-code the ipv6 address because EC2 doesn't support public IPs for IPv6 */
+    /* resolve amazon.com and hard-code the ipv6 address to an EC2 host with an ACL that blackholes the connection */
     const struct aws_string* addr1_ipv4 = NULL;
     struct aws_string* addr2_ipv6 = aws_string_new_from_c_str(allocator, "2600:1f18:431a:5c42:79e:ece6:a117:6091");
     struct aws_string* amazon_com = aws_string_new_from_c_str(allocator, "www.amazon.com");

--- a/tests/channel_test.c
+++ b/tests/channel_test.c
@@ -757,12 +757,12 @@ static void s_test_channel_connect_some_hosts_timeout_shutdown(
     aws_mutex_unlock(test_args->mutex);
 }
 
-static bool s_setup_complete_pred(void* user_data) {
+static bool s_setup_complete_pred(void *user_data) {
     struct channel_connect_test_args *test_args = user_data;
     return test_args->setup;
 }
 
-static bool s_shutdown_complete_pred(void* user_data) {
+static bool s_shutdown_complete_pred(void *user_data) {
     struct channel_connect_test_args *test_args = user_data;
     return test_args->shutdown;
 }
@@ -779,16 +779,17 @@ static int s_test_channel_connect_some_hosts_timeout(struct aws_allocator *alloc
     struct aws_mutex mutex = AWS_MUTEX_INIT;
 
     /* resolve amazon.com and hard-code the ipv6 address to an EC2 host with an ACL that blackholes the connection */
-    const struct aws_string* addr1_ipv4 = NULL;
-    struct aws_string* addr2_ipv6 = aws_string_new_from_c_str(allocator, "2600:1f18:431a:5c42:79e:ece6:a117:6091");
-    struct aws_string* amazon_com = aws_string_new_from_c_str(allocator, "www.amazon.com");
+    const struct aws_string *addr1_ipv4 = NULL;
+    struct aws_string *addr2_ipv6 = aws_string_new_from_c_str(allocator, "2600:1f18:431a:5c42:79e:ece6:a117:6091");
+    struct aws_string *amazon_com = aws_string_new_from_c_str(allocator, "www.amazon.com");
     struct aws_array_list addresses;
     struct aws_host_address address_storage[1];
-    struct aws_host_address* resolved_address = NULL;
-    aws_array_list_init_static(&addresses, address_storage, AWS_ARRAY_SIZE(address_storage), sizeof(struct aws_host_address));
+    struct aws_host_address *resolved_address = NULL;
+    aws_array_list_init_static(
+        &addresses, address_storage, AWS_ARRAY_SIZE(address_storage), sizeof(struct aws_host_address));
     aws_default_dns_resolve(allocator, amazon_com, &addresses, NULL);
     ASSERT_INT_EQUALS(1, aws_array_list_length(&addresses));
-    aws_array_list_get_at_ptr(&addresses, (void*)&resolved_address, 0);
+    aws_array_list_get_at_ptr(&addresses, (void *)&resolved_address, 0);
     addr1_ipv4 = aws_string_new_from_string(allocator, resolved_address->address);
     aws_string_destroy(amazon_com);
 
@@ -868,7 +869,8 @@ static int s_test_channel_connect_some_hosts_timeout(struct aws_allocator *alloc
     /* this should cause a disconnect and tear down */
     ASSERT_SUCCESS(aws_mutex_lock(&mutex));
     ASSERT_SUCCESS(aws_channel_shutdown(callback_data.channel, AWS_OP_SUCCESS));
-    ASSERT_SUCCESS(aws_condition_variable_wait_pred(&callback_data.cv, &mutex, s_shutdown_complete_pred, &callback_data));
+    ASSERT_SUCCESS(
+        aws_condition_variable_wait_pred(&callback_data.cv, &mutex, s_shutdown_complete_pred, &callback_data));
 
     ASSERT_INT_EQUALS(0, callback_data.error_code, aws_error_str(callback_data.error_code));
     ASSERT_SUCCESS(aws_mutex_unlock(&mutex));

--- a/tests/channel_test.c
+++ b/tests/channel_test.c
@@ -16,11 +16,15 @@
 #include <aws/common/atomics.h>
 #include <aws/common/clock.h>
 #include <aws/common/condition_variable.h>
+#include <aws/common/string.h>
 
 #include <aws/io/channel.h>
+#include <aws/io/channel_bootstrap.h>
 #include <aws/io/event_loop.h>
+#include <aws/io/socket.h>
 #include <aws/testing/aws_test_harness.h>
 
+#include "mock_dns_resolver.h"
 #include "read_write_test_handler.h"
 
 struct channel_setup_test_args {
@@ -710,3 +714,153 @@ static int s_test_channel_cancels_pending_tasks(struct aws_allocator *allocator,
 }
 
 AWS_TEST_CASE(channel_cancels_pending_tasks, s_test_channel_cancels_pending_tasks)
+
+struct channel_connect_test_args {
+    struct aws_mutex *mutex;
+    struct aws_condition_variable cv;
+    int error_code;
+    struct aws_channel *channel;
+    bool setup;
+    bool shutdown;
+};
+
+static void s_test_channel_connect_some_hosts_timeout_setup(
+    struct aws_client_bootstrap *bootstrap,
+    int error_code,
+    struct aws_channel *channel,
+    void *user_data) {
+
+    struct channel_connect_test_args *test_args = user_data;
+    test_args->setup = true;
+    test_args->channel = channel;
+    test_args->error_code = error_code;
+
+    aws_condition_variable_notify_one(&test_args->cv);
+}
+
+static void s_test_channel_connect_some_hosts_timeout_shutdown(
+    struct aws_client_bootstrap *bootstrap,
+    int error_code,
+    struct aws_channel *channel,
+    void *user_data) {
+
+    struct channel_connect_test_args *test_args = user_data;
+    test_args->channel = NULL;
+    test_args->shutdown = true;
+    test_args->error_code = error_code;
+
+    aws_condition_variable_notify_one(&test_args->cv);
+}
+
+static int s_test_channel_connect_some_hosts_timeout(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    aws_load_error_strings();
+    aws_io_load_error_strings();
+
+    struct aws_event_loop_group event_loop_group;
+    ASSERT_SUCCESS(aws_event_loop_group_default_init(&event_loop_group, allocator, 1));
+
+    struct aws_mutex mutex = AWS_MUTEX_INIT;
+
+    /* resolve amazon.com and hard-code the ipv6 address because EC2 doesn't support public IPs for IPv6 */
+    const struct aws_string* addr1_ipv4 = NULL;
+    struct aws_string* addr2_ipv6 = aws_string_new_from_c_str(allocator, "2600:1f18:431a:5c42:79e:ece6:a117:6091");
+    struct aws_string* amazon_com = aws_string_new_from_c_str(allocator, "www.amazon.com");
+    struct aws_array_list addresses;
+    struct aws_host_address address_storage[1];
+    struct aws_host_address* resolved_address = NULL;
+    aws_array_list_init_static(&addresses, address_storage, AWS_ARRAY_SIZE(address_storage), sizeof(struct aws_host_address));
+    aws_default_dns_resolve(allocator, amazon_com, &addresses, NULL);
+    ASSERT_INT_EQUALS(1, aws_array_list_length(&addresses));
+    aws_array_list_get_at_ptr(&addresses, (void*)&resolved_address, 0);
+    addr1_ipv4 = aws_string_new_from_string(allocator, resolved_address->address);
+    aws_string_destroy(amazon_com);
+
+    /* create a resolver with 2 addresses: 1 IPv4 which will always succeed, and 1 IPv6 which will always timeout */
+    struct mock_dns_resolver mock_dns_resolver;
+    ASSERT_SUCCESS(mock_dns_resolver_init(&mock_dns_resolver, 2, allocator));
+
+    struct aws_host_resolution_config mock_resolver_config = {
+        .max_ttl = 1,
+        .impl = mock_dns_resolve,
+        .impl_data = &mock_dns_resolver,
+    };
+
+    struct aws_host_address host_address_1_ipv4 = {
+        .address = addr1_ipv4,
+        .allocator = allocator,
+        .expiry = 0,
+        /* connections should always succeed, if not, things are worse than this unit test failing */
+        .host = aws_string_new_from_c_str(allocator, "www.amazon.com"),
+        .connection_failure_count = 0,
+        .record_type = AWS_ADDRESS_RECORD_TYPE_A,
+        .use_count = 0,
+        .weight = 0,
+    };
+
+    struct aws_host_address host_address_1_ipv6 = {
+        .address = addr2_ipv6,
+        .allocator = allocator,
+        .expiry = 0,
+        /* same black-holed host from the timeout test, connections are a guaranteed timeout */
+        .host = aws_string_new_from_c_str(allocator, "ec2-54-158-231-48.compute-1.amazonaws.com"),
+        .connection_failure_count = 0,
+        .record_type = AWS_ADDRESS_RECORD_TYPE_AAAA,
+        .use_count = 0,
+        .weight = 0,
+    };
+
+    struct aws_array_list address_list;
+    ASSERT_SUCCESS(aws_array_list_init_dynamic(&address_list, allocator, 2, sizeof(struct aws_host_address)));
+    ASSERT_SUCCESS(aws_array_list_push_back(&address_list, &host_address_1_ipv6));
+    ASSERT_SUCCESS(aws_array_list_push_back(&address_list, &host_address_1_ipv4));
+    ASSERT_SUCCESS(mock_dns_resolver_append_address_list(&mock_dns_resolver, &address_list));
+
+    struct aws_client_bootstrap bootstrap;
+    aws_client_bootstrap_init(&bootstrap, allocator, &event_loop_group, NULL, &mock_resolver_config);
+
+    struct aws_socket_options options;
+    AWS_ZERO_STRUCT(options);
+    options.connect_timeout_ms = 3000;
+    options.type = AWS_SOCKET_STREAM;
+
+    struct channel_connect_test_args callback_data = {
+        .mutex = &mutex,
+        .cv = AWS_CONDITION_VARIABLE_INIT,
+        .error_code = 0,
+        .channel = NULL,
+        .setup = false,
+        .shutdown = false,
+    };
+
+    aws_client_bootstrap_new_socket_channel(
+        &bootstrap,
+        "www.amazon.com",
+        80,
+        &options,
+        s_test_channel_connect_some_hosts_timeout_setup,
+        s_test_channel_connect_some_hosts_timeout_shutdown,
+        &callback_data);
+
+    aws_condition_variable_wait(&callback_data.cv, &mutex);
+    ASSERT_TRUE(callback_data.setup);
+    ASSERT_INT_EQUALS(0, callback_data.error_code, aws_error_str(callback_data.error_code));
+    ASSERT_NOT_NULL(callback_data.channel);
+
+    /* this should cause a disconnect and tear down */
+    aws_channel_shutdown(callback_data.channel, AWS_OP_SUCCESS);
+    aws_condition_variable_wait(&callback_data.cv, &mutex);
+    ASSERT_INT_EQUALS(0, callback_data.error_code, aws_error_str(callback_data.error_code));
+    ASSERT_TRUE(callback_data.shutdown);
+
+    /* clean up */
+    aws_host_address_clean_up(resolved_address);
+    aws_client_bootstrap_clean_up(&bootstrap);
+    mock_dns_resolver_clean_up(&mock_dns_resolver);
+    aws_event_loop_group_clean_up(&event_loop_group);
+
+    return 0;
+}
+
+AWS_TEST_CASE(channel_connect_some_hosts_timeout, s_test_channel_connect_some_hosts_timeout);

--- a/tests/channel_test.c
+++ b/tests/channel_test.c
@@ -729,6 +729,7 @@ static void s_test_channel_connect_some_hosts_timeout_setup(
     int error_code,
     struct aws_channel *channel,
     void *user_data) {
+    (void)bootstrap;
 
     struct channel_connect_test_args *test_args = user_data;
     aws_mutex_lock(test_args->mutex);
@@ -744,6 +745,8 @@ static void s_test_channel_connect_some_hosts_timeout_shutdown(
     int error_code,
     struct aws_channel *channel,
     void *user_data) {
+    (void)bootstrap;
+    (void)channel;
 
     struct channel_connect_test_args *test_args = user_data;
     aws_mutex_lock(test_args->mutex);


### PR DESCRIPTION
…r happy eyeballs where one connection times out

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
