### PR TITLE
Upstream over head hints, max fragment size, read before close, small…

### DIFF
--- a/include/aws/io/message_pool.h
+++ b/include/aws/io/message_pool.h
@@ -28,11 +28,14 @@ struct aws_memory_pool {
 struct aws_message_pool {
     struct aws_allocator *alloc;
     struct aws_memory_pool application_data_pool;
+    struct aws_memory_pool small_block_pool;
 };
 
 struct aws_message_pool_creation_args {
     size_t application_data_msg_data_size;
     uint8_t application_data_msg_count;
+    size_t small_block_msg_data_size;
+    uint8_t small_block_msg_count;
 };
 
 #ifdef __cplusplus

--- a/include/aws/io/socket_channel_handler.h
+++ b/include/aws/io/socket_channel_handler.h
@@ -22,8 +22,6 @@ struct aws_channel_handler;
 struct aws_channel_slot;
 struct aws_event_loop;
 
-static const size_t AWS_SOCKET_HANDLER_DEFAULT_MAX_READ = 16 * 1024;
-
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/include/aws/io/tls_channel_handler.h
+++ b/include/aws/io/tls_channel_handler.h
@@ -139,6 +139,10 @@ struct aws_tls_ctx_options {
      * Password for the pkcs12 file in pkcs12_path.
      */
     const char *pkcs12_password;
+
+    /** max tls fragment size. Default is the value of g_aws_channel_max_fragment_size. */
+    size_t max_fragment_size;
+
     /**
      * default is true for clients and false for servers.
      * You should not change this default for clients unless

--- a/source/alpn_handler.c
+++ b/source/alpn_handler.c
@@ -21,7 +21,7 @@ struct alpn_handler {
     void *user_data;
 };
 
-int alpn_process_read_message(
+int s_alpn_process_read_message(
     struct aws_channel_handler *handler,
     struct aws_channel_slot *slot,
     struct aws_io_message *message) {
@@ -54,7 +54,7 @@ int alpn_process_read_message(
     return AWS_OP_SUCCESS;
 }
 
-static int alpn_shutdown(
+static int s_alpn_shutdown(
     struct aws_channel_handler *handler,
     struct aws_channel_slot *slot,
     enum aws_channel_direction dir,
@@ -64,24 +64,30 @@ static int alpn_shutdown(
     return aws_channel_slot_on_handler_shutdown_complete(slot, dir, error_code, abort_immediately);
 }
 
-size_t alpn_get_current_window_size(struct aws_channel_handler *handler) {
+size_t s_alpn_get_current_window_size(struct aws_channel_handler *handler) {
     (void)handler;
     return SIZE_MAX;
 }
 
-void alpn_destroy(struct aws_channel_handler *handler) {
+void s_alpn_destroy(struct aws_channel_handler *handler) {
     struct alpn_handler *alpn_handler = (struct alpn_handler *)handler->impl;
     aws_mem_release(handler->alloc, alpn_handler);
     aws_mem_release(handler->alloc, handler);
 }
 
+size_t s_alpn_message_overhead(struct aws_channel_handler *handler) {
+    (void)handler;
+    return 0;
+}
+
 struct aws_channel_handler_vtable s_alpn_handler_vtable = {
-    .initial_window_size = alpn_get_current_window_size,
+    .initial_window_size = s_alpn_get_current_window_size,
     .increment_read_window = NULL,
-    .shutdown = alpn_shutdown,
+    .shutdown = s_alpn_shutdown,
     .process_write_message = NULL,
-    .process_read_message = alpn_process_read_message,
-    .destroy = alpn_destroy,
+    .process_read_message = s_alpn_process_read_message,
+    .destroy = s_alpn_destroy,
+    .message_overhead = s_alpn_message_overhead,
 };
 
 struct aws_channel_handler *aws_tls_alpn_handler_new(

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -307,7 +307,7 @@ static void s_on_client_channel_on_setup_completed(struct aws_channel *channel, 
             connection_args->bootstrap->allocator,
             connection_args->channel_data.socket,
             socket_slot,
-            AWS_SOCKET_HANDLER_DEFAULT_MAX_READ);
+            g_aws_channel_max_fragment_size);
 
         if (!socket_channel_handler) {
             err_code = aws_last_error();
@@ -792,7 +792,7 @@ static void s_on_server_channel_on_setup_completed(struct aws_channel *channel, 
             channel_data->server_connection_args->bootstrap->allocator,
             channel_data->socket,
             socket_slot,
-            AWS_SOCKET_HANDLER_DEFAULT_MAX_READ);
+            g_aws_channel_max_fragment_size);
 
         if (!socket_channel_handler) {
             err_code = aws_last_error();

--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -148,7 +148,7 @@ static OSStatus s_write_cb(SSLConnectionRef conn, const void *data, size_t *len)
             return errSecMemoryError;
         }
 
-        const size_t overhead = aws_channel_slot_upstream_message_overhead(handler->slot);
+        const size_t overhead = aws_channel_slot_upstream_message_overhead(handler->parent_slot);
         const size_t available_msg_write_capacity = buffer_cursor.len - overhead;
 
         const size_t to_write = message->message_data.capacity > available_msg_write_capacity
@@ -448,6 +448,8 @@ static int s_process_write_message(
     struct aws_channel_handler *handler,
     struct aws_channel_slot *slot,
     struct aws_io_message *message) {
+    (void)slot;
+    
     struct secure_transport_handler *secure_transport_handler = handler->impl;
 
     if (AWS_UNLIKELY(!secure_transport_handler->negotiation_finished)) {

--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -119,7 +119,7 @@ static OSStatus s_read_cb(SSLConnectionRef conn, void *data, size_t *len) {
 
         if (message->copy_mark == message->message_data.len) {
             /* note: value is the first member of the allocated struct */
-            aws_channel_release_message_to_pool(handler->parent_slot->channel, message);
+            aws_mem_release(message->allocator, message);
         } else {
             aws_linked_list_push_front(&handler->input_queue, &message->queueing_handle);
         }
@@ -148,11 +148,16 @@ static OSStatus s_write_cb(SSLConnectionRef conn, const void *data, size_t *len)
             return errSecMemoryError;
         }
 
-        const size_t to_write =
-            message->message_data.capacity > buffer_cursor.len ? buffer_cursor.len : message->message_data.capacity;
+        const size_t overhead = aws_channel_slot_upstream_message_overhead(handler->slot);
+        const size_t available_msg_write_capacity = buffer_cursor.len - overhead;
+
+        const size_t to_write = message->message_data.capacity > available_msg_write_capacity
+                                    ? available_msg_write_capacity
+                                    : message->message_data.capacity;
+
         struct aws_byte_cursor chunk = aws_byte_cursor_advance(&buffer_cursor, to_write);
         if (aws_byte_buf_append(&message->message_data, &chunk)) {
-            aws_channel_release_message_to_pool(handler->parent_slot->channel, message);
+            aws_mem_release(message->allocator, message);
             return errSecBufferTooSmall;
         }
         processed += message->message_data.len;
@@ -165,7 +170,7 @@ static OSStatus s_write_cb(SSLConnectionRef conn, const void *data, size_t *len)
         }
 
         if (aws_channel_slot_send_message(handler->parent_slot, message, AWS_CHANNEL_DIR_WRITE)) {
-            aws_channel_release_message_to_pool(handler->parent_slot->channel, message);
+            aws_mem_release(message->allocator, message);
             return errSSLClosedNoNotify;
         }
     }
@@ -351,7 +356,7 @@ static int s_drive_negotiation(struct aws_channel_handler *handler) {
 
             message->message_data.len = sizeof(struct aws_tls_negotiated_protocol_message);
             if (aws_channel_slot_send_message(secure_transport_handler->parent_slot, message, AWS_CHANNEL_DIR_READ)) {
-                aws_channel_release_message_to_pool(secure_transport_handler->parent_slot->channel, message);
+                aws_mem_release(message->allocator, message);
                 aws_channel_shutdown(secure_transport_handler->parent_slot->channel, aws_last_error());
                 return AWS_OP_SUCCESS;
             }
@@ -460,7 +465,7 @@ static int s_process_write_message(
         return aws_raise_error(AWS_IO_TLS_ERROR_WRITE_FAILURE);
     }
 
-    aws_channel_release_message_to_pool(slot->channel, message);
+    aws_mem_release(message->allocator, message);
 
     return AWS_OP_SUCCESS;
 }
@@ -479,7 +484,7 @@ static int s_handle_shutdown(
         while (!aws_linked_list_empty(&secure_transport_handler->input_queue)) {
             struct aws_linked_list_node *node = aws_linked_list_pop_front(&secure_transport_handler->input_queue);
             struct aws_io_message *message = AWS_CONTAINER_OF(node, struct aws_io_message, queueing_handle);
-            aws_channel_release_message_to_pool(secure_transport_handler->parent_slot->channel, message);
+            aws_mem_release(message->allocator, message);
         }
     }
 
@@ -532,7 +537,7 @@ static int s_process_read_message(
             &read);
 
         if (read <= 0) {
-            aws_channel_release_message_to_pool(slot->channel, outgoing_read_message);
+            aws_mem_release(outgoing_read_message->allocator, outgoing_read_message);
             continue;
         };
 
@@ -546,11 +551,11 @@ static int s_process_read_message(
 
         if (slot->adj_right) {
             if (aws_channel_slot_send_message(slot, outgoing_read_message, AWS_CHANNEL_DIR_READ)) {
-                aws_channel_release_message_to_pool(slot->channel, outgoing_read_message);
+                aws_mem_release(outgoing_read_message->allocator, outgoing_read_message);
                 return AWS_OP_ERR;
             }
         } else {
-            aws_channel_release_message_to_pool(slot->channel, outgoing_read_message);
+            aws_mem_release(outgoing_read_message->allocator, outgoing_read_message);
         }
     }
 
@@ -598,6 +603,11 @@ static int s_increment_read_window(struct aws_channel_handler *handler, struct a
     return AWS_OP_SUCCESS;
 }
 
+size_t s_message_overhead(struct aws_channel_handler *handler) {
+    (void)handler;
+    return EST_TLS_RECORD_OVERHEAD;
+}
+
 static size_t s_initial_window_size(struct aws_channel_handler *handler) {
     (void)handler;
     return EST_HANDSHAKE_SIZE;
@@ -620,6 +630,7 @@ static struct aws_channel_handler_vtable s_handler_vtable = {
     .shutdown = s_handle_shutdown,
     .increment_read_window = s_increment_read_window,
     .initial_window_size = s_initial_window_size,
+    .message_overhead = s_message_overhead,
 };
 
 struct secure_transport_ctx {
@@ -629,6 +640,7 @@ struct secure_transport_ctx {
     CFArrayRef ca_cert;
     enum aws_tls_versions minimum_version;
     const char *alpn_list;
+    size_t max_fragment_size;
     bool veriify_peer;
 };
 

--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -449,7 +449,7 @@ static int s_process_write_message(
     struct aws_channel_slot *slot,
     struct aws_io_message *message) {
     (void)slot;
-    
+
     struct secure_transport_handler *secure_transport_handler = handler->impl;
 
     if (AWS_UNLIKELY(!secure_transport_handler->negotiation_finished)) {

--- a/source/socket_channel_handler.c
+++ b/source/socket_channel_handler.c
@@ -67,7 +67,7 @@ static void s_on_socket_write_complete(
             message->on_completion(channel, message, error_code, message->user_data);
         }
 
-        aws_channel_release_message_to_pool(channel, message);
+        aws_mem_release(message->allocator, message);
 
         if (error_code) {
             aws_channel_shutdown(channel, error_code);
@@ -128,14 +128,14 @@ static void s_do_read(struct socket_handler *socket_handler) {
         }
 
         if (aws_socket_read(socket_handler->socket, &message->message_data, &read)) {
-            aws_channel_release_message_to_pool(socket_handler->slot->channel, message);
+            aws_mem_release(message->allocator, message);
             break;
         }
 
         total_read += read;
 
         if (aws_channel_slot_send_message(socket_handler->slot, message, AWS_CHANNEL_DIR_READ)) {
-            aws_channel_release_message_to_pool(socket_handler->slot->channel, message);
+            aws_mem_release(message->allocator, message);
             break;
         }
     }
@@ -159,15 +159,20 @@ static void s_do_read(struct socket_handler *socket_handler) {
     }
 }
 
-/* the socket is either readable or errored out. If it's readable, kick of s_do_read() to do its thing.
+/* the socket is either readable or errored out. If it's readable, kick off s_do_read() to do its thing.
  * If an error, start the channel shutdown process. */
 static void s_on_readable_notification(struct aws_socket *socket, int error_code, void *user_data) {
     (void)socket;
 
     struct socket_handler *socket_handler = user_data;
-    if (!error_code) {
-        s_do_read(socket_handler);
-    } else if (!socket_handler->shutdown_in_progress) {
+
+    /* read regardless so we can pick up data that was sent prior to the close. For example, peer sends a TLS ALERT
+     * then immediately closes the socket. On some platforms, we'll never see the readable flag. So we want to make
+     * sure we read the ALERT, otherwise, we'll end up telling the user that the channel shutdown because of a socket
+     * closure, when in reality it was a TLS error */
+    s_do_read(socket_handler);
+
+    if (error_code && !socket_handler->shutdown_in_progress) {
         aws_channel_shutdown(socket_handler->slot->channel, error_code);
     }
 }
@@ -183,7 +188,7 @@ static void s_read_task(struct aws_channel_task *task, void *arg, aws_task_statu
     }
 }
 
-int socket_increment_read_window(struct aws_channel_handler *handler, struct aws_channel_slot *slot, size_t size) {
+int s_socket_increment_read_window(struct aws_channel_handler *handler, struct aws_channel_slot *slot, size_t size) {
     (void)size;
 
     struct socket_handler *socket_handler = handler->impl;
@@ -244,22 +249,28 @@ static int s_socket_shutdown(
     return AWS_OP_SUCCESS;
 }
 
-size_t socket_initial_window_size(struct aws_channel_handler *handler) {
+size_t s_message_overhead(struct aws_channel_handler *handler) {
+    (void)handler;
+    return 0;
+}
+
+size_t s_socket_initial_window_size(struct aws_channel_handler *handler) {
     (void)handler;
     return SIZE_MAX;
 }
 
-void socket_destroy(struct aws_channel_handler *handler) {
+void s_socket_destroy(struct aws_channel_handler *handler) {
     aws_mem_release(handler->alloc, handler);
 }
 
 static struct aws_channel_handler_vtable s_vtable = {
     .process_read_message = s_socket_process_read_message,
-    .destroy = socket_destroy,
+    .destroy = s_socket_destroy,
     .process_write_message = s_socket_process_write_message,
-    .initial_window_size = socket_initial_window_size,
-    .increment_read_window = socket_increment_read_window,
+    .initial_window_size = s_socket_initial_window_size,
+    .increment_read_window = s_socket_increment_read_window,
     .shutdown = s_socket_shutdown,
+    .message_overhead = s_message_overhead,
 };
 
 struct aws_channel_handler *aws_socket_handler_new(

--- a/source/socket_channel_handler.c
+++ b/source/socket_channel_handler.c
@@ -188,7 +188,10 @@ static void s_read_task(struct aws_channel_task *task, void *arg, aws_task_statu
     }
 }
 
-int s_socket_increment_read_window(struct aws_channel_handler *handler, struct aws_channel_slot *slot, size_t size) {
+static int s_socket_increment_read_window(
+    struct aws_channel_handler *handler,
+    struct aws_channel_slot *slot,
+    size_t size) {
     (void)size;
 
     struct socket_handler *socket_handler = handler->impl;
@@ -249,17 +252,17 @@ static int s_socket_shutdown(
     return AWS_OP_SUCCESS;
 }
 
-size_t s_message_overhead(struct aws_channel_handler *handler) {
+static size_t s_message_overhead(struct aws_channel_handler *handler) {
     (void)handler;
     return 0;
 }
 
-size_t s_socket_initial_window_size(struct aws_channel_handler *handler) {
+static size_t s_socket_initial_window_size(struct aws_channel_handler *handler) {
     (void)handler;
     return SIZE_MAX;
 }
 
-void s_socket_destroy(struct aws_channel_handler *handler) {
+static void s_socket_destroy(struct aws_channel_handler *handler) {
     aws_mem_release(handler->alloc, handler);
 }
 

--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -13,12 +13,14 @@
  * permissions and limitations under the License.
  */
 
+#include <aws/io/channel.h>
 #include <aws/io/tls_channel_handler.h>
 
 void aws_tls_ctx_options_init_default_client(struct aws_tls_ctx_options *options) {
     AWS_ZERO_STRUCT(*options);
     options->minimum_tls_version = AWS_IO_TLS_VER_SYS_DEFAULTS;
     options->verify_peer = true;
+    options->max_fragment_size = g_aws_channel_max_fragment_size;
 }
 
 void aws_tls_ctx_options_init_client_mtls(
@@ -30,6 +32,7 @@ void aws_tls_ctx_options_init_client_mtls(
     options->verify_peer = true;
     options->certificate_path = cert_path;
     options->private_key_path = pkey_path;
+    options->max_fragment_size = g_aws_channel_max_fragment_size;
 }
 
 void aws_tls_ctx_options_init_client_mtls_pkcs12(
@@ -41,6 +44,7 @@ void aws_tls_ctx_options_init_client_mtls_pkcs12(
     options->verify_peer = true;
     options->pkcs12_path = pkcs12_path;
     options->pkcs12_password = pkcs_pwd;
+    options->max_fragment_size = g_aws_channel_max_fragment_size;
 }
 
 void aws_tls_ctx_options_init_default_server(
@@ -52,6 +56,7 @@ void aws_tls_ctx_options_init_default_server(
     options->verify_peer = false;
     options->certificate_path = cert_path;
     options->private_key_path = pkey_path;
+    options->max_fragment_size = g_aws_channel_max_fragment_size;
 }
 
 void aws_tls_ctx_options_init_server_pkcs12(
@@ -63,6 +68,7 @@ void aws_tls_ctx_options_init_server_pkcs12(
     options->verify_peer = false;
     options->pkcs12_path = pkcs12_path;
     options->pkcs12_password = pkcs_pwd;
+    options->max_fragment_size = g_aws_channel_max_fragment_size;
 }
 
 void aws_tls_ctx_options_set_alpn_list(struct aws_tls_ctx_options *options, const char *alpn_list) {

--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -864,7 +864,7 @@ static int s_process_pending_output_messages(struct aws_channel_handler *handler
                     handler, sc_handler->slot, &read_out_msg->message_data, sc_handler->options.user_data);
             }
             if (aws_channel_slot_send_message(sc_handler->slot, read_out_msg, AWS_CHANNEL_DIR_READ)) {
-                aws_mem_release(message->allocator, message);
+                aws_mem_release(read_out_msg->allocator, read_out_msg);
                 return AWS_OP_ERR;
             }
 
@@ -1002,7 +1002,7 @@ static int s_process_write_message(
 
         while (message_cursor.len) {
             /* message size will be the lesser of either payload + record overhead or the max TLS record size.*/
-            size_t upstream_overhead = aws_channel_slot_upstream_message_overhead(handler->slot);
+            size_t upstream_overhead = aws_channel_slot_upstream_message_overhead(sc_handler->slot);
             size_t requested_length =
                 message_cursor.len + sc_handler->stream_sizes.cbHeader + sc_handler->stream_sizes.cbTrailer;
             size_t to_write = sc_handler->stream_sizes.cbMaximumMessage - upstream_overhead < requested_length

--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -43,6 +43,8 @@
 #define READ_IN_SIZE READ_OUT_SIZE
 #define EST_HANDSHAKE_SIZE (7 * KB_1)
 
+#define EST_TLS_RECORD_OVERHEAD 53 /* 5 byte header + 32 + 16 bytes for padding */
+
 void aws_tls_init_static_state(struct aws_allocator *alloc) {
     (void)alloc;
 }
@@ -198,7 +200,7 @@ static void s_on_negotiation_success(struct aws_channel_handler *handler) {
         protocol_message->protocol = sc_handler->protocol;
         message->message_data.len = sizeof(struct aws_tls_negotiated_protocol_message);
         if (aws_channel_slot_send_message(sc_handler->slot, message, AWS_CHANNEL_DIR_READ)) {
-            aws_channel_release_message_to_pool(sc_handler->slot->channel, message);
+            aws_mem_release(message->allocator, message);
             aws_channel_shutdown(sc_handler->slot->channel, aws_last_error());
         }
     }
@@ -394,7 +396,7 @@ static int s_do_server_side_negotiation_step_1(struct aws_channel_handler *handl
     FreeContextBuffer(output_buffer.pvBuffer);
 
     if (aws_channel_slot_send_message(sc_handler->slot, outgoing_message, AWS_CHANNEL_DIR_WRITE)) {
-        aws_channel_release_message_to_pool(sc_handler->slot->channel, outgoing_message);
+        aws_mem_release(outgoing_message->allocator, outgoing_message);
         s_invoke_negotiation_error(handler, aws_last_error());
         return AWS_OP_ERR;
     }
@@ -486,7 +488,7 @@ static int s_do_server_side_negotiation_step_2(struct aws_channel_handler *handl
                 FreeContextBuffer(buf_ptr->pvBuffer);
 
                 if (aws_channel_slot_send_message(sc_handler->slot, outgoing_message, AWS_CHANNEL_DIR_WRITE)) {
-                    aws_channel_release_message_to_pool(sc_handler->slot->channel, outgoing_message);
+                    aws_mem_release(outgoing_message->allocator, outgoing_message);
                     s_invoke_negotiation_error(handler, aws_last_error());
                     return AWS_OP_ERR;
                 }
@@ -626,7 +628,7 @@ static int s_do_client_side_negotiation_step_1(struct aws_channel_handler *handl
     FreeContextBuffer(output_buffer.pvBuffer);
 
     if (aws_channel_slot_send_message(sc_handler->slot, outgoing_message, AWS_CHANNEL_DIR_WRITE)) {
-        aws_channel_release_message_to_pool(sc_handler->slot->channel, outgoing_message);
+        aws_mem_release(outgoing_message->allocator, outgoing_message);
 
         s_invoke_negotiation_error(handler, aws_last_error());
         return AWS_OP_ERR;
@@ -722,7 +724,7 @@ static int s_do_client_side_negotiation_step_2(struct aws_channel_handler *handl
                 FreeContextBuffer(buf_ptr->pvBuffer);
 
                 if (aws_channel_slot_send_message(sc_handler->slot, outgoing_message, AWS_CHANNEL_DIR_WRITE)) {
-                    aws_channel_release_message_to_pool(sc_handler->slot->channel, outgoing_message);
+                    aws_mem_release(outgoing_message->allocator, outgoing_message);
                     s_invoke_negotiation_error(handler, aws_last_error());
                     return AWS_OP_ERR;
                 }
@@ -862,7 +864,7 @@ static int s_process_pending_output_messages(struct aws_channel_handler *handler
                     handler, sc_handler->slot, &read_out_msg->message_data, sc_handler->options.user_data);
             }
             if (aws_channel_slot_send_message(sc_handler->slot, read_out_msg, AWS_CHANNEL_DIR_READ)) {
-                aws_channel_release_message_to_pool(sc_handler->slot->channel, read_out_msg);
+                aws_mem_release(message->allocator, message);
                 return AWS_OP_ERR;
             }
 
@@ -968,7 +970,7 @@ static int s_process_read_message(
         }
 
         if (!err) {
-            aws_channel_release_message_to_pool(slot->channel, message);
+            aws_mem_release(message->allocator, message);
             return AWS_OP_SUCCESS;
         }
 
@@ -980,7 +982,7 @@ static int s_process_read_message(
         if (s_process_pending_output_messages(handler)) {
             return AWS_OP_ERR;
         }
-        aws_channel_release_message_to_pool(slot->channel, message);
+        aws_mem_release(message->allocator, message);
     }
 
     return AWS_OP_SUCCESS;
@@ -1000,10 +1002,11 @@ static int s_process_write_message(
 
         while (message_cursor.len) {
             /* message size will be the lesser of either payload + record overhead or the max TLS record size.*/
+            size_t upstream_overhead = aws_channel_slot_upstream_message_overhead(handler->slot);
             size_t requested_length =
                 message_cursor.len + sc_handler->stream_sizes.cbHeader + sc_handler->stream_sizes.cbTrailer;
-            size_t to_write = sc_handler->stream_sizes.cbMaximumMessage < requested_length
-                                  ? sc_handler->stream_sizes.cbMaximumMessage
+            size_t to_write = sc_handler->stream_sizes.cbMaximumMessage - upstream_overhead < requested_length
+                                  ? sc_handler->stream_sizes.cbMaximumMessage - upstream_overhead
                                   : requested_length;
             struct aws_io_message *outgoing_message =
                 aws_channel_acquire_message_from_pool(slot->channel, AWS_IO_MESSAGE_APPLICATION_DATA, to_write);
@@ -1067,7 +1070,7 @@ static int s_process_write_message(
                                                      sc_handler->stream_sizes.cbHeader +
                                                      sc_handler->stream_sizes.cbTrailer;
                 if (aws_channel_slot_send_message(slot, outgoing_message, AWS_CHANNEL_DIR_WRITE)) {
-                    aws_channel_release_message_to_pool(slot->channel, outgoing_message);
+                    aws_mem_release(outgoing_message->allocator, outgoing_message);
                     return AWS_OP_ERR;
                 }
 
@@ -1077,7 +1080,7 @@ static int s_process_write_message(
             }
         }
 
-        aws_channel_release_message_to_pool(slot->channel, message);
+        aws_mem_release(message->allocator, message);
     }
 
     return AWS_OP_SUCCESS;
@@ -1085,7 +1088,7 @@ static int s_process_write_message(
 
 static int s_increment_read_window(struct aws_channel_handler *handler, struct aws_channel_slot *slot, size_t size) {
     (void)size;
-    struct secure_channel_handler *sc_handler = (struct secure_channel_handler *)handler->impl;
+    struct secure_channel_handler *sc_handler = handler->impl;
 
     if (AWS_UNLIKELY(!sc_handler->stream_sizes.cbMaximumMessage)) {
         SECURITY_STATUS status =
@@ -1115,6 +1118,21 @@ static int s_increment_read_window(struct aws_channel_handler *handler, struct a
         aws_channel_schedule_task_now(slot->channel, &sc_handler->sequential_task_storage);
     }
     return AWS_OP_SUCCESS;
+}
+
+size_t s_message_overhead(struct aws_channel_handler *handler) {
+    struct secure_channel_handler *sc_handler = handler->impl;
+
+    if (AWS_UNLIKELY(!sc_handler->stream_sizes.cbMaximumMessage)) {
+        SECURITY_STATUS status =
+            QueryContextAttributes(&sc_handler->sec_handle, SECPKG_ATTR_STREAM_SIZES, &sc_handler->stream_sizes);
+
+        if (status != SEC_E_OK) {
+            return EST_TLS_RECORD_OVERHEAD;
+        }
+    }
+
+    return sc_handler->stream_sizes.cbTrailer + sc_handler->stream_sizes.cbHeader;
 }
 
 static size_t s_initial_window_size(struct aws_channel_handler *handler) {
@@ -1197,7 +1215,7 @@ static int s_handler_shutdown(
 
             /* we don't really care if this succeeds or not, it's just sending the TLS alert. */
             if (aws_channel_slot_send_message(slot, outgoing_message, AWS_CHANNEL_DIR_WRITE)) {
-                aws_channel_release_message_to_pool(slot->channel, outgoing_message);
+                aws_mem_release(outgoing_message->allocator, outgoing_message);
             }
         }
     }
@@ -1271,6 +1289,7 @@ static struct aws_channel_handler_vtable s_handler_vtable = {
     .shutdown = s_handler_shutdown,
     .increment_read_window = s_increment_read_window,
     .initial_window_size = s_initial_window_size,
+    .message_overhead = s_message_overhead,
 };
 
 static struct aws_channel_handler *s_tls_handler_new(

--- a/tests/alpn_handler_test.c
+++ b/tests/alpn_handler_test.c
@@ -54,6 +54,12 @@ static int s_alpn_test_shutdown(
     return aws_channel_slot_on_handler_shutdown_complete(slot, dir, error_code, abort_immediately);
 }
 
+static size_t s_alpn_test_message_overhead(struct aws_channel_handler *handler) {
+    (void)handler;
+
+    return 0;
+}
+
 static size_t s_alpn_test_initial_window_size(struct aws_channel_handler *handler) {
     (void)handler;
 
@@ -68,6 +74,7 @@ struct aws_channel_handler_vtable s_alpn_test_vtable = {
     .destroy = s_alpn_test_destroy,
     .shutdown = s_alpn_test_shutdown,
     .initial_window_size = s_alpn_test_initial_window_size,
+    .message_overhead = s_alpn_test_message_overhead,
 };
 
 static struct aws_channel_handler *s_alpn_tls_successful_negotiation(

--- a/tests/socket_handler_test.c
+++ b/tests/socket_handler_test.c
@@ -466,7 +466,8 @@ static int s_socket_close_test(struct aws_allocator *allocator, void *ctx) {
         aws_condition_variable_wait_pred(&condition_variable, &mutex, s_channel_shutdown_predicate, &outgoing_args));
 
     ASSERT_INT_EQUALS(AWS_OP_SUCCESS, incoming_args.error_code);
-    ASSERT_INT_EQUALS(AWS_IO_SOCKET_CLOSED, outgoing_args.error_code);
+    ASSERT_TRUE(
+        AWS_IO_SOCKET_CLOSED == outgoing_args.error_code || AWS_IO_SOCKET_NOT_CONNECTED == outgoing_args.error_code);
 
     ASSERT_SUCCESS(aws_server_bootstrap_destroy_socket_listener(&server_bootstrap, listener));
     aws_client_bootstrap_clean_up(&client_bootstrap);

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -263,6 +263,8 @@ static int s_tls_channel_echo_and_backpressure_test_fn(struct aws_allocator *all
         allocator, s_tls_test_handle_read, s_tls_test_handle_write, true, read_tag.len / 2, &incoming_rw_args);
     ASSERT_NOT_NULL(outgoing_rw_handler);
 
+    g_aws_channel_max_fragment_size = 4096;
+
     struct aws_tls_ctx_options server_ctx_options;
 #ifdef __APPLE__
     aws_tls_ctx_options_init_server_pkcs12(&server_ctx_options, "./unittests.p12", "1234");


### PR DESCRIPTION
… block memory pools.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
