### PR TITLE
Connect race fix

### DIFF
--- a/build-deps.sh
+++ b/build-deps.sh
@@ -1,0 +1,94 @@
+#!/usr/bin/env bash
+
+# usage:
+# ./build-deps.sh
+#   -c, --clean - remove any cached CMake config before building
+#   -i, --install <path> - sets the CMAKE_INSTALL_PREFIX, the root where the deps will be install
+#   -l, --local - Tells the script to look for local dependency source trees in the same parent as this repo
+#   <all other args> - will be passed to cmake as-is
+
+set -e
+set -x
+
+# everything is relative to the directory this script is in
+home_dir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
+
+# where to have cmake put its binaries
+deps_dir=$home_dir/build/deps
+# where deps will be installed
+install_prefix=$deps_dir/install
+# whether or not to look for local sources for deps, they should be in
+# the same parent directory as this repo
+prefer_local_deps=0
+
+cmake_args=""
+
+function install_dep {
+    local dep=$1
+    local commit_or_branch=$2
+
+    # if the local deps are preferred and the local dep exists, use it
+    if [ $prefer_local_deps -ne 0 ] && [ -d "$home_dir/../$dep" ]; then
+        pushd $home_dir/../$dep
+        echo "Using local repo: $home_dir/../$dep branch:" `git branch | grep \* | cut -d ' ' -f2` "commit: " `git rev-parse HEAD`
+    else # git clone the repo and build it
+        pushd $deps_dir
+        if [ -d $dep ]; then
+            cd $dep
+            git pull --rebase
+        else
+            git clone https://github.com/awslabs/$dep.git
+            cd $dep
+        fi
+
+        if [ -n "$commit_or_branch" ]; then
+            git checkout $commit_or_branch
+        fi
+        echo "Using git repo: $dep branch:" `git branch | grep \* | cut -d ' ' -f2` "commit: " `git rev-parse HEAD`
+    fi
+
+    mkdir -p dep-build
+    cd dep-build
+
+    cmake -GNinja $cmake_args -DCMAKE_INSTALL_PREFIX=$install_prefix ..
+    cmake --build . --target all
+    cmake --build . --target install
+
+    popd
+}
+
+cmake_args=()
+while [[ $# -gt 0 ]]
+do
+    arg="$1"
+
+    case $arg in
+        -c|--clean)
+        clean=1
+        shift
+        ;;
+        -i|--install)
+        install_prefix=$2
+        shift
+        shift
+        ;;
+        -l|--local|--prefer-local)
+        prefer_local_deps=1
+        shift
+        ;;
+        *)    # everything else
+        cmake_args="$cmake_args $arg" # unknown args are passed to cmake
+        shift
+        ;;
+    esac
+done
+
+if [ $clean ]; then
+    rm -rf $deps_dir
+fi
+mkdir -p $deps_dir
+
+install_dep aws-c-common
+if [ "$(uname)" != "Darwin" ]; then
+    install_dep s2n
+fi

--- a/build-deps.sh
+++ b/build-deps.sh
@@ -89,6 +89,6 @@ fi
 mkdir -p $deps_dir
 
 install_dep aws-c-common
-if [ "$(uname)" != "Darwin" ]; then
+if [ "$OSTYPE" != "darwin" ]; then
     install_dep s2n
 fi

--- a/source/posix/socket.c
+++ b/source/posix/socket.c
@@ -338,6 +338,7 @@ static void s_handle_socket_timeout(struct aws_task *task, void *args, aws_task_
 
     struct posix_socket_connect_args *socket_args = args;
 
+    /* successful connection will have nulled out connect_args->socket */
     if (socket_args->socket) {
         socket_args->socket->state = TIMEDOUT;
         if (status == AWS_TASK_STATUS_RUN_READY) {
@@ -481,8 +482,18 @@ int aws_socket_connect(
     if (error_code) {
         error_code = errno;
         if (error_code == EINPROGRESS || error_code == EALREADY) {
+            /* schedule a task to run at the connect timeout interval, if this task runs before the connect
+             * happens, we consider that a timeout. */
+            uint64_t timeout = 0;
+            aws_event_loop_current_clock_time(event_loop, &timeout);
+
+            timeout += aws_timestamp_convert(
+                socket->options.connect_timeout_ms, AWS_TIMESTAMP_MILLIS, AWS_TIMESTAMP_NANOS, NULL);
+            aws_event_loop_schedule_task_future(event_loop, &socket_impl->connect_args->task, timeout);
+
             socket_impl->currently_subscribed = true;
-            /* This event is for when the connection finishes. (the fd will flip writable). */
+            /* This event is for when the connection finishes. (the fd will flip writable). This must come
+             * after the timeout task is scheduled, because it can complete nearly imediately */
             if (aws_event_loop_subscribe_to_io_events(
                     event_loop,
                     &socket->io_handle,
@@ -493,15 +504,6 @@ int aws_socket_connect(
                 socket->event_loop = NULL;
                 goto err_clean_up;
             }
-
-            uint64_t timeout = 0;
-            aws_event_loop_current_clock_time(event_loop, &timeout);
-
-            timeout += aws_timestamp_convert(
-                socket->options.connect_timeout_ms, AWS_TIMESTAMP_MILLIS, AWS_TIMESTAMP_NANOS, NULL);
-            /* schedule a task to run at the connect timeout interval, if this task runs before the connect
-             * happens, we consider that a timeout. */
-            aws_event_loop_schedule_task_future(event_loop, &socket_impl->connect_args->task, timeout);
         } else {
             int aws_error = s_determine_socket_error(error_code);
             aws_raise_error(aws_error);


### PR DESCRIPTION
Moved timeout task before io subscription, fixes race where io event could come in before timeout task is scheduled, leading to a nullptr access on the socket connect args

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
