### PR TITLE
Expose log subject all the way to the user macros

### DIFF
--- a/include/aws/io/logging.h
+++ b/include/aws/io/logging.h
@@ -147,7 +147,7 @@ struct aws_logger_standard_options {
  * Checks for a logger and filters based on log level.
  *
  */
-#define AWS_LOGF_RAW(log_level, subject, ...)                                                                          \
+#define AWS_LOGF(log_level, subject, ...)                                                                              \
     {                                                                                                                  \
         assert(log_level > 0);                                                                                         \
         struct aws_logger *logger = aws_logger_get();                                                                  \
@@ -155,8 +155,6 @@ struct aws_logger_standard_options {
             logger->vtable->log(logger, log_level, subject, __VA_ARGS__);                                              \
         }                                                                                                              \
     }
-
-#define AWS_LOGF(log_level, ...) AWS_LOGF_RAW(log_level, AWS_LS_IO_GENERAL, __VA_ARGS__)
 
 /**
  * LOGF_<level> variants for each level.  These are what should be used directly to do all logging.
@@ -169,39 +167,39 @@ struct aws_logger_standard_options {
  * Later we will likely expose Subject-aware variants
  */
 #if !defined(AWS_STATIC_LOG_LEVEL) || (AWS_STATIC_LOG_LEVEL >= AWS_LOG_LEVEL_FATAL)
-#    define AWS_LOGF_FATAL(...) AWS_LOGF(AWS_LL_FATAL, __VA_ARGS__)
+#    define AWS_LOGF_FATAL(subject, ...) AWS_LOGF(AWS_LL_FATAL, subject, __VA_ARGS__)
 #else
-#    define AWS_LOGF_FATAL(...)
+#    define AWS_LOGF_FATAL(subject, ...)
 #endif
 
 #if !defined(AWS_STATIC_LOG_LEVEL) || (AWS_STATIC_LOG_LEVEL >= AWS_LOG_LEVEL_ERROR)
-#    define AWS_LOGF_ERROR(...) AWS_LOGF(AWS_LL_ERROR, __VA_ARGS__)
+#    define AWS_LOGF_ERROR(subject, ...) AWS_LOGF(AWS_LL_ERROR, subject, __VA_ARGS__)
 #else
-#    define AWS_LOGF_ERROR(...)
+#    define AWS_LOGF_ERROR(subject, ...)
 #endif
 
 #if !defined(AWS_STATIC_LOG_LEVEL) || (AWS_STATIC_LOG_LEVEL >= AWS_LOG_LEVEL_WARN)
-#    define AWS_LOGF_WARN(...) AWS_LOGF(AWS_LL_WARN, __VA_ARGS__)
+#    define AWS_LOGF_WARN(subject, ...) AWS_LOGF(AWS_LL_WARN, subject, __VA_ARGS__)
 #else
-#    define AWS_LOGF_WARN(...)
+#    define AWS_LOGF_WARN(subject, ...)
 #endif
 
 #if !defined(AWS_STATIC_LOG_LEVEL) || (AWS_STATIC_LOG_LEVEL >= AWS_LOG_LEVEL_INFO)
-#    define AWS_LOGF_INFO(...) AWS_LOGF(AWS_LL_INFO, __VA_ARGS__)
+#    define AWS_LOGF_INFO(subject, ...) AWS_LOGF(AWS_LL_INFO, subject, __VA_ARGS__)
 #else
-#    define AWS_LOGF_INFO(...)
+#    define AWS_LOGF_INFO(subject, ...)
 #endif
 
 #if !defined(AWS_STATIC_LOG_LEVEL) || (AWS_STATIC_LOG_LEVEL >= AWS_LOG_LEVEL_DEBUG)
-#    define AWS_LOGF_DEBUG(...) AWS_LOGF(AWS_LL_DEBUG, __VA_ARGS__)
+#    define AWS_LOGF_DEBUG(subject, ...) AWS_LOGF(AWS_LL_DEBUG, subject, __VA_ARGS__)
 #else
-#    define AWS_LOGF_DEBUG(...)
+#    define AWS_LOGF_DEBUG(subject, ...)
 #endif
 
 #if !defined(AWS_STATIC_LOG_LEVEL) || (AWS_STATIC_LOG_LEVEL >= AWS_LOG_LEVEL_TRACE)
-#    define AWS_LOGF_TRACE(...) AWS_LOGF(AWS_LL_TRACE, __VA_ARGS__)
+#    define AWS_LOGF_TRACE(subject, ...) AWS_LOGF(AWS_LL_TRACE, subject, __VA_ARGS__)
 #else
-#    define AWS_LOGF_TRACE(...)
+#    define AWS_LOGF_TRACE(subject, ...)
 #endif
 
 AWS_EXTERN_C_BEGIN

--- a/tests/logging/logging_test_utilities.h
+++ b/tests/logging/logging_test_utilities.h
@@ -54,12 +54,12 @@ int do_log_test(
 #define DECLARE_LOGF_ALL_LEVELS_FUNCTION(fn_name)                                                                      \
     static void fn_name(enum aws_log_level level) {                                                                    \
         (void)level;                                                                                                   \
-        AWS_LOGF_FATAL("%d", (int)AWS_LL_FATAL);                                                                       \
-        AWS_LOGF_ERROR("%d", (int)AWS_LL_ERROR);                                                                       \
-        AWS_LOGF_WARN("%d", (int)AWS_LL_WARN);                                                                         \
-        AWS_LOGF_INFO("%d", (int)AWS_LL_INFO);                                                                         \
-        AWS_LOGF_DEBUG("%d", (int)AWS_LL_DEBUG);                                                                       \
-        AWS_LOGF_TRACE("%d", (int)AWS_LL_TRACE);                                                                       \
+        AWS_LOGF_FATAL(AWS_LS_IO_GENERAL, "%d", (int)AWS_LL_FATAL);                                                    \
+        AWS_LOGF_ERROR(AWS_LS_IO_GENERAL, "%d", (int)AWS_LL_ERROR);                                                    \
+        AWS_LOGF_WARN(AWS_LS_IO_GENERAL, "%d", (int)AWS_LL_WARN);                                                      \
+        AWS_LOGF_INFO(AWS_LS_IO_GENERAL, "%d", (int)AWS_LL_INFO);                                                      \
+        AWS_LOGF_DEBUG(AWS_LS_IO_GENERAL, "%d", (int)AWS_LL_DEBUG);                                                    \
+        AWS_LOGF_TRACE(AWS_LS_IO_GENERAL, "%d", (int)AWS_LL_TRACE);                                                    \
     }
 
 #endif /* AWS_COMMON_LOGGING_TEST_UTILITIES_H */

--- a/tests/logging/pipeline_logger_test.c
+++ b/tests/logging/pipeline_logger_test.c
@@ -101,21 +101,21 @@ int do_pipeline_logger_test(
 }
 
 static void s_unformatted_pipeline_logger_test_callback(void) {
-    AWS_LOGF_TRACE("trace log call");
-    AWS_LOGF_DEBUG("debug log call");
-    AWS_LOGF_INFO("info log call");
-    AWS_LOGF_WARN("warn log call");
-    AWS_LOGF_ERROR("error log call");
-    AWS_LOGF_FATAL("fatal log call");
+    AWS_LOGF_TRACE(AWS_LS_IO_GENERAL, "trace log call");
+    AWS_LOGF_DEBUG(AWS_LS_IO_GENERAL, "debug log call");
+    AWS_LOGF_INFO(AWS_LS_IO_GENERAL, "info log call");
+    AWS_LOGF_WARN(AWS_LS_IO_GENERAL, "warn log call");
+    AWS_LOGF_ERROR(AWS_LS_IO_GENERAL, "error log call");
+    AWS_LOGF_FATAL(AWS_LS_IO_GENERAL, "fatal log call");
 }
 
 static void s_formatted_pipeline_logger_test_callback(void) {
-    AWS_LOGF_TRACE("%s log call", "trace");
-    AWS_LOGF_DEBUG("%s log call", "debug");
-    AWS_LOGF_INFO("%s log call", "info");
-    AWS_LOGF_WARN("%s log call", "warn");
-    AWS_LOGF_ERROR("%s log call", "error");
-    AWS_LOGF_FATAL("%s log call", "fatal");
+    AWS_LOGF_TRACE(AWS_LS_IO_GENERAL, "%s log call", "trace");
+    AWS_LOGF_DEBUG(AWS_LS_IO_GENERAL, "%s log call", "debug");
+    AWS_LOGF_INFO(AWS_LS_IO_GENERAL, "%s log call", "info");
+    AWS_LOGF_WARN(AWS_LS_IO_GENERAL, "%s log call", "warn");
+    AWS_LOGF_ERROR(AWS_LS_IO_GENERAL, "%s log call", "error");
+    AWS_LOGF_FATAL(AWS_LS_IO_GENERAL, "%s log call", "fatal");
 }
 
 static const char *expected_test_user_content[] =


### PR DESCRIPTION
Adds subject as a parameter to all of the logging macros


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
