### PR TITLE
fix up io_testing_channel

### DIFF
--- a/include/aws/testing/io_testing_channel.h
+++ b/include/aws/testing/io_testing_channel.h
@@ -58,7 +58,7 @@ static int s_testing_loop_subscribe_to_io_events(
     struct aws_event_loop *event_loop,
     struct aws_io_handle *handle,
     int events,
-    aws_event_loop_on_event_fn on_event,
+    aws_event_loop_on_event_fn *on_event,
     void *user_data) {
     (void)event_loop;
     (void)handle;
@@ -158,14 +158,17 @@ static int s_testing_channel_handler_shutdown(
     int error_code,
     bool free_scarce_resources_immediately) {
 
+    (void)handler;
     return aws_channel_slot_on_handler_shutdown_complete(slot, dir, error_code, free_scarce_resources_immediately);
 }
 
 static size_t s_testing_channel_handler_initial_window_size(struct aws_channel_handler *handler) {
+    (void)handler;
     return 16 * 1024;
 }
 
 static size_t s_testing_channel_handler_message_overhead(struct aws_channel_handler *handler) {
+    (void)handler;
     return 0;
 }
 

--- a/include/aws/testing/io_testing_channel.h
+++ b/include/aws/testing/io_testing_channel.h
@@ -42,7 +42,7 @@ static int s_testing_loop_wait_for_stop_completion(struct aws_event_loop *event_
 
 static void s_testing_loop_schedule_task_now(struct aws_event_loop *event_loop, struct aws_task *task) {
     struct testing_loop *testing_loop = event_loop->impl_data;
-    return aws_task_scheduler_schedule_now(&testing_loop->scheduler, task);
+    aws_task_scheduler_schedule_now(&testing_loop->scheduler, task);
 }
 
 static void s_testing_loop_schedule_task_future(
@@ -51,27 +51,7 @@ static void s_testing_loop_schedule_task_future(
     uint64_t run_at_nanos) {
 
     struct testing_loop *testing_loop = event_loop->impl_data;
-    return aws_task_scheduler_schedule_future(&testing_loop->scheduler, task, run_at_nanos);
-}
-
-static int s_testing_loop_subscribe_to_io_events(
-    struct aws_event_loop *event_loop,
-    struct aws_io_handle *handle,
-    int events,
-    aws_event_loop_on_event_fn *on_event,
-    void *user_data) {
-    (void)event_loop;
-    (void)handle;
-    (void)events;
-    (void)on_event;
-    (void)user_data;
-    return AWS_OP_SUCCESS;
-}
-
-static int s_testing_loop_unsubscribe_from_io_events(struct aws_event_loop *event_loop, struct aws_io_handle *handle) {
-    (void)event_loop;
-    (void)handle;
-    return AWS_OP_SUCCESS;
+    aws_task_scheduler_schedule_future(&testing_loop->scheduler, task, run_at_nanos);
 }
 
 static bool s_testing_loop_is_on_callers_thread(struct aws_event_loop *event_loop) {
@@ -94,8 +74,6 @@ static struct aws_event_loop_vtable s_testing_loop_vtable = {
     .schedule_task_now = s_testing_loop_schedule_task_now,
     .schedule_task_future = s_testing_loop_schedule_task_future,
     .stop = s_testing_loop_stop,
-    .subscribe_to_io_events = s_testing_loop_subscribe_to_io_events,
-    .unsubscribe_from_io_events = s_testing_loop_unsubscribe_from_io_events,
     .wait_for_stop_completion = s_testing_loop_wait_for_stop_completion,
 };
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,8 @@ endif ()
 add_test_case(event_loop_stop_then_restart)
 add_test_case(event_loop_group_setup_and_shutdown)
 
+add_test_case(io_testing_channel)
+
 add_test_case(local_socket_communication)
 add_test_case(tcp_socket_communication)
 add_test_case(udp_socket_communication)

--- a/tests/io_testing_channel_test.c
+++ b/tests/io_testing_channel_test.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+#include <aws/testing/io_testing_channel.h>
+
+static int s_test_io_testing_channel(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    struct testing_channel testing_channel;
+    ASSERT_SUCCESS(testing_channel_init(&testing_channel, allocator));
+    ASSERT_SUCCESS(testing_channel_clean_up(&testing_channel));
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(io_testing_channel, s_test_io_testing_channel)


### PR DESCRIPTION
Resurrecting and fixing this up for use in another lib.

New `testing_channel` struct is necessary because `aws_channel`'s definition moved to a C file, but we still need to know about the special event-loop and channel-handler.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
