### PR TITLE
Fix leaked va_list

### DIFF
--- a/tests/logging/test_logger.c
+++ b/tests/logging/test_logger.c
@@ -44,6 +44,9 @@ int s_test_logger_log_fn(
 #else
     int written = vsnprintf(buffer, TEST_LOGGER_MAX_LOG_LINE_SIZE, format, format_args);
 #endif // WIN32
+
+    va_end(format_args);
+
     if (written < 0) {
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }


### PR DESCRIPTION
Clang7 warned me about this.
It didn't show up in CI because Clang6 is the latest we run.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
