### PR TITLE
libuv loop 2.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -63,6 +63,8 @@ if (WIN32)
                 "source/windows/iocp/*.c"
                 )
          list(APPEND AWS_IO_OS_SRC ${AWS_IO_IOCP_SRC})
+
+         set(EVENT_LOOP_DEFINE "IO_COMPLETION_PORTS")
     endif ()
 
     if (MSVC)
@@ -76,8 +78,6 @@ if (WIN32)
     #Also note, you don't get a choice on TLS implementation for Windows.
     set(PLATFORM_LIBS Secur32 Crypt32)
     set(TLS_STACK_DETERMINED ON)
-
-    set(EVENT_LOOP_DEFINE "IO_COMPLETION_PORTS")
 
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     file(GLOB AWS_IO_OS_HEADERS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,8 @@ if (WIN32)
     set(PLATFORM_LIBS Secur32 Crypt32)
     set(TLS_STACK_DETERMINED ON)
 
+    set(EVENT_LOOP_DEFINE "IO_COMPLETION_PORTS")
+
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
     file(GLOB AWS_IO_OS_HEADERS
             )
@@ -86,6 +88,9 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")
             "source/posix/*.c"
             )
     set(PLATFORM_LIBS "")
+
+    set(EVENT_LOOP_DEFINE "EPOLL")
+
 elseif (APPLE)
 
     file(GLOB AWS_IO_OS_HEADERS
@@ -97,14 +102,16 @@ elseif (APPLE)
             "source/darwin/*.c"
             )
 
-        find_library(SECURITY_LIB Security)
-        if (NOT SECURITY_LIB)
-            message(FATAL_ERROR "Security framework not found")
-        endif ()
+    find_library(SECURITY_LIB Security)
+    if (NOT SECURITY_LIB)
+        message(FATAL_ERROR "Security framework not found")
+    endif ()
 
-        #No choice on TLS for apple, darwinssl will always be used.
-        set(PLATFORM_LIBS ${SECURITY_LIB})
-        set(TLS_STACK_DETERMINED ON)
+    #No choice on TLS for apple, darwinssl will always be used.
+    set(PLATFORM_LIBS ${SECURITY_LIB})
+    set(TLS_STACK_DETERMINED ON)
+
+    set(EVENT_LOOP_DEFINE "KQUEUE")
 
 elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "NetBSD")
     file(GLOB AWS_IO_OS_HEADERS
@@ -114,6 +121,8 @@ elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "NetB
             "source/bsd/*.c"
             "source/posix/*.c"
             )
+
+    set(EVENT_LOOP_DEFINE "KQUEUE")
 
 endif()
 
@@ -171,9 +180,7 @@ aws_add_sanitizers(${CMAKE_PROJECT_NAME})
 set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES VERSION 1.0.0)
 set_target_properties(${CMAKE_PROJECT_NAME} PROPERTIES SOVERSION 0unstable)
 
-if (USE_IO_COMPLETION_PORTS)
-    target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC "-DAWS_USE_IO_COMPLETION_PORTS")
-endif ()
+target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC "-DAWS_USE_${EVENT_LOOP_DEFINE}")
 
 if (USE_LIBUV)
     target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC AWS_USE_LIBUV)

--- a/codebuild/common-posix.sh
+++ b/codebuild/common-posix.sh
@@ -15,7 +15,7 @@ function install_library {
     CURRENT_DIR=`pwd`
     cd $BUILD_PATH
     git clone https://github.com/awslabs/$1.git
-    
+
     cd $1
     if [ -n "$2" ]; then
         git checkout $2

--- a/codebuild/linux-libuv-x64.yml
+++ b/codebuild/linux-libuv-x64.yml
@@ -1,0 +1,23 @@
+version: 0.2
+#this buildspec assumes the ubuntu 14.04 trusty image
+phases:
+  install:
+    commands:
+      - wget -O - https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+      - sudo add-apt-repository ppa:ubuntu-toolchain-r/test
+      - sudo apt-add-repository "deb http://apt.llvm.org/trusty/ llvm-toolchain-trusty-6.0 main"
+      - sudo apt-get update -y
+      - sudo apt-get install cmake3 clang-6.0 clang-tidy-6.0 clang-format-6.0 libuv-dev -y -f
+
+  pre_build:
+    commands:
+      - export CC=clang-6.0
+  build:
+    commands:
+      - echo Build started on `date`
+      - ASAN_OPTIONS=detect_leaks=0 ./codebuild/common-posix.sh -DUSE_LIBUV=ON -DCMAKE_EXPORT_COMPILE_COMMANDS=ON
+      - clang-tidy-6.0 -p=build **/*.c
+  post_build:
+    commands:
+      - echo Build completed on `date`
+

--- a/source/libuv/uv_event_loop.c
+++ b/source/libuv/uv_event_loop.c
@@ -196,6 +196,15 @@ static void s_uv_poll_cb(uv_loop_t *loop, uv__io_t *w, unsigned int events) {
     handle_data->on_event(handle_data->event_loop, handle_data->owner, aws_events, handle_data->on_event_user_data);
 }
 
+static void s_uv_poll_assert_cb(uv_poll_t* handle, int status, int events) {
+    (void)handle;
+    (void)status;
+    (void)events;
+
+    /* If this triggers, s_uv_poll_cb wasn't properly installed */
+    AWS_FATAL_ASSERT(false);
+}
+
 static void s_do_subscribe(struct libuv_loop *impl, struct handle_data *handle_data) {
 
     /* Initalize the handle to default state */
@@ -217,7 +226,7 @@ static void s_do_subscribe(struct libuv_loop *impl, struct handle_data *handle_d
 #endif
 
     /* Start listening for events. The callback should never actually be called, so we use a poison. */
-    uv_poll_start(&handle_data->poll, handle_data->uv_events, (uv_poll_cb)0xBAADF00D);
+    uv_poll_start(&handle_data->poll, handle_data->uv_events, s_uv_poll_assert_cb);
 
 #if defined(AWS_USE_KQUEUE)
     /* Need to re-subscribe using EV_CLEAR. Impl shamelessly stolen from kqueue_event_loop.c */

--- a/source/libuv/uv_event_loop.c
+++ b/source/libuv/uv_event_loop.c
@@ -196,7 +196,7 @@ static void s_uv_poll_cb(uv_loop_t *loop, uv__io_t *w, unsigned int events) {
     handle_data->on_event(handle_data->event_loop, handle_data->owner, aws_events, handle_data->on_event_user_data);
 }
 
-static void s_uv_poll_assert_cb(uv_poll_t* handle, int status, int events) {
+static void s_uv_poll_assert_cb(uv_poll_t *handle, int status, int events) {
     (void)handle;
     (void)status;
     (void)events;

--- a/source/libuv/uv_event_loop.c
+++ b/source/libuv/uv_event_loop.c
@@ -216,7 +216,7 @@ static void s_do_subscribe(struct libuv_loop *impl, struct handle_data *handle_d
     handle_data->uv_events |= UV_DISCONNECT;
 #endif
 
-    /* Start listening for events */
+    /* Start listening for events. The callback should never actually be called, so we use a poison. */
     uv_poll_start(&handle_data->poll, handle_data->uv_events, (uv_poll_cb)0xBAADF00D);
 
 #if defined(AWS_USE_KQUEUE)
@@ -836,9 +836,9 @@ struct aws_event_loop *aws_event_loop_new_libuv(struct aws_allocator *alloc, aws
     uv_loop_t *uv_loop = NULL;
 
 #if UV_VERSION_MAJOR == 0
-    size_t alloc_count = 3;
+    const size_t alloc_count = 3;
 #else
-    size_t alloc_count = 4;
+    const size_t alloc_count = 4;
 #endif
 
     aws_mem_acquire_many(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -153,11 +153,6 @@ add_test_case(test_pipeline_logger_formatted_test)
 set(TEST_BINARY_NAME ${CMAKE_PROJECT_NAME}-tests)
 generate_test_driver(${TEST_BINARY_NAME})
 
-# libuv is level triggered, so don't test edge trigger-ness
-if (NOT USE_LIBUV)
-    target_compile_definitions(${TEST_BINARY_NAME} PRIVATE AWS_TEST_EDGE_TRIGGERS=1)
-endif ()
-
 #SSL certificates to use for testing.
 add_custom_command(TARGET ${TEST_BINARY_NAME} PRE_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory

--- a/tests/event_loop_test.c
+++ b/tests/event_loop_test.c
@@ -721,18 +721,14 @@ static int s_state_on_writable(struct thread_tester *tester) {
 
 static int s_state_fail_if_more_readable_events(struct thread_tester *tester) {
     PRINT_STATE();
-#    ifdef AWS_TEST_EDGE_TRIGGERS
     ASSERT_INT_EQUALS(0, tester->read_handle_event_counts[AWS_IO_EVENT_TYPE_READABLE]);
-#    endif /* AWS_TEST_EDGE_TRIGGERS */
 
     return AWS_OP_SUCCESS;
 }
 
 static int s_state_fail_if_more_writable_events(struct thread_tester *tester) {
     PRINT_STATE();
-#    ifdef AWS_TEST_EDGE_TRIGGERS
     ASSERT_INT_EQUALS(0, tester->write_handle_event_counts[AWS_IO_EVENT_TYPE_WRITABLE]);
-#    endif /* AWS_TEST_EDGE_TRIGGERS */
 
     return AWS_OP_SUCCESS;
 }

--- a/tests/pipe_test.c
+++ b/tests/pipe_test.c
@@ -512,11 +512,9 @@ static int test_pipe_readable_event_sent_once(struct pipe_state *state) {
 
     ASSERT_SUCCESS(s_wait_for_results(state));
 
-#ifdef AWS_TEST_EDGE_TRIGGERS
     /* Accept 1 or 2 events. Epoll notifies about "readable" when sending "write end closed" event.
      * That's fine, we just don't want dozens of readable events to have come in. */
     ASSERT_TRUE(state->readable_events.count <= 2);
-#endif
 
     return AWS_OP_SUCCESS;
 }
@@ -640,9 +638,7 @@ static int test_pipe_readable_event_sent_on_resubscribe_if_data_present(struct p
 
     ASSERT_SUCCESS(s_wait_for_results(state));
 
-#ifdef AWS_TEST_EDGE_TRIGGERS
     ASSERT_INT_EQUALS(2, state->readable_events.count);
-#endif
 
     return AWS_OP_SUCCESS;
 }


### PR DESCRIPTION
Improvements include:
* All subscriptions through the AWS Event Loop API are now edge triggered
* libuv v0.10 and v1.x are both supported
* One of `AWS_USE_IO_COMPLETION_PORTS`, `AWS_USE_EPOLL`, or `AWS_USE_KQUEUE` is always defined.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
