### PR TITLE
Fixed bad logic on window updates for tls handlers.

### DIFF
--- a/source/alpn_handler.c
+++ b/source/alpn_handler.c
@@ -64,9 +64,9 @@ static int s_alpn_shutdown(
     return aws_channel_slot_on_handler_shutdown_complete(slot, dir, error_code, abort_immediately);
 }
 
-static size_t s_alpn_get_current_window_size(struct aws_channel_handler *handler) {
+static size_t s_alpn_get_initial_window_size(struct aws_channel_handler *handler) {
     (void)handler;
-    return SIZE_MAX;
+    return sizeof(struct aws_tls_negotiated_protocol_message);
 }
 
 static void s_alpn_destroy(struct aws_channel_handler *handler) {
@@ -81,7 +81,7 @@ static size_t s_alpn_message_overhead(struct aws_channel_handler *handler) {
 }
 
 static struct aws_channel_handler_vtable s_alpn_handler_vtable = {
-    .initial_window_size = s_alpn_get_current_window_size,
+    .initial_window_size = s_alpn_get_initial_window_size,
     .increment_read_window = NULL,
     .shutdown = s_alpn_shutdown,
     .process_write_message = NULL,

--- a/source/channel.c
+++ b/source/channel.c
@@ -371,16 +371,17 @@ struct aws_io_message *aws_channel_acquire_message_from_pool(
     size_t size_hint) {
 
     struct aws_io_message *message = aws_message_pool_acquire(channel->msg_pool, message_type, size_hint);
-    AWS_LOGF_TRACE(
-        AWS_LS_IO_CHANNEL,
-        "id=%p: acquired message %p of length %llu from pool %p.",
-        (void *)channel,
-        (void *)message,
-        (unsigned long long)size_hint,
-        (void *)channel->msg_pool);
 
     if (AWS_LIKELY(message)) {
         message->owning_channel = channel;
+        AWS_LOGF_TRACE(
+            AWS_LS_IO_CHANNEL,
+            "id=%p: acquired message %p of length %llu from pool %p. Requested size was %llu",
+            (void *)channel,
+            (void *)message,
+            (unsigned long long)message->message_data.len,
+            (void *)channel->msg_pool,
+            (unsigned long long)size_hint);
     }
 
     return message;

--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -645,8 +645,7 @@ static int s_increment_read_window(struct aws_channel_handler *handler, struct a
     size_t downstream_size = aws_channel_slot_downstream_read_window(slot);
     size_t current_window_size = slot->window_size;
 
-    size_t increment_by = downstream_size - current_window_size;
-    size_t likely_records_count = (size_t)ceil((double)(increment_by) / (double)(MAX_RECORD_SIZE));
+    size_t likely_records_count = (size_t)ceil((double)(downstream_size) / (double)(MAX_RECORD_SIZE));
     size_t offset_size = aws_mul_size_saturating(likely_records_count, EST_TLS_RECORD_OVERHEAD);
     size_t total_desired_size = aws_add_size_saturating(offset_size, downstream_size);
 

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -531,11 +531,12 @@ static int s_s2n_handler_increment_read_window(
     AWS_LOGF_TRACE(
         AWS_LS_IO_TLS, "id=%p: Increment read window message received %llu", (void *)handler, (unsigned long long)size);
 
-    if (downstream_size > current_window_size) {
-        size_t increment_by = downstream_size - current_window_size;
-        size_t likely_records_count = (size_t)ceil((double)(increment_by) / (double)(MAX_RECORD_SIZE));
-        size_t offset_size = likely_records_count * (EST_TLS_RECORD_OVERHEAD);
-        size_t total_desired_size = offset_size + downstream_size;
+    size_t increment_by = downstream_size - current_window_size;
+    size_t likely_records_count = (size_t)ceil((double)(increment_by) / (double)(MAX_RECORD_SIZE));
+    size_t offset_size = aws_mul_size_saturating(likely_records_count, EST_TLS_RECORD_OVERHEAD);
+    size_t total_desired_size = aws_add_size_saturating(offset_size, downstream_size);
+
+    if (total_desired_size > current_window_size) {
         size_t window_update_size = total_desired_size - current_window_size;
         AWS_LOGF_TRACE(
             AWS_LS_IO_TLS,

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -531,8 +531,7 @@ static int s_s2n_handler_increment_read_window(
     AWS_LOGF_TRACE(
         AWS_LS_IO_TLS, "id=%p: Increment read window message received %llu", (void *)handler, (unsigned long long)size);
 
-    size_t increment_by = downstream_size - current_window_size;
-    size_t likely_records_count = (size_t)ceil((double)(increment_by) / (double)(MAX_RECORD_SIZE));
+    size_t likely_records_count = (size_t)ceil((double)(downstream_size) / (double)(MAX_RECORD_SIZE));
     size_t offset_size = aws_mul_size_saturating(likely_records_count, EST_TLS_RECORD_OVERHEAD);
     size_t total_desired_size = aws_add_size_saturating(offset_size, downstream_size);
 

--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -1307,12 +1307,13 @@ static int s_increment_read_window(struct aws_channel_handler *handler, struct a
     size_t downstream_size = aws_channel_slot_downstream_read_window(slot);
     size_t current_window_size = slot->window_size;
 
-    if (downstream_size > current_window_size) {
-        size_t increment_by = downstream_size - current_window_size;
-        size_t likely_records_count = (size_t)ceil((double)(increment_by) / (double)(READ_IN_SIZE));
-        size_t offset_size =
-            likely_records_count * (sc_handler->stream_sizes.cbTrailer + sc_handler->stream_sizes.cbHeader);
-        size_t total_desired_size = offset_size + downstream_size;
+    size_t increment_by = downstream_size - current_window_size;
+    size_t likely_records_count = (size_t)ceil((double)(increment_by) / (double)(READ_IN_SIZE));
+    size_t offset_size = aws_mul_size_saturating(
+        likely_records_count, sc_handler->stream_sizes.cbTrailer + sc_handler->stream_sizes.cbHeader);
+    size_t total_desired_size = aws_add_size_saturating(offset_size, downstream_size);
+
+    if (total_desired_size > current_window_size) {
         size_t window_update_size = total_desired_size - current_window_size;
         AWS_LOGF_TRACE(
             AWS_LS_IO_TLS,

--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -1307,8 +1307,7 @@ static int s_increment_read_window(struct aws_channel_handler *handler, struct a
     size_t downstream_size = aws_channel_slot_downstream_read_window(slot);
     size_t current_window_size = slot->window_size;
 
-    size_t increment_by = downstream_size - current_window_size;
-    size_t likely_records_count = (size_t)ceil((double)(increment_by) / (double)(READ_IN_SIZE));
+    size_t likely_records_count = (size_t)ceil((double)(downstream_size) / (double)(READ_IN_SIZE));
     size_t offset_size = aws_mul_size_saturating(
         likely_records_count, sc_handler->stream_sizes.cbTrailer + sc_handler->stream_sizes.cbHeader);
     size_t total_desired_size = aws_add_size_saturating(offset_size, downstream_size);


### PR DESCRIPTION
TLS back pressure was broken. This makes sure the window updates propagate correctly through the tls handlers. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
