### PR TITLE
Honor CTest's BUILD_TESTING option

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -225,4 +225,6 @@ install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${CMAKE_PROJECT_NAME}-config.cmake"
         COMPONENT Development)
 
 include(CTest)
-add_subdirectory(tests)
+if (BUILD_TESTING)
+    add_subdirectory(tests)
+endif ()


### PR DESCRIPTION
Per [CTest's docs](https://cmake.org/cmake/help/v3.7/module/CTest.html), there's a `BUILD_TESTING` option we should be using to allow disabling of unit tests. This is required to build with libuv on platforms without libuv libraries (i.e. anything targeting node).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
