### PR TITLE
Logger improvements

### DIFF
--- a/include/aws/io/log_channel.h
+++ b/include/aws/io/log_channel.h
@@ -33,11 +33,11 @@ struct aws_log_writer;
 struct aws_log_channel;
 
 typedef int (*aws_log_channel_send_fn)(struct aws_log_channel *channel, struct aws_string *output);
-typedef int (*aws_log_channel_cleanup_fn)(struct aws_log_channel *channel);
+typedef void (*aws_log_channel_clean_up_fn)(struct aws_log_channel *channel);
 
 struct aws_log_channel_vtable {
     const aws_log_channel_send_fn send;
-    const aws_log_channel_cleanup_fn cleanup;
+    const aws_log_channel_clean_up_fn clean_up;
 };
 
 struct aws_log_channel {
@@ -52,7 +52,7 @@ AWS_EXTERN_C_BEGIN
 /*
  * Simple channel that results in log lines being written in the same thread they were generated in.
  *
- * The passed in log writer is not an ownership transfer.  The log channel does not cleanup the writer.
+ * The passed in log writer is not an ownership transfer.  The log channel does not clean up the writer.
  */
 AWS_IO_API
 int aws_log_channel_init_foreground(
@@ -63,7 +63,7 @@ int aws_log_channel_init_foreground(
 /*
  * Simple channel that sends log lines to a background thread.
  *
- * The passed in log writer is not an ownership transfer.  The log channel does not cleanup the writer.
+ * The passed in log writer is not an ownership transfer.  The log channel does not clean up the writer.
  */
 AWS_IO_API
 int aws_log_channel_init_background(
@@ -75,7 +75,7 @@ int aws_log_channel_init_background(
  * Channel cleanup function
  */
 AWS_IO_API
-int aws_log_channel_cleanup(struct aws_log_channel *channel);
+void aws_log_channel_clean_up(struct aws_log_channel *channel);
 
 AWS_EXTERN_C_END
 

--- a/include/aws/io/log_channel.h
+++ b/include/aws/io/log_channel.h
@@ -32,12 +32,12 @@ struct aws_log_writer;
  */
 struct aws_log_channel;
 
-typedef int (*aws_log_channel_send_fn)(struct aws_log_channel *channel, struct aws_string *output);
-typedef void (*aws_log_channel_clean_up_fn)(struct aws_log_channel *channel);
+typedef int(aws_log_channel_send_fn)(struct aws_log_channel *channel, struct aws_string *output);
+typedef void(aws_log_channel_clean_up_fn)(struct aws_log_channel *channel);
 
 struct aws_log_channel_vtable {
-    const aws_log_channel_send_fn send;
-    const aws_log_channel_clean_up_fn clean_up;
+    aws_log_channel_send_fn *send;
+    aws_log_channel_clean_up_fn *clean_up;
 };
 
 struct aws_log_channel {

--- a/include/aws/io/log_formatter.h
+++ b/include/aws/io/log_formatter.h
@@ -35,7 +35,7 @@ struct aws_string;
  */
 struct aws_log_formatter;
 
-typedef int (*aws_log_formatter_format_fn)(
+typedef int(aws_log_formatter_format_fn)(
     struct aws_log_formatter *formatter,
     struct aws_string **formatted_output,
     enum aws_log_level level,
@@ -43,11 +43,11 @@ typedef int (*aws_log_formatter_format_fn)(
     const char *format,
     va_list args);
 
-typedef void (*aws_log_formatter_clean_up_fn)(struct aws_log_formatter *logger);
+typedef void(aws_log_formatter_clean_up_fn)(struct aws_log_formatter *logger);
 
 struct aws_log_formatter_vtable {
-    const aws_log_formatter_format_fn format;
-    const aws_log_formatter_clean_up_fn clean_up;
+    aws_log_formatter_format_fn *format;
+    aws_log_formatter_clean_up_fn *clean_up;
 };
 
 struct aws_log_formatter {

--- a/include/aws/io/log_formatter.h
+++ b/include/aws/io/log_formatter.h
@@ -43,11 +43,11 @@ typedef int (*aws_log_formatter_format_fn)(
     const char *format,
     va_list args);
 
-typedef int (*aws_log_formatter_cleanup_fn)(struct aws_log_formatter *logger);
+typedef void (*aws_log_formatter_clean_up_fn)(struct aws_log_formatter *logger);
 
 struct aws_log_formatter_vtable {
     const aws_log_formatter_format_fn format;
-    const aws_log_formatter_cleanup_fn cleanup;
+    const aws_log_formatter_clean_up_fn clean_up;
 };
 
 struct aws_log_formatter {
@@ -74,11 +74,11 @@ int aws_log_formatter_init_default(
     struct aws_log_formatter_standard_options *options);
 
 /*
- * Cleans up a log formatter (minus the base structure memory) by calling the formatter's cleanup function
+ * Cleans up a log formatter (minus the base structure memory) by calling the formatter's clean_up function
  * via the vtable.
  */
 AWS_IO_API
-int aws_log_formatter_cleanup(struct aws_log_formatter *formatter);
+void aws_log_formatter_clean_up(struct aws_log_formatter *formatter);
 
 AWS_EXTERN_C_END
 

--- a/include/aws/io/log_writer.h
+++ b/include/aws/io/log_writer.h
@@ -30,12 +30,12 @@ struct aws_string;
  */
 struct aws_log_writer;
 
-typedef int (*aws_log_writer_write_fn)(struct aws_log_writer *writer, const struct aws_string *output);
-typedef void (*aws_log_writer_clean_up_fn)(struct aws_log_writer *writer);
+typedef int(aws_log_writer_write_fn)(struct aws_log_writer *writer, const struct aws_string *output);
+typedef void(aws_log_writer_clean_up_fn)(struct aws_log_writer *writer);
 
 struct aws_log_writer_vtable {
-    const aws_log_writer_write_fn write;
-    const aws_log_writer_clean_up_fn clean_up;
+    aws_log_writer_write_fn *write;
+    aws_log_writer_clean_up_fn *clean_up;
 };
 
 struct aws_log_writer {

--- a/include/aws/io/log_writer.h
+++ b/include/aws/io/log_writer.h
@@ -31,11 +31,11 @@ struct aws_string;
 struct aws_log_writer;
 
 typedef int (*aws_log_writer_write_fn)(struct aws_log_writer *writer, const struct aws_string *output);
-typedef int (*aws_log_writer_cleanup_fn)(struct aws_log_writer *writer);
+typedef void (*aws_log_writer_clean_up_fn)(struct aws_log_writer *writer);
 
 struct aws_log_writer_vtable {
     const aws_log_writer_write_fn write;
-    const aws_log_writer_cleanup_fn cleanup;
+    const aws_log_writer_clean_up_fn clean_up;
 };
 
 struct aws_log_writer {
@@ -46,6 +46,7 @@ struct aws_log_writer {
 
 struct aws_log_writer_file_options {
     const char *filename;
+    FILE *file;
 };
 
 AWS_EXTERN_C_BEGIN
@@ -75,7 +76,7 @@ int aws_log_writer_init_file(
  * Frees all resources used by a log writer with the exception of the base structure memory
  */
 AWS_IO_API
-int aws_log_writer_cleanup(struct aws_log_writer *writer);
+void aws_log_writer_clean_up(struct aws_log_writer *writer);
 
 AWS_EXTERN_C_END
 

--- a/include/aws/io/logging.h
+++ b/include/aws/io/logging.h
@@ -123,7 +123,7 @@ struct aws_logger_vtable {
 #endif /* non-ms compilers: TODO - find out what versions format support was added in */
         ;
     enum aws_log_level (*const get_log_level)(struct aws_logger *logger, aws_log_subject_t subject);
-    int (*const cleanup)(struct aws_logger *logger);
+    void (*const clean_up)(struct aws_logger *logger);
 };
 
 struct aws_logger {
@@ -147,9 +147,15 @@ struct aws_logger_pipeline {
     enum aws_log_level level;
 };
 
+/**
+ * Options for aws_logger_init_standard().
+ * Set `filename` to open a file for logging and close it when the logger cleans up.
+ * Set `file` to use a file that is already open, such as `stderr` or `stdout`.
+ */
 struct aws_logger_standard_options {
     enum aws_log_level level;
     const char *filename;
+    FILE* file;
 };
 
 /**
@@ -227,10 +233,10 @@ AWS_IO_API
 struct aws_logger *aws_logger_get(void);
 
 /**
- * Cleans up all resources used by the logger; simply invokes the cleanup v-function
+ * Cleans up all resources used by the logger; simply invokes the clean_up v-function
  */
 AWS_IO_API
-int aws_logger_cleanup(struct aws_logger *logger);
+void aws_logger_clean_up(struct aws_logger *logger);
 
 /**
  * Converts a log level to a c-string constant.  Intended primarily to support building log lines that
@@ -272,6 +278,12 @@ int aws_logger_init_from_external(
 
 /**
  * Connects log subject strings with log subject integer values
+ */
+AWS_IO_API
+void aws_register_log_subject_info_list(struct aws_log_subject_info_list *log_subject_list);
+
+/**
+ * Load aws-c-io's log subject strings.
  */
 AWS_IO_API
 void aws_io_load_log_subject_strings(void);

--- a/include/aws/io/logging.h
+++ b/include/aws/io/logging.h
@@ -155,7 +155,7 @@ struct aws_logger_pipeline {
 struct aws_logger_standard_options {
     enum aws_log_level level;
     const char *filename;
-    FILE* file;
+    FILE *file;
 };
 
 /**

--- a/source/log_formatter.c
+++ b/source/log_formatter.c
@@ -91,7 +91,7 @@ static int s_default_aws_log_formatter_format_fn(
     struct aws_string *raw_string =
         (struct aws_string *)aws_mem_acquire(formatter->allocator, sizeof(struct aws_string) + total_length);
     if (raw_string == NULL) {
-        goto error_cleanup;
+        goto error_clean_up;
     }
 
     char *log_line_buffer = (char *)raw_string->bytes;
@@ -102,12 +102,12 @@ static int s_default_aws_log_formatter_format_fn(
      */
     const char *level_string = NULL;
     if (aws_log_level_to_string(level, &level_string)) {
-        goto error_cleanup;
+        goto error_clean_up;
     }
 
     int log_level_length = snprintf(log_line_buffer, total_length, "[%s] [", level_string);
     if (log_level_length < 0) {
-        goto error_cleanup;
+        goto error_clean_up;
     }
 
     current_index += log_level_length;
@@ -130,7 +130,7 @@ static int s_default_aws_log_formatter_format_fn(
 
     int result = aws_date_time_to_utc_time_str(&current_time, impl->date_format, &timestamp_buffer);
     if (result != AWS_OP_SUCCESS) {
-        goto error_cleanup;
+        goto error_clean_up;
     }
 
     current_index += timestamp_buffer.len;
@@ -142,7 +142,7 @@ static int s_default_aws_log_formatter_format_fn(
     int thread_id_written =
         snprintf(log_line_buffer + current_index, total_length - current_index, "] [%" PRIu64 "] ", current_thread_id);
     if (thread_id_written < 0) {
-        goto error_cleanup;
+        goto error_clean_up;
     }
 
     current_index += thread_id_written;
@@ -153,7 +153,7 @@ static int s_default_aws_log_formatter_format_fn(
             snprintf(log_line_buffer + current_index, total_length - current_index, "[%s]", subject_name);
 
         if (subject_written < 0) {
-            goto error_cleanup;
+            goto error_clean_up;
         }
 
         current_index += subject_written;
@@ -171,7 +171,7 @@ static int s_default_aws_log_formatter_format_fn(
     int written_count = vsnprintf(log_line_buffer + current_index, total_length - current_index, format, args);
 #endif // WIN32
     if (written_count < 0) {
-        goto error_cleanup;
+        goto error_clean_up;
     }
 
     /*
@@ -180,7 +180,7 @@ static int s_default_aws_log_formatter_format_fn(
     current_index += written_count;
     written_count = snprintf(log_line_buffer + current_index, total_length - current_index, "\n");
     if (written_count < 0) {
-        goto error_cleanup;
+        goto error_clean_up;
     }
 
     *(struct aws_allocator **)(&raw_string->allocator) = formatter->allocator;
@@ -190,7 +190,7 @@ static int s_default_aws_log_formatter_format_fn(
 
     return AWS_OP_SUCCESS;
 
-error_cleanup:
+error_clean_up:
 
     if (raw_string != NULL) {
         aws_mem_release(formatter->allocator, raw_string);
@@ -199,15 +199,13 @@ error_cleanup:
     return AWS_OP_ERR;
 }
 
-static int s_default_aws_log_formatter_cleanup_fn(struct aws_log_formatter *formatter) {
+static void s_default_aws_log_formatter_clean_up_fn(struct aws_log_formatter *formatter) {
     aws_mem_release(formatter->allocator, formatter->impl);
-
-    return AWS_OP_SUCCESS;
 }
 
 static struct aws_log_formatter_vtable s_default_log_formatter_vtable = {
     .format = s_default_aws_log_formatter_format_fn,
-    .cleanup = s_default_aws_log_formatter_cleanup_fn};
+    .clean_up = s_default_aws_log_formatter_clean_up_fn};
 
 int aws_log_formatter_init_default(
     struct aws_log_formatter *formatter,
@@ -224,7 +222,7 @@ int aws_log_formatter_init_default(
     return AWS_OP_SUCCESS;
 }
 
-int aws_log_formatter_cleanup(struct aws_log_formatter *formatter) {
-    assert(formatter->vtable->cleanup);
-    return (formatter->vtable->cleanup)(formatter);
+void aws_log_formatter_clean_up(struct aws_log_formatter *formatter) {
+    assert(formatter->vtable->clean_up);
+    (formatter->vtable->clean_up)(formatter);
 }

--- a/source/log_formatter.c
+++ b/source/log_formatter.c
@@ -47,7 +47,7 @@ struct aws_default_log_formatter_impl {
     enum aws_date_format date_format;
 };
 
-static int s_default_aws_log_formatter_format_fn(
+static int s_default_aws_log_formatter_format(
     struct aws_log_formatter *formatter,
     struct aws_string **formatted_output,
     enum aws_log_level level,
@@ -199,13 +199,14 @@ error_clean_up:
     return AWS_OP_ERR;
 }
 
-static void s_default_aws_log_formatter_clean_up_fn(struct aws_log_formatter *formatter) {
+static void s_default_aws_log_formatter_clean_up(struct aws_log_formatter *formatter) {
     aws_mem_release(formatter->allocator, formatter->impl);
 }
 
 static struct aws_log_formatter_vtable s_default_log_formatter_vtable = {
-    .format = s_default_aws_log_formatter_format_fn,
-    .clean_up = s_default_aws_log_formatter_clean_up_fn};
+    .format = s_default_aws_log_formatter_format,
+    .clean_up = s_default_aws_log_formatter_clean_up,
+};
 
 int aws_log_formatter_init_default(
     struct aws_log_formatter *formatter,

--- a/source/log_writer.c
+++ b/source/log_writer.c
@@ -31,90 +31,11 @@
 
 struct aws_file_writer;
 
-/*
- * All three default implementations use a "subclass" implementation
- * that operates on C library file streams.  Stdout/Stderr implementations
- * do not actually open/close their stream.
- *
- * It is the responsibility of the open vtable function to set the log_file
- * member of the aws_file_writer.
- */
-typedef int (*aws_file_writer_open_file_fn)(struct aws_file_writer *writer);
-typedef int (*aws_file_writer_close_file_fn)(struct aws_file_writer *writer);
-
-struct aws_file_writer_vtable {
-    aws_file_writer_open_file_fn open_file;
-    aws_file_writer_close_file_fn close_file;
-};
-
 struct aws_file_writer {
-    struct aws_file_writer_vtable *vtable;
     FILE *log_file;
-    struct aws_string *base_file_name;
+    bool close_file_on_cleanup;
 };
 
-/*
- * Stdout subclass implementation
- */
-static int s_stdout_writer_open_file_fn(struct aws_file_writer *writer) {
-    writer->log_file = stdout;
-
-    return AWS_OP_SUCCESS;
-}
-
-static int s_stdout_writer_close_file_fn(struct aws_file_writer *writer) {
-    (void)writer;
-
-    return AWS_OP_SUCCESS;
-}
-
-static struct aws_file_writer_vtable s_stdout_writer_vtable = {.open_file = s_stdout_writer_open_file_fn,
-                                                               .close_file = s_stdout_writer_close_file_fn};
-
-/*
- * Stderr subclass implementation
- */
-static int s_stderr_writer_open_file_fn(struct aws_file_writer *writer) {
-    writer->log_file = stderr;
-
-    return AWS_OP_SUCCESS;
-}
-
-static int s_stderr_writer_close_file_fn(struct aws_file_writer *writer) {
-    (void)writer;
-
-    return AWS_OP_SUCCESS;
-}
-
-static struct aws_file_writer_vtable s_stderr_writer_vtable = {.open_file = s_stderr_writer_open_file_fn,
-                                                               .close_file = s_stderr_writer_close_file_fn};
-
-/*
- * File-sink subclass implementation - uses fopen and fclose for now
- */
-static int s_file_writer_open_file_fn(struct aws_file_writer *writer) {
-    writer->log_file = fopen((const char *)aws_string_bytes(writer->base_file_name), "a+");
-    if (writer->log_file == NULL) {
-        return aws_io_translate_and_raise_file_open_error(errno);
-    }
-
-    return AWS_OP_SUCCESS;
-}
-
-static int s_file_writer_close_file_fn(struct aws_file_writer *writer) {
-    if (fclose(writer->log_file)) {
-        return aws_io_translate_and_raise_file_open_error(errno);
-    }
-
-    return AWS_OP_SUCCESS;
-}
-
-static struct aws_file_writer_vtable s_file_writer_vtable = {.open_file = s_file_writer_open_file_fn,
-                                                             .close_file = s_file_writer_close_file_fn};
-
-/*
- * Shared implementation across all three writers
- */
 static int s_aws_file_writer_write_fn(struct aws_log_writer *writer, const struct aws_string *output) {
     struct aws_file_writer *impl = (struct aws_file_writer *)writer->impl;
 
@@ -126,23 +47,18 @@ static int s_aws_file_writer_write_fn(struct aws_log_writer *writer, const struc
     return AWS_OP_SUCCESS;
 }
 
-static int s_aws_file_writer_cleanup_fn(struct aws_log_writer *writer) {
+static void s_aws_file_writer_clean_up_fn(struct aws_log_writer *writer) {
     struct aws_file_writer *impl = (struct aws_file_writer *)writer->impl;
 
-    assert(impl->vtable->close_file != NULL);
-    int result = (impl->vtable->close_file)(impl);
-
-    if (impl->base_file_name != NULL) {
-        aws_mem_release(writer->allocator, impl->base_file_name);
+    if (impl->close_file_on_cleanup) {
+        fclose(impl->log_file);
     }
 
     aws_mem_release(writer->allocator, impl);
-
-    return result;
 }
 
 static struct aws_log_writer_vtable s_aws_file_writer_vtable = {.write = s_aws_file_writer_write_fn,
-                                                                .cleanup = s_aws_file_writer_cleanup_fn};
+                                                                .clean_up = s_aws_file_writer_clean_up_fn};
 
 /*
  * Shared internal init implementation
@@ -150,8 +66,13 @@ static struct aws_log_writer_vtable s_aws_file_writer_vtable = {.write = s_aws_f
 static int s_aws_file_writer_init_internal(
     struct aws_log_writer *writer,
     struct aws_allocator *allocator,
-    const char *file_name,
-    struct aws_file_writer_vtable *vtable) {
+    const char *file_name_to_open,
+    FILE *currently_open_file) {
+
+    /* One or the other should be set */
+    if (!(file_name_to_open != NULL ^ currently_open_file != NULL)) {
+        return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
+    }
 
     /* Allocate and initialize the file writer */
     struct aws_file_writer *impl = (struct aws_file_writer *)aws_mem_acquire(allocator, sizeof(struct aws_file_writer));
@@ -159,26 +80,19 @@ static int s_aws_file_writer_init_internal(
         return AWS_OP_ERR;
     }
 
-    impl->vtable = vtable;
     impl->log_file = NULL;
-    impl->base_file_name = NULL;
+    impl->close_file_on_cleanup = false;
 
-    /* copy the file name, if necessary */
-    if (file_name != NULL) {
-        impl->base_file_name = aws_string_new_from_c_str(allocator, file_name);
-        if (impl->base_file_name == NULL) {
+    /* Open file if name passed in */
+    if (file_name_to_open != NULL) {
+        impl->log_file = fopen(file_name_to_open, "a+");
+        if (impl->log_file == NULL) {
             aws_mem_release(allocator, impl);
-            return AWS_OP_ERR;
+            return aws_io_translate_and_raise_file_open_error(errno);
         }
-    }
-
-    /* attempt to open the file */
-    if ((vtable->open_file)(impl)) {
-        if (impl->base_file_name != NULL) {
-            aws_mem_release(allocator, impl->base_file_name);
-        }
-        aws_mem_release(allocator, impl);
-        return AWS_OP_ERR;
+        impl->close_file_on_cleanup = true;
+    } else {
+        impl->log_file = currently_open_file;
     }
 
     writer->vtable = &s_aws_file_writer_vtable;
@@ -192,21 +106,21 @@ static int s_aws_file_writer_init_internal(
  * Public initialization interface
  */
 int aws_log_writer_init_stdout(struct aws_log_writer *writer, struct aws_allocator *allocator) {
-    return s_aws_file_writer_init_internal(writer, allocator, NULL, &s_stdout_writer_vtable);
+    return s_aws_file_writer_init_internal(writer, allocator, NULL, stdout);
 }
 
 int aws_log_writer_init_stderr(struct aws_log_writer *writer, struct aws_allocator *allocator) {
-    return s_aws_file_writer_init_internal(writer, allocator, NULL, &s_stderr_writer_vtable);
+    return s_aws_file_writer_init_internal(writer, allocator, NULL, stderr);
 }
 
 int aws_log_writer_init_file(
     struct aws_log_writer *writer,
     struct aws_allocator *allocator,
     struct aws_log_writer_file_options *options) {
-    return s_aws_file_writer_init_internal(writer, allocator, options->filename, &s_file_writer_vtable);
+    return s_aws_file_writer_init_internal(writer, allocator, options->filename, options->file);
 }
 
-int aws_log_writer_cleanup(struct aws_log_writer *writer) {
-    assert(writer->vtable->cleanup);
-    return (writer->vtable->cleanup)(writer);
+void aws_log_writer_clean_up(struct aws_log_writer *writer) {
+    assert(writer->vtable->clean_up);
+    (writer->vtable->clean_up)(writer);
 }

--- a/source/log_writer.c
+++ b/source/log_writer.c
@@ -36,7 +36,7 @@ struct aws_file_writer {
     bool close_file_on_cleanup;
 };
 
-static int s_aws_file_writer_write_fn(struct aws_log_writer *writer, const struct aws_string *output) {
+static int s_aws_file_writer_write(struct aws_log_writer *writer, const struct aws_string *output) {
     struct aws_file_writer *impl = (struct aws_file_writer *)writer->impl;
 
     size_t length = output->len;
@@ -47,7 +47,7 @@ static int s_aws_file_writer_write_fn(struct aws_log_writer *writer, const struc
     return AWS_OP_SUCCESS;
 }
 
-static void s_aws_file_writer_clean_up_fn(struct aws_log_writer *writer) {
+static void s_aws_file_writer_clean_up(struct aws_log_writer *writer) {
     struct aws_file_writer *impl = (struct aws_file_writer *)writer->impl;
 
     if (impl->close_file_on_cleanup) {
@@ -57,8 +57,8 @@ static void s_aws_file_writer_clean_up_fn(struct aws_log_writer *writer) {
     aws_mem_release(writer->allocator, impl);
 }
 
-static struct aws_log_writer_vtable s_aws_file_writer_vtable = {.write = s_aws_file_writer_write_fn,
-                                                                .clean_up = s_aws_file_writer_clean_up_fn};
+static struct aws_log_writer_vtable s_aws_file_writer_vtable = {.write = s_aws_file_writer_write,
+                                                                .clean_up = s_aws_file_writer_clean_up};
 
 /*
  * Shared internal init implementation

--- a/source/log_writer.c
+++ b/source/log_writer.c
@@ -70,7 +70,7 @@ static int s_aws_file_writer_init_internal(
     FILE *currently_open_file) {
 
     /* One or the other should be set */
-    if (!(file_name_to_open != NULL ^ currently_open_file != NULL)) {
+    if (!((file_name_to_open != NULL) ^ (currently_open_file != NULL))) {
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 

--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -178,8 +178,8 @@ int aws_tls_ctx_options_init_server_pkcs12_from_path(
     struct aws_tls_ctx_options *options,
     struct aws_allocator *allocator,
     const char *pkcs12_path,
-    struct aws_byte_cursor *pkcs_pwd) {
-    if (aws_tls_ctx_options_init_client_mtls_pkcs12_from_path(options, allocator, pkcs12_path, pkcs_pwd)) {
+    struct aws_byte_cursor *pkcs_password) {
+    if (aws_tls_ctx_options_init_client_mtls_pkcs12_from_path(options, allocator, pkcs12_path, pkcs_password)) {
         return AWS_OP_ERR;
     }
 
@@ -191,8 +191,8 @@ int aws_tls_ctx_options_init_server_pkcs12(
     struct aws_tls_ctx_options *options,
     struct aws_allocator *allocator,
     struct aws_byte_cursor *pkcs12,
-    struct aws_byte_cursor *pkcs_pwd) {
-    if (aws_tls_ctx_options_init_client_mtls_pkcs12(options, allocator, pkcs12, pkcs_pwd)) {
+    struct aws_byte_cursor *pkcs_password) {
+    if (aws_tls_ctx_options_init_client_mtls_pkcs12(options, allocator, pkcs12, pkcs_password)) {
         return AWS_OP_ERR;
     }
 

--- a/tests/logging/log_channel_test.c
+++ b/tests/logging/log_channel_test.c
@@ -35,7 +35,7 @@ struct mock_log_writer_impl {
     struct aws_array_list log_lines;
 };
 
-static int s_mock_log_writer_write_fn(struct aws_log_writer *writer, const struct aws_string *output) {
+static int s_mock_log_writer_write(struct aws_log_writer *writer, const struct aws_string *output) {
     struct mock_log_writer_impl *impl = (struct mock_log_writer_impl *)writer->impl;
 
     struct aws_string *output_copy = aws_string_new_from_string(writer->allocator, output);
@@ -48,7 +48,7 @@ static int s_mock_log_writer_write_fn(struct aws_log_writer *writer, const struc
     return AWS_OP_SUCCESS;
 }
 
-static void s_mock_log_writer_clean_up_fn(struct aws_log_writer *writer) {
+static void s_mock_log_writer_clean_up(struct aws_log_writer *writer) {
     struct mock_log_writer_impl *impl = (struct mock_log_writer_impl *)writer->impl;
 
     size_t line_count = aws_array_list_length(&impl->log_lines);
@@ -66,8 +66,8 @@ static void s_mock_log_writer_clean_up_fn(struct aws_log_writer *writer) {
     aws_mem_release(writer->allocator, impl);
 }
 
-static struct aws_log_writer_vtable s_mock_writer_vtable = {.write = s_mock_log_writer_write_fn,
-                                                            .clean_up = s_mock_log_writer_clean_up_fn};
+static struct aws_log_writer_vtable s_mock_writer_vtable = {.write = s_mock_log_writer_write,
+                                                            .clean_up = s_mock_log_writer_clean_up};
 
 static int s_aws_mock_log_writer_init(struct aws_log_writer *writer, struct aws_allocator *allocator) {
     struct mock_log_writer_impl *impl =
@@ -180,7 +180,7 @@ static int s_do_channel_test(
 }
 
 #define DEFINE_FOREGROUND_LOG_CHANNEL_TEST(test_name, string_array_name)                                               \
-    static int s_foreground_log_channel_##test_name##_fn(struct aws_allocator *allocator, void *ctx) {                 \
+    static int s_foreground_log_channel_##test_name(struct aws_allocator *allocator, void *ctx) {                      \
         (void)ctx;                                                                                                     \
         return s_do_channel_test(                                                                                      \
             allocator,                                                                                                 \
@@ -189,10 +189,10 @@ static int s_do_channel_test(
             sizeof(string_array_name) / sizeof(struct aws_string **),                                                  \
             NULL);                                                                                                     \
     }                                                                                                                  \
-    AWS_TEST_CASE(test_foreground_log_channel_##test_name, s_foreground_log_channel_##test_name##_fn);
+    AWS_TEST_CASE(test_foreground_log_channel_##test_name, s_foreground_log_channel_##test_name);
 
 #define DEFINE_BACKGROUND_LOG_CHANNEL_TEST(test_name, string_array_name, sleep_times)                                  \
-    static int s_background_log_channel_##test_name##_fn(struct aws_allocator *allocator, void *ctx) {                 \
+    static int s_background_log_channel_##test_name(struct aws_allocator *allocator, void *ctx) {                      \
         (void)ctx;                                                                                                     \
         return s_do_channel_test(                                                                                      \
             allocator,                                                                                                 \
@@ -201,7 +201,7 @@ static int s_do_channel_test(
             sizeof(string_array_name) / sizeof(struct aws_string **),                                                  \
             sleep_times);                                                                                              \
     }                                                                                                                  \
-    AWS_TEST_CASE(test_background_log_channel_##test_name, s_background_log_channel_##test_name##_fn);
+    AWS_TEST_CASE(test_background_log_channel_##test_name, s_background_log_channel_##test_name);
 
 /*
  * Test data
@@ -221,13 +221,15 @@ const struct aws_string **s_channel_test_numbers[] = {&s_log_line_1, &s_log_line
 
 const struct aws_string **s_channel_test_words[] = {&s_log_line_simple, &s_log_line_multiline, &s_log_line_fake};
 
-const struct aws_string **s_channel_test_all[] = {&s_log_line_1,
-                                                  &s_log_line_2,
-                                                  &s_log_line_3,
-                                                  &s_log_line_4,
-                                                  &s_log_line_simple,
-                                                  &s_log_line_multiline,
-                                                  &s_log_line_fake};
+const struct aws_string **s_channel_test_all[] = {
+    &s_log_line_1,
+    &s_log_line_2,
+    &s_log_line_3,
+    &s_log_line_4,
+    &s_log_line_simple,
+    &s_log_line_multiline,
+    &s_log_line_fake,
+};
 
 static int s_background_sleep_times_ns[] = {0, 100000, 0, 0, 1000000, 0, 1000000};
 

--- a/tests/logging/log_channel_test.c
+++ b/tests/logging/log_channel_test.c
@@ -48,7 +48,7 @@ static int s_mock_log_writer_write_fn(struct aws_log_writer *writer, const struc
     return AWS_OP_SUCCESS;
 }
 
-static int s_mock_log_writer_cleanup_fn(struct aws_log_writer *writer) {
+static void s_mock_log_writer_clean_up_fn(struct aws_log_writer *writer) {
     struct mock_log_writer_impl *impl = (struct mock_log_writer_impl *)writer->impl;
 
     size_t line_count = aws_array_list_length(&impl->log_lines);
@@ -64,12 +64,10 @@ static int s_mock_log_writer_cleanup_fn(struct aws_log_writer *writer) {
     aws_array_list_clean_up(&impl->log_lines);
 
     aws_mem_release(writer->allocator, impl);
-
-    return AWS_OP_SUCCESS;
 }
 
 static struct aws_log_writer_vtable s_mock_writer_vtable = {.write = s_mock_log_writer_write_fn,
-                                                            .cleanup = s_mock_log_writer_cleanup_fn};
+                                                            .clean_up = s_mock_log_writer_clean_up_fn};
 
 static int s_aws_mock_log_writer_init(struct aws_log_writer *writer, struct aws_allocator *allocator) {
     struct mock_log_writer_impl *impl =
@@ -170,13 +168,13 @@ static int s_do_channel_test(
         }
     }
 
-    aws_log_channel_cleanup(&log_channel);
+    aws_log_channel_clean_up(&log_channel);
 
     if (!s_verify_mock_equal(log_channel.writer, test_lines, test_lines_length)) {
         result = AWS_OP_ERR;
     }
 
-    aws_log_writer_cleanup(&mock_writer);
+    aws_log_writer_clean_up(&mock_writer);
 
     return result;
 }

--- a/tests/logging/log_formatter_test.c
+++ b/tests/logging/log_formatter_test.c
@@ -24,11 +24,11 @@
 
 #define TEST_FORMATTER_MAX_BUFFER_SIZE 4096
 
-typedef int (*log_formatter_test_fn)(struct aws_log_formatter *formatter, struct aws_string **output);
+typedef int(log_formatter_test_fn)(struct aws_log_formatter *formatter, struct aws_string **output);
 
 int do_default_log_formatter_test(
     struct aws_allocator *allocator,
-    log_formatter_test_fn test_fn,
+    log_formatter_test_fn *test_fn,
     const char *expected_user_output,
     enum aws_log_level log_level,
     enum aws_date_format date_format) {
@@ -150,11 +150,11 @@ int do_default_log_formatter_test(
 }
 
 #define DEFINE_LOG_FORMATTER_TEST(test_function, log_level, date_format, expected_user_string)                         \
-    static int s_log_formatter_##test_function##_fn(struct aws_allocator *allocator, void *ctx) {                      \
+    static int s_log_formatter_##test_function(struct aws_allocator *allocator, void *ctx) {                           \
         (void)ctx;                                                                                                     \
         return do_default_log_formatter_test(allocator, test_function, expected_user_string, log_level, date_format);  \
     }                                                                                                                  \
-    AWS_TEST_CASE(test_log_formatter_##test_function, s_log_formatter_##test_function##_fn);
+    AWS_TEST_CASE(test_log_formatter_##test_function, s_log_formatter_##test_function);
 
 static int invoke_formatter(
     struct aws_log_formatter *formatter,

--- a/tests/logging/log_formatter_test.c
+++ b/tests/logging/log_formatter_test.c
@@ -45,7 +45,7 @@ int do_default_log_formatter_test(
     struct aws_string *output = NULL;
     int result = (*test_fn)(&formatter, &output);
 
-    aws_log_formatter_cleanup(&formatter);
+    aws_log_formatter_clean_up(&formatter);
 
     char buffer[TEST_FORMATTER_MAX_BUFFER_SIZE];
     snprintf(buffer, TEST_FORMATTER_MAX_BUFFER_SIZE, "%s", (const char *)output->bytes);

--- a/tests/logging/log_writer_test.c
+++ b/tests/logging/log_writer_test.c
@@ -112,7 +112,7 @@ AWS_STATIC_STRING_FROM_LITERAL(s_simple_file_content, SIMPLE_FILE_CONTENT);
 /*
  * Simple file test
  */
-static int s_log_writer_simple_file_test_fn(struct aws_allocator *allocator, void *ctx) {
+static int s_log_writer_simple_file_test(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
     remove(s_test_file_name);
@@ -124,12 +124,12 @@ static int s_log_writer_simple_file_test_fn(struct aws_allocator *allocator, voi
 
     return do_default_log_writer_test(&writer, SIMPLE_FILE_CONTENT, s_simple_file_content, NULL);
 }
-AWS_TEST_CASE(test_log_writer_simple_file_test, s_log_writer_simple_file_test_fn);
+AWS_TEST_CASE(test_log_writer_simple_file_test, s_log_writer_simple_file_test);
 
 /*
  * Existing file test (verifies append is being used)
  */
-static int s_log_writer_existing_file_test_fn(struct aws_allocator *allocator, void *ctx) {
+static int s_log_writer_existing_file_test(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
     remove(s_test_file_name);
@@ -144,12 +144,12 @@ static int s_log_writer_existing_file_test_fn(struct aws_allocator *allocator, v
 
     return do_default_log_writer_test(&writer, s_combined_text, s_simple_file_content, NULL);
 }
-AWS_TEST_CASE(test_log_writer_existing_file_test, s_log_writer_existing_file_test_fn);
+AWS_TEST_CASE(test_log_writer_existing_file_test, s_log_writer_existing_file_test);
 
 /*
  * (Error case) Bad filename test
  */
-static int s_log_writer_bad_file_test_fn(struct aws_allocator *allocator, void *ctx) {
+static int s_log_writer_bad_file_test(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
     struct aws_log_writer_file_options options = {.filename = "."};
@@ -168,4 +168,4 @@ static int s_log_writer_bad_file_test_fn(struct aws_allocator *allocator, void *
 
     return AWS_OP_SUCCESS;
 }
-AWS_TEST_CASE(test_log_writer_bad_file_test, s_log_writer_bad_file_test_fn);
+AWS_TEST_CASE(test_log_writer_bad_file_test, s_log_writer_bad_file_test);

--- a/tests/logging/log_writer_test.c
+++ b/tests/logging/log_writer_test.c
@@ -49,7 +49,7 @@ int do_default_log_writer_test(
 
     int result = writer->vtable->write(writer, output);
 
-    aws_log_writer_cleanup(writer);
+    aws_log_writer_clean_up(writer);
 
     /*
      * When we redirect stdout/stderr to a file, we need to close the file manually since the writer implementations do

--- a/tests/logging/logging_test_utilities.c
+++ b/tests/logging/logging_test_utilities.c
@@ -37,7 +37,7 @@ int do_log_test(
 
     /* clean up */
     aws_logger_set(NULL);
-    aws_logger_cleanup(&test_logger);
+    aws_logger_clean_up(&test_logger);
 
     /* Check the test results last */
     ASSERT_SUCCESS(strcmp(buffer, expected_result), "Expected \"%s\" but received \"%s\"", expected_result, buffer);

--- a/tests/logging/logging_test_utilities.h
+++ b/tests/logging/logging_test_utilities.h
@@ -38,11 +38,11 @@ int do_log_test(
  * A macro capable of defining simple logging tests that follow the do_log_test function pattern
  */
 #define TEST_LEVEL_FILTER(log_level, expected, action_fn)                                                              \
-    static int s_logging_filter_at_##log_level##_##action_fn##_fn(struct aws_allocator *allocator, void *ctx) {        \
+    static int s_logging_filter_at_##log_level##_##action_fn(struct aws_allocator *allocator, void *ctx) {             \
         (void)ctx;                                                                                                     \
         return do_log_test(allocator, log_level, expected, action_fn);                                                 \
     }                                                                                                                  \
-    AWS_TEST_CASE(test_logging_filter_at_##log_level##_##action_fn, s_logging_filter_at_##log_level##_##action_fn##_fn);
+    AWS_TEST_CASE(test_logging_filter_at_##log_level##_##action_fn, s_logging_filter_at_##log_level##_##action_fn);
 
 /**
  * A macro that defines a function that invokes all 6 LOGF_<level> variants

--- a/tests/logging/pipeline_logger_test.c
+++ b/tests/logging/pipeline_logger_test.c
@@ -33,11 +33,11 @@ static const char *s_test_file_name =
     "./aws_log_writer_test.log";
 #endif
 
-typedef void (*log_test_fn)(void);
+typedef void(log_test_fn)(void);
 
 int do_pipeline_logger_test(
     struct aws_allocator *allocator,
-    log_test_fn log_fn,
+    log_test_fn *log_fn,
     const char **expected_user_content,
     size_t user_content_count) {
 
@@ -122,7 +122,7 @@ static const char *expected_test_user_content[] =
     {"trace log call", "debug log call", "info log call", "warn log call", "error log call", "fatal log call"};
 
 #define DEFINE_PIPELINE_LOGGER_TEST(test_name, callback_function)                                                      \
-    static int s_pipeline_logger_##test_name##_fn(struct aws_allocator *allocator, void *ctx) {                        \
+    static int s_pipeline_logger_##test_name(struct aws_allocator *allocator, void *ctx) {                             \
         (void)ctx;                                                                                                     \
         return do_pipeline_logger_test(                                                                                \
             allocator,                                                                                                 \
@@ -130,7 +130,7 @@ static const char *expected_test_user_content[] =
             expected_test_user_content,                                                                                \
             sizeof(expected_test_user_content) / sizeof(expected_test_user_content[0]));                               \
     }                                                                                                                  \
-    AWS_TEST_CASE(test_pipeline_logger_##test_name, s_pipeline_logger_##test_name##_fn);
+    AWS_TEST_CASE(test_pipeline_logger_##test_name, s_pipeline_logger_##test_name);
 
 DEFINE_PIPELINE_LOGGER_TEST(unformatted_test, s_unformatted_pipeline_logger_test_callback)
 DEFINE_PIPELINE_LOGGER_TEST(formatted_test, s_formatted_pipeline_logger_test_callback)

--- a/tests/logging/pipeline_logger_test.c
+++ b/tests/logging/pipeline_logger_test.c
@@ -56,7 +56,7 @@ int do_pipeline_logger_test(
 
     aws_logger_set(NULL);
 
-    aws_logger_cleanup(&logger);
+    aws_logger_clean_up(&logger);
 
     char buffer[TEST_PIPELINE_MAX_BUFFER_SIZE];
     FILE *file = fopen(s_test_file_name, "r");

--- a/tests/logging/test_logger.c
+++ b/tests/logging/test_logger.c
@@ -68,20 +68,18 @@ enum aws_log_level s_test_logger_get_log_level_fn(struct aws_logger *logger, aws
     return impl->level;
 }
 
-int s_test_logger_cleanup(struct aws_logger *logger) {
+void s_test_logger_clean_up(struct aws_logger *logger) {
     struct test_logger_impl *impl = (struct test_logger_impl *)logger->p_impl;
 
     aws_byte_buf_clean_up(&impl->log_buffer);
 
     struct aws_allocator *allocator = logger->allocator;
     aws_mem_release(allocator, impl);
-
-    return AWS_OP_SUCCESS;
 }
 
 static struct aws_logger_vtable s_test_logger_vtable = {.get_log_level = s_test_logger_get_log_level_fn,
                                                         .log = s_test_logger_log_fn,
-                                                        .cleanup = s_test_logger_cleanup};
+                                                        .clean_up = s_test_logger_clean_up};
 
 int test_logger_init(struct aws_logger *logger, struct aws_allocator *allocator, enum aws_log_level level) {
 

--- a/tests/logging/test_logger.c
+++ b/tests/logging/test_logger.c
@@ -25,7 +25,7 @@
  */
 #define TEST_LOGGER_MAX_LOG_LINE_SIZE 256
 
-int s_test_logger_log_fn(
+int s_test_logger_log(
     struct aws_logger *logger,
     enum aws_log_level log_level,
     aws_log_subject_t subject,
@@ -60,7 +60,7 @@ int s_test_logger_log_fn(
     return AWS_OP_SUCCESS;
 }
 
-enum aws_log_level s_test_logger_get_log_level_fn(struct aws_logger *logger, aws_log_subject_t subject) {
+enum aws_log_level s_test_logger_get_log_level(struct aws_logger *logger, aws_log_subject_t subject) {
     (void)subject;
 
     struct test_logger_impl *impl = (struct test_logger_impl *)logger->p_impl;
@@ -77,8 +77,8 @@ void s_test_logger_clean_up(struct aws_logger *logger) {
     aws_mem_release(allocator, impl);
 }
 
-static struct aws_logger_vtable s_test_logger_vtable = {.get_log_level = s_test_logger_get_log_level_fn,
-                                                        .log = s_test_logger_log_fn,
+static struct aws_logger_vtable s_test_logger_vtable = {.get_log_level = s_test_logger_get_log_level,
+                                                        .log = s_test_logger_log,
                                                         .clean_up = s_test_logger_clean_up};
 
 int test_logger_init(struct aws_logger *logger, struct aws_allocator *allocator, enum aws_log_level level) {


### PR DESCRIPTION
- aws_register_log_subject_info_list() made public.
- aws_logger_init_standard() works with stderr & stdout.
- rename "cleanup" functions to "clean_up" (style guide).
- clean_up functions are now void.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
