### PR TITLE
Add support for overriding uv.h location

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -10,6 +10,6 @@ CheckOptions:
   - key:             google-runtime-int.TypeSufix
     value:           '_t'
   - key:             fuchsia-restrict-system-includes.Includes
-    value:           '*,-stdint.h,-stdbool.h'
+    value:           '*,-stdint.h,-stdbool.h,-uv.h'
 
 ...

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,10 @@ file(GLOB AWS_IO_HEADERS
         "include/aws/io/*.h"
         )
 
+file(GLOB AWS_IO_UV_HEADERS
+        "include/aws/io/uv/*.h"
+        )
+
 file(GLOB AWS_IO_TESTING_HEADERS
         "include/aws/testing/*.h"
         )
@@ -192,6 +196,12 @@ if (USE_LIBUV)
     if (UV_LINK_LIBRARY)
         target_link_libraries(${CMAKE_PROJECT_NAME} PUBLIC ${LIBUV_LIBRARY})
     endif ()
+
+    # Allow specific overriding of uv.h location
+    if (UV_HEADER_PATH)
+        message(STATUS "Using uv.h location: ${UV_HEADER_PATH}")
+        target_compile_definitions(${CMAKE_PROJECT_NAME} PUBLIC "UV_HEADER_PATH=${UV_HEADER_PATH}")
+    endif ()
 endif ()
 
 if (BUILD_JNI_BINDINGS)
@@ -217,6 +227,9 @@ aws_prepare_shared_lib_exports(${CMAKE_PROJECT_NAME})
 
 install(FILES ${AWS_IO_HEADERS} DESTINATION "include/aws/io" COMPONENT Development)
 install(FILES ${AWS_IO_TESTING_HEADERS} DESTINATION "include/aws/testing" COMPONENT Development)
+if (USE_LIBUV)
+    install(FILES ${AWS_IO_UV_HEADERS} DESTINATION "include/aws/io/uv" COMPONENT Development)
+endif ()
 
 install(EXPORT "${CMAKE_PROJECT_NAME}-targets"
         DESTINATION "${LIBRARY_DIRECTORY}/${CMAKE_PROJECT_NAME}/cmake/"

--- a/include/aws/io/uv/uv_include.h
+++ b/include/aws/io/uv/uv_include.h
@@ -16,7 +16,10 @@
  * permissions and limitations under the License.
  */
 
-/* This file exists to support the UV_HEADER_PATH macro */
+/**
+ * This file exists to support the UV_HEADER_PATH macro, which
+ * may be defined by CMake when building against things that bundle libuv (ie. nodejs).
+ */
 
 /* Default, just search the include paths */
 #ifndef UV_HEADER_PATH

--- a/include/aws/io/uv/uv_include.h
+++ b/include/aws/io/uv/uv_include.h
@@ -1,0 +1,30 @@
+#ifndef AWS_IO_UV_UV_INCLUDE
+#define AWS_IO_UV_UV_INCLUDE
+
+/*
+ * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/* This file exists to support the UV_HEADER_PATH macro */
+
+/* Default, just search the include paths */
+#ifndef UV_HEADER_PATH
+#    define UV_HEADER_PATH uv.h
+#endif
+
+#define UV_HEADER_PATH_2 <UV_HEADER_PATH>
+/* NOLINTNEXTLINE(fuchsia-restrict-system-includes) */
+#include UV_HEADER_PATH_2
+
+#endif /* AWS_IO_UV_UV_INCLUDE */

--- a/source/host_resolver.c
+++ b/source/host_resolver.c
@@ -832,7 +832,7 @@ int aws_host_resolver_init_default(
 
 #ifdef AWS_USE_LIBUV
 
-#    include <uv.h>
+#    include <aws/io/uv/uv_include.h>
 
 struct uv_host_resolver {
     /* This needs to be the first element in the struct so the pointers are safely castable.

--- a/source/libuv/uv_event_loop.c
+++ b/source/libuv/uv_event_loop.c
@@ -20,8 +20,9 @@
 #include <aws/common/task_scheduler.h>
 #include <aws/common/thread.h>
 
+#include <aws/io/uv/uv_include.h>
+
 #include <poll.h>
-#include <uv.h>
 
 #if defined(AWS_USE_EPOLL)
 #    include <sys/epoll.h>


### PR DESCRIPTION
This is important if building for nodejs, to ensure that the version being included matches the version in node.

Also adds a clang-tidy rule that disallows including uv.h directly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
