### PR TITLE
Better pki path default

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,7 +80,7 @@ if (WIN32)
     #platform libs come from aws-c-common transitively, so we don't specify them here, but for documentation purposes,
     #Kernel32 and wsock2 are pulled in automatically. Here we add the lib containing the schannel API.
     #Also note, you don't get a choice on TLS implementation for Windows.
-    set(PLATFORM_LIBS Secur32 Crypt32)
+    set(PLATFORM_LIBS Secur32 Crypt32 Shlwapi)
     set(TLS_STACK_DETERMINED ON)
 
 elseif (CMAKE_SYSTEM_NAME STREQUAL "Linux")

--- a/include/aws/io/exports.h
+++ b/include/aws/io/exports.h
@@ -25,7 +25,7 @@
 #        endif /* AWS_IO_EXPORTS */
 #    else
 #        define AWS_IO_API
-#    endif // USE_IMPORT_EXPORT
+#    endif /* USE_IMPORT_EXPORT */
 
 #else
 #    if ((__GNUC__ >= 4) || defined(__clang__)) && defined(AWS_IO_USE_IMPORT_EXPORT) && defined(AWS_IO_EXPORTS)

--- a/include/aws/io/file_utils.h
+++ b/include/aws/io/file_utils.h
@@ -69,4 +69,4 @@ bool aws_path_exists(const char *path);
 
 AWS_EXTERN_C_END
 
-#endif // AWS_IO_FILE_UTILS_H
+#endif /* AWS_IO_FILE_UTILS_H */

--- a/include/aws/io/file_utils.h
+++ b/include/aws/io/file_utils.h
@@ -65,7 +65,7 @@ struct aws_string *aws_get_home_directory(struct aws_allocator *allocator);
  * Returns true if a file or path exists, otherwise, false.
  */
 AWS_IO_API
-bool aws_does_path_exist(const char *path);
+bool aws_path_exists(const char *path);
 
 AWS_EXTERN_C_END
 

--- a/include/aws/io/file_utils.h
+++ b/include/aws/io/file_utils.h
@@ -61,6 +61,12 @@ char aws_get_platform_directory_separator(void);
 AWS_IO_API
 struct aws_string *aws_get_home_directory(struct aws_allocator *allocator);
 
+/**
+ * Returns true if a file or path exists, otherwise, false.
+ */
+AWS_IO_API
+bool aws_does_path_exist(const char *path);
+
 AWS_EXTERN_C_END
 
 #endif // AWS_IO_FILE_UTILS_H

--- a/source/log_formatter.c
+++ b/source/log_formatter.c
@@ -30,14 +30,14 @@
 #    pragma warning(disable : 4204) /* non-constant aggregate initializer */
 #endif
 
-// (max) strlen of "[<LogLevel>]"
+/* (max) strlen of "[<LogLevel>]" */
 #define LOG_LEVEL_PREFIX_PADDING 7
 
-// (max) strlen of "[<ThreadId>]"
+/* (max) strlen of "[<ThreadId>]" */
 #define THREAD_ID_PREFIX_PADDING 22
 
-// strlen of (user-content separator) " - " + "\n" + spaces between prefix fields + brackets around timestamp + 1 +
-// subject_name padding
+/* strlen of (user-content separator) " - " + "\n" + spaces between prefix fields + brackets around timestamp + 1 +
+   subject_name padding */
 #define MISC_PADDING 15
 
 #define MAX_LOG_LINE_PREFIX_SIZE                                                                                       \
@@ -169,7 +169,7 @@ static int s_default_aws_log_formatter_format(
         vsnprintf_s(log_line_buffer + current_index, total_length - current_index, _TRUNCATE, format, args);
 #else
     int written_count = vsnprintf(log_line_buffer + current_index, total_length - current_index, format, args);
-#endif // WIN32
+#endif /* WIN32 */
     if (written_count < 0) {
         goto error_clean_up;
     }

--- a/source/posix/file_utils.c
+++ b/source/posix/file_utils.c
@@ -18,6 +18,9 @@
 #include <aws/common/environment.h>
 #include <aws/common/string.h>
 
+#include <sys/stat.h>
+#include <unistd.h>
+
 char aws_get_platform_directory_separator(void) {
     return '/';
 }
@@ -33,4 +36,9 @@ struct aws_string *aws_get_home_directory(struct aws_allocator *allocator) {
     }
 
     return NULL;
+}
+
+bool aws_does_path_exist(const char *path) {
+    struct stat buffer;
+    return stat (path, &buffer) == 0;
 }

--- a/source/posix/file_utils.c
+++ b/source/posix/file_utils.c
@@ -40,5 +40,5 @@ struct aws_string *aws_get_home_directory(struct aws_allocator *allocator) {
 
 bool aws_does_path_exist(const char *path) {
     struct stat buffer;
-    return stat (path, &buffer) == 0;
+    return stat(path, &buffer) == 0;
 }

--- a/source/posix/file_utils.c
+++ b/source/posix/file_utils.c
@@ -38,7 +38,7 @@ struct aws_string *aws_get_home_directory(struct aws_allocator *allocator) {
     return NULL;
 }
 
-bool aws_does_path_exist(const char *path) {
+bool aws_path_exists(const char *path) {
     struct stat buffer;
     return stat(path, &buffer) == 0;
 }

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -772,7 +772,7 @@ static const char *s_determine_default_pki_dir(void) {
 
     /* android */
     if (aws_does_path_exist("/system/etc/security/cacerts")) {
-        return "/system/etc/security/cacerts"
+        return "/system/etc/security/cacerts";
     }
 
     /* Free BSD */
@@ -801,7 +801,7 @@ static const char *s_determine_default_pki_ca_file(void) {
 
     /* Open SUSE */
     if (aws_does_path_exist("/etc/ssl/ca-bundle.pem")) {
-        return "/etc/ssl/ca-bundle.pem"
+        return "/etc/ssl/ca-bundle.pem";
     }
 
     /* Open ELEC */

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -36,6 +36,9 @@
 #define MAX_RECORD_SIZE (KB_1 * 16)
 #define EST_HANDSHAKE_SIZE (7 * KB_1)
 
+static const char *s_default_ca_dir = NULL;
+static const char *s_default_ca_file = NULL;
+
 /* this is completely absurd and the reason I hate dependencies, but I'm assuming
  * you don't want your older versions of openssl's libcrypto crashing on you. */
 #if defined(LIBRESSL_VERSION_NUMBER) && (OPENSSL_VERSION_NUMBER == 0x20000000L)
@@ -50,8 +53,6 @@
 
 static struct aws_mutex *s_libcrypto_locks = NULL;
 static struct aws_allocator *s_libcrypto_allocator = NULL;
-static const char *s_default_ca_dir = NULL;
-static const char *s_default_ca_file = NULL;
 
 static void s_locking_fn(int mode, int n, const char *unused0, int unused1) {
     (void)unused0;

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -95,27 +95,27 @@ struct s2n_ctx {
 
 static const char *s_determine_default_pki_dir(void) {
     /* debian variants */
-    if (aws_does_path_exist("/etc/ssl/certs")) {
+    if (aws_path_exists("/etc/ssl/certs")) {
         return "/etc/ssl/certs";
     }
 
     /* RHEL variants */
-    if (aws_does_path_exist("/etc/pki/tls/certs")) {
+    if (aws_path_exists("/etc/pki/tls/certs")) {
         return "/etc/pki/tls/certs";
     }
 
     /* android */
-    if (aws_does_path_exist("/system/etc/security/cacerts")) {
+    if (aws_path_exists("/system/etc/security/cacerts")) {
         return "/system/etc/security/cacerts";
     }
 
     /* Free BSD */
-    if (aws_does_path_exist("/usr/local/share/certs")) {
+    if (aws_path_exists("/usr/local/share/certs")) {
         return "/usr/local/share/certs";
     }
 
     /* Net BSD */
-    if (aws_does_path_exist("/etc/openssl/certs")) {
+    if (aws_path_exists("/etc/openssl/certs")) {
         return "/etc/openssl/certs";
     }
 
@@ -124,27 +124,27 @@ static const char *s_determine_default_pki_dir(void) {
 
 static const char *s_determine_default_pki_ca_file(void) {
     /* debian variants */
-    if (aws_does_path_exist("/etc/ssl/certs/ca-certificates.crt")) {
+    if (aws_path_exists("/etc/ssl/certs/ca-certificates.crt")) {
         return "/etc/ssl/certs/ca-certificates.crt";
     }
 
     /* Old RHEL variants */
-    if (aws_does_path_exist("/etc/pki/tls/certs/ca-bundle.crt")) {
+    if (aws_path_exists("/etc/pki/tls/certs/ca-bundle.crt")) {
         return "/etc/pki/tls/certs/ca-bundle.crt";
     }
 
     /* Open SUSE */
-    if (aws_does_path_exist("/etc/ssl/ca-bundle.pem")) {
+    if (aws_path_exists("/etc/ssl/ca-bundle.pem")) {
         return "/etc/ssl/ca-bundle.pem";
     }
 
     /* Open ELEC */
-    if (aws_does_path_exist("/etc/pki/tls/cacert.pem")) {
+    if (aws_path_exists("/etc/pki/tls/cacert.pem")) {
         return "/etc/pki/tls/cacert.pem";
     }
 
     /* Modern RHEL variants */
-    if (aws_does_path_exist("/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem")) {
+    if (aws_path_exists("/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem")) {
         return "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem";
     }
 

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -781,7 +781,7 @@ static const char *s_determine_default_pki_dir(void) {
     }
 
     /* Net BSD */
-    if (aws_does_path_exist("/etc/openssl/certs") {
+    if (aws_does_path_exist("/etc/openssl/certs")) {
         return "/etc/openssl/certs";
     }
 
@@ -810,7 +810,7 @@ static const char *s_determine_default_pki_ca_file(void) {
     }
 
     /* Modern RHEL variants */
-    if (aws_does_path_exist("/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem") {
+    if (aws_does_path_exist("/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem")) {
         return "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem";
     }
 

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -917,7 +917,7 @@ static struct aws_tls_ctx *s_tls_ctx_new(
                 ca_file = s_default_ca_file;
             }
 
-            if (s2n_config_set_verification_ca_location(s2n_ctx->s2n_config, ca_file, ca_path)) {
+            if (s2n_config_set_verification_ca_location(s2n_ctx->s2n_config, ca_file, ca_dir)) {
                 AWS_LOGF_ERROR(AWS_LS_IO_TLS, "ctx: configuration error %s", s2n_strerror_debug(s2n_errno, "EN"));
                 aws_raise_error(AWS_IO_TLS_CTX_ERROR);
                 goto cleanup_s2n_config;

--- a/source/windows/file_utils.c
+++ b/source/windows/file_utils.c
@@ -18,6 +18,8 @@
 #include <aws/common/environment.h>
 #include <aws/common/string.h>
 
+#include <Shlwapi.h>
+
 char aws_get_platform_directory_separator(void) {
     return '\\';
 }
@@ -81,4 +83,8 @@ struct aws_string *aws_get_home_directory(struct aws_allocator *allocator) {
     }
 
     return NULL;
+}
+
+bool aws_does_path_exist(const char *path) {
+    return PathFileExistsA(path) == TRUE;
 }

--- a/source/windows/file_utils.c
+++ b/source/windows/file_utils.c
@@ -85,6 +85,6 @@ struct aws_string *aws_get_home_directory(struct aws_allocator *allocator) {
     return NULL;
 }
 
-bool aws_does_path_exist(const char *path) {
+bool aws_path_exists(const char *path) {
     return PathFileExistsA(path) == TRUE;
 }

--- a/tests/logging/log_writer_test.c
+++ b/tests/logging/log_writer_test.c
@@ -23,7 +23,7 @@
 
 #ifndef WIN32
 #    include <sys/file.h>
-#endif // WIN32
+#endif /* WIN32 */
 
 #ifdef _MSC_VER
 #    pragma warning(disable : 4996) /* Disable warnings about fopen() being insecure */

--- a/tests/logging/test_logger.c
+++ b/tests/logging/test_logger.c
@@ -43,7 +43,7 @@ int s_test_logger_log(
     int written = vsnprintf_s(buffer, TEST_LOGGER_MAX_LOG_LINE_SIZE, _TRUNCATE, format, format_args);
 #else
     int written = vsnprintf(buffer, TEST_LOGGER_MAX_LOG_LINE_SIZE, format, format_args);
-#endif // WIN32
+#endif /* WIN32 */
 
     va_end(format_args);
 

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -481,7 +481,6 @@ static int s_verify_negotiation_fails(struct aws_allocator *allocator, const str
 
     struct aws_tls_ctx_options client_ctx_options;
     aws_tls_ctx_options_init_default_client(&client_ctx_options, allocator);
-    aws_tls_ctx_options_override_default_trust_store_from_path(&client_ctx_options, "/etc/ssl/certs", NULL);
 
     struct aws_tls_ctx *client_ctx = aws_tls_client_ctx_new(allocator, &client_ctx_options);
 
@@ -650,7 +649,6 @@ static int s_verify_good_host(struct aws_allocator *allocator, const struct aws_
 
     struct aws_tls_ctx_options client_ctx_options;
     aws_tls_ctx_options_init_default_client(&client_ctx_options, allocator);
-    aws_tls_ctx_options_override_default_trust_store_from_path(&client_ctx_options, "/etc/ssl/certs", NULL);
     aws_tls_ctx_options_set_alpn_list(&client_ctx_options, "h2;http/1.1");
 
     struct aws_tls_ctx *client_ctx = aws_tls_client_ctx_new(allocator, &client_ctx_options);


### PR DESCRIPTION
We now handle PKI default paths, properly on unix systems, since if a custom libcrypto build is used, it cannot reliably find them on its own.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
