### PR TITLE
Host resolver is no longer owned by the channel bootstrap. Updates to…

### DIFF
--- a/include/aws/io/channel_bootstrap.h
+++ b/include/aws/io/channel_bootstrap.h
@@ -213,7 +213,7 @@ AWS_IO_API struct aws_server_bootstrap *aws_server_bootstrap_new(
  * calling this if you don't want a memory leak. Note that the memory will not be freed right away if there are
  * outstanding channels or channel events
  */
-AWS_IO_API void aws_server_bootstrap_destroy(struct aws_server_bootstrap *bootstrap);
+AWS_IO_API void aws_server_bootstrap_release(struct aws_server_bootstrap *bootstrap);
 
 /**
  * When using TLS, if ALPN is used, this callback will be invoked from the channel. The returned handler will be added

--- a/include/aws/io/channel_bootstrap.h
+++ b/include/aws/io/channel_bootstrap.h
@@ -77,7 +77,6 @@ struct aws_client_bootstrap {
     struct aws_host_resolver *host_resolver;
     struct aws_host_resolution_config host_resolver_config;
     aws_channel_on_protocol_negotiated_fn *on_protocol_negotiated;
-    bool owns_resolver;
     struct aws_atomic_var ref_count;
 };
 
@@ -135,9 +134,8 @@ AWS_EXTERN_C_BEGIN
 
 /**
  * Initializes the client bootstrap with `allocator` and `el_group`. This object manages client connections and
- * channels. If host_resolver is NULL, the default configuration will be used. Otherwise, the provided host_resolver
- * will be used for resolving host names. If host_resolution_config is NULL, the default will be used.
- * host_resolution_config will be copied.
+ * channels. host_resolver will be used for resolving host names.
+ * If host_resolution_config is NULL, the default will be used, host_resolution_config will be copied.
  */
 AWS_IO_API struct aws_client_bootstrap *aws_client_bootstrap_new(
     struct aws_allocator *allocator,
@@ -150,7 +148,7 @@ AWS_IO_API struct aws_client_bootstrap *aws_client_bootstrap_new(
  * calling this if you don't want a memory leak. Note that this will not necessarily free the memory immediately if
  * there are channels or channel events outstanding.
  */
-AWS_IO_API void aws_client_bootstrap_destroy(struct aws_client_bootstrap *bootstrap);
+AWS_IO_API void aws_client_bootstrap_release(struct aws_client_bootstrap *bootstrap);
 
 /**
  * When using TLS, if ALPN is used, this callback will be invoked from the channel. The returned handler will be added

--- a/include/aws/io/host_resolver.h
+++ b/include/aws/io/host_resolver.h
@@ -17,6 +17,8 @@
 
 #include <aws/io/io.h>
 
+struct aws_event_loop_group;
+
 typedef enum aws_address_record_type {
     /* ipv4 address. */
     AWS_ADDRESS_RECORD_TYPE_A,
@@ -159,7 +161,8 @@ AWS_IO_API int aws_default_dns_resolve(
 AWS_IO_API int aws_host_resolver_init_default(
     struct aws_host_resolver *resolver,
     struct aws_allocator *allocator,
-    size_t max_entries);
+    size_t max_entries,
+    struct aws_event_loop_group *el_group);
 
 #ifdef AWS_USE_LIBUV
 

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -144,7 +144,6 @@ struct aws_client_bootstrap *aws_client_bootstrap_new(
     }
 
     return bootstrap;
-    ;
 }
 
 int aws_client_bootstrap_set_alpn_callback(
@@ -818,7 +817,7 @@ struct aws_server_bootstrap *aws_server_bootstrap_new(
     return bootstrap;
 }
 
-void aws_server_bootstrap_destroy(struct aws_server_bootstrap *bootstrap) {
+void aws_server_bootstrap_release(struct aws_server_bootstrap *bootstrap) {
     /* if destroy is being called, the user intends to not use the bootstrap anymore
      * so we clean up the thread local state while the event loop thread is
      * still alive */

--- a/source/host_resolver.c
+++ b/source/host_resolver.c
@@ -408,12 +408,13 @@ static void resolver_thread_fn(void *arg) {
             struct aws_linked_list_node *resolution_callback_node = aws_linked_list_pop_front(&pending_resolve_copy);
             struct pending_callback *pending_callback =
                 AWS_CONTAINER_OF(resolution_callback_node, struct pending_callback, node);
+
             aws_rw_lock_wlock(&host_entry->entry_lock);
             struct aws_host_address *aaaa_address = aws_lru_cache_use_lru_element(&host_entry->aaaa_records);
             struct aws_host_address *a_address = aws_lru_cache_use_lru_element(&host_entry->a_records);
             aws_rw_lock_wunlock(&host_entry->entry_lock);
 
-            if (aaaa_address || a_address) {
+            if ((aaaa_address || a_address) && host_entry->keep_active) {
                 struct aws_host_address address_array[2];
                 AWS_ZERO_ARRAY(address_array);
                 struct aws_array_list callback_address_list;
@@ -446,6 +447,12 @@ static void resolver_thread_fn(void *arg) {
                     pending_callback->user_data);
                 aws_array_list_clean_up(&callback_address_list);
             } else {
+
+                if (!host_entry->keep_active && !err_code) {
+                    aws_raise_error(AWS_ERROR_IO_OPERATION_CANCELLED);
+                    err_code = AWS_ERROR_IO_OPERATION_CANCELLED;
+                }
+
                 pending_callback->callback(
                     host_entry->resolver, host_entry->host_name, err_code, NULL, pending_callback->user_data);
             }
@@ -489,9 +496,13 @@ static void on_host_value_removed(void *value) {
         aws_thread_clean_up(&host_entry->resolver_thread);
     }
 
+    if (!aws_linked_list_empty(&host_entry->pending_resolution_callbacks)) {
+        aws_raise_error(AWS_IO_DNS_HOST_REMOVED_FROM_CACHE);
+    }
+
     while (!aws_linked_list_empty(&host_entry->pending_resolution_callbacks)) {
         struct aws_linked_list_node *resolution_callback_node =
-            aws_linked_list_front(&host_entry->pending_resolution_callbacks);
+            aws_linked_list_pop_front(&host_entry->pending_resolution_callbacks);
         struct pending_callback *pending_callback =
             AWS_CONTAINER_OF(resolution_callback_node, struct pending_callback, node);
         pending_callback->callback(

--- a/source/host_resolver.c
+++ b/source/host_resolver.c
@@ -832,8 +832,14 @@ static struct aws_host_resolver_vtable s_vtable = {
 int aws_host_resolver_init_default(
     struct aws_host_resolver *resolver,
     struct aws_allocator *allocator,
-    size_t max_entries) {
+    size_t max_entries,
+    struct aws_event_loop_group *el_group) {
 
+    /* NOTE: we don't use el_group yet, but we will in the future. Also, we
+      don't want host resolvers getting cleaned up after el_groups; this will force that
+      in bindings, and encourage it in C land. */
+    (void)el_group;
+    assert(el_group);
     struct default_host_resolver *default_host_resolver =
         aws_mem_acquire(allocator, sizeof(struct default_host_resolver));
 

--- a/source/windows/iocp/iocp_event_loop.c
+++ b/source/windows/iocp/iocp_event_loop.c
@@ -343,7 +343,6 @@ static int s_run(struct aws_event_loop *event_loop) {
 
     /* If asserts hit, you must call stop() and wait_for_stop_completion() before calling run() again */
     assert(impl->thread_data.state == EVENT_THREAD_STATE_READY_TO_RUN);
-    assert(impl->synced_data.state == EVENT_THREAD_STATE_READY_TO_RUN);
 
     impl->synced_data.state = EVENT_THREAD_STATE_RUNNING;
 

--- a/tests/channel_test.c
+++ b/tests/channel_test.c
@@ -883,8 +883,11 @@ static int s_test_channel_connect_some_hosts_timeout(struct aws_allocator *alloc
     ASSERT_SUCCESS(aws_array_list_push_back(&address_list, &host_address_1_ipv4));
     ASSERT_SUCCESS(mock_dns_resolver_append_address_list(&mock_dns_resolver, &address_list));
 
+    struct aws_host_resolver resolver;
+    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 64));
+
     struct aws_client_bootstrap *bootstrap =
-        aws_client_bootstrap_new(allocator, &event_loop_group, NULL, &mock_resolver_config);
+        aws_client_bootstrap_new(allocator, &event_loop_group, &resolver, &mock_resolver_config);
     ASSERT_NOT_NULL(bootstrap);
 
     struct aws_socket_options options;
@@ -928,7 +931,8 @@ static int s_test_channel_connect_some_hosts_timeout(struct aws_allocator *alloc
 
     /* clean up */
     aws_host_address_clean_up(resolved_address);
-    aws_client_bootstrap_destroy(bootstrap);
+    aws_client_bootstrap_release(bootstrap);
+    aws_host_resolver_clean_up(&resolver);
     mock_dns_resolver_clean_up(&mock_dns_resolver);
     aws_event_loop_group_clean_up(&event_loop_group);
 

--- a/tests/channel_test.c
+++ b/tests/channel_test.c
@@ -884,7 +884,7 @@ static int s_test_channel_connect_some_hosts_timeout(struct aws_allocator *alloc
     ASSERT_SUCCESS(mock_dns_resolver_append_address_list(&mock_dns_resolver, &address_list));
 
     struct aws_host_resolver resolver;
-    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 64));
+    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 8, &event_loop_group));
 
     struct aws_client_bootstrap *bootstrap =
         aws_client_bootstrap_new(allocator, &event_loop_group, &resolver, &mock_resolver_config);

--- a/tests/default_host_resolver_test.c
+++ b/tests/default_host_resolver_test.c
@@ -16,7 +16,10 @@
 #include <aws/common/condition_variable.h>
 #include <aws/common/string.h>
 #include <aws/common/thread.h>
+
+#include <aws/io/event_loop.h>
 #include <aws/io/host_resolver.h>
+
 #include <aws/testing/aws_test_harness.h>
 
 #include "mock_dns_resolver.h"
@@ -86,7 +89,9 @@ static int s_test_default_with_ipv6_lookup_fn(struct aws_allocator *allocator, v
     (void)ctx;
     struct aws_host_resolver resolver;
 
-    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 10));
+    struct aws_event_loop_group el_group;
+    ASSERT_SUCCESS(aws_event_loop_group_default_init(&el_group, allocator, 1));
+    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 10, &el_group));
 
     const struct aws_string *host_name = aws_string_new_from_c_str(allocator, "s3.dualstack.us-east-1.amazonaws.com");
     ASSERT_NOT_NULL(host_name);
@@ -135,7 +140,7 @@ static int s_test_default_with_ipv6_lookup_fn(struct aws_allocator *allocator, v
     aws_host_address_clean_up(&callback_data.a_address);
     aws_string_destroy((void *)host_name);
     aws_host_resolver_clean_up(&resolver);
-
+    aws_event_loop_group_clean_up(&el_group);
     return 0;
 }
 
@@ -146,7 +151,9 @@ static int s_test_default_with_ipv4_only_lookup_fn(struct aws_allocator *allocat
     (void)ctx;
     struct aws_host_resolver resolver;
 
-    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 10));
+    struct aws_event_loop_group el_group;
+    ASSERT_SUCCESS(aws_event_loop_group_default_init(&el_group, allocator, 1));
+    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 10, &el_group));
 
     const struct aws_string *host_name = aws_string_new_from_c_str(allocator, "s3.us-east-1.amazonaws.com");
     ASSERT_NOT_NULL(host_name);
@@ -188,6 +195,7 @@ static int s_test_default_with_ipv4_only_lookup_fn(struct aws_allocator *allocat
     aws_host_address_clean_up(&callback_data.a_address);
     aws_string_destroy((void *)host_name);
     aws_host_resolver_clean_up(&resolver);
+    aws_event_loop_group_clean_up(&el_group);
 
     return 0;
 }
@@ -206,7 +214,9 @@ static int s_test_default_with_multiple_lookups_fn(struct aws_allocator *allocat
     (void)ctx;
     struct aws_host_resolver resolver;
 
-    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 10));
+    struct aws_event_loop_group el_group;
+    ASSERT_SUCCESS(aws_event_loop_group_default_init(&el_group, allocator, 1));
+    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 10, &el_group));
 
     const struct aws_string *host_name_1 = aws_string_new_from_c_str(allocator, "s3.dualstack.us-east-1.amazonaws.com");
     const struct aws_string *host_name_2 = aws_string_new_from_c_str(allocator, "s3.us-east-1.amazonaws.com");
@@ -290,6 +300,7 @@ static int s_test_default_with_multiple_lookups_fn(struct aws_allocator *allocat
     aws_string_destroy((void *)host_name_1);
     aws_string_destroy((void *)host_name_2);
     aws_host_resolver_clean_up(&resolver);
+    aws_event_loop_group_clean_up(&el_group);
 
     return 0;
 }
@@ -300,8 +311,9 @@ static int s_test_resolver_ttls_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
     struct aws_host_resolver resolver;
 
-    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 10));
-
+    struct aws_event_loop_group el_group;
+    ASSERT_SUCCESS(aws_event_loop_group_default_init(&el_group, allocator, 1));
+    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 10, &el_group));
     const struct aws_string *host_name = aws_string_new_from_c_str(allocator, "host_address");
 
     const struct aws_string *addr1_ipv4 = aws_string_new_from_c_str(allocator, "address1ipv4");
@@ -449,6 +461,7 @@ static int s_test_resolver_ttls_fn(struct aws_allocator *allocator, void *ctx) {
     mock_dns_resolver_clean_up(&mock_resolver);
     aws_host_resolver_clean_up(&resolver);
     aws_string_destroy((void *)host_name);
+    aws_event_loop_group_clean_up(&el_group);
 
     return 0;
 }
@@ -459,7 +472,9 @@ static int s_test_resolver_connect_failure_recording_fn(struct aws_allocator *al
     (void)ctx;
     struct aws_host_resolver resolver;
 
-    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 10));
+    struct aws_event_loop_group el_group;
+    ASSERT_SUCCESS(aws_event_loop_group_default_init(&el_group, allocator, 1));
+    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 10, &el_group));
 
     const struct aws_string *host_name = aws_string_new_from_c_str(allocator, "host_address");
 
@@ -630,6 +645,7 @@ static int s_test_resolver_connect_failure_recording_fn(struct aws_allocator *al
     mock_dns_resolver_clean_up(&mock_resolver);
     aws_host_resolver_clean_up(&resolver);
     aws_string_destroy((void *)host_name);
+    aws_event_loop_group_clean_up(&el_group);
 
     return 0;
 }
@@ -640,8 +656,9 @@ static int s_test_resolver_ttl_refreshes_on_resolve_fn(struct aws_allocator *all
     (void)ctx;
     struct aws_host_resolver resolver;
 
-    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 10));
-
+    struct aws_event_loop_group el_group;
+    ASSERT_SUCCESS(aws_event_loop_group_default_init(&el_group, allocator, 1));
+    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 10, &el_group));
     const struct aws_string *host_name = aws_string_new_from_c_str(allocator, "host_address");
 
     const struct aws_string *addr1_ipv4 = aws_string_new_from_c_str(allocator, "address1ipv4");
@@ -799,6 +816,7 @@ static int s_test_resolver_ttl_refreshes_on_resolve_fn(struct aws_allocator *all
     mock_dns_resolver_clean_up(&mock_resolver);
     aws_host_resolver_clean_up(&resolver);
     aws_string_destroy((void *)host_name);
+    aws_event_loop_group_clean_up(&el_group);
 
     return 0;
 }
@@ -809,7 +827,9 @@ static int s_test_resolver_ipv4_address_lookup_fn(struct aws_allocator *allocato
     (void)ctx;
     struct aws_host_resolver resolver;
 
-    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 10));
+    struct aws_event_loop_group el_group;
+    ASSERT_SUCCESS(aws_event_loop_group_default_init(&el_group, allocator, 1));
+    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 10, &el_group));
 
     const struct aws_string *host_name = aws_string_new_from_c_str(allocator, "127.0.0.1");
     ASSERT_NOT_NULL(host_name);
@@ -850,6 +870,7 @@ static int s_test_resolver_ipv4_address_lookup_fn(struct aws_allocator *allocato
     aws_host_address_clean_up(&callback_data.a_address);
     aws_string_destroy((void *)host_name);
     aws_host_resolver_clean_up(&resolver);
+    aws_event_loop_group_clean_up(&el_group);
 
     return 0;
 }
@@ -859,7 +880,9 @@ static int s_test_resolver_ipv6_address_lookup_fn(struct aws_allocator *allocato
     (void)ctx;
     struct aws_host_resolver resolver;
 
-    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 10));
+    struct aws_event_loop_group el_group;
+    ASSERT_SUCCESS(aws_event_loop_group_default_init(&el_group, allocator, 1));
+    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 10, &el_group));
 
     const struct aws_string *host_name = aws_string_new_from_c_str(allocator, "::1");
     ASSERT_NOT_NULL(host_name);
@@ -900,6 +923,7 @@ static int s_test_resolver_ipv6_address_lookup_fn(struct aws_allocator *allocato
     aws_host_address_clean_up(&callback_data.aaaa_address);
     aws_string_destroy((void *)host_name);
     aws_host_resolver_clean_up(&resolver);
+    aws_event_loop_group_clean_up(&el_group);
 
     return 0;
 }

--- a/tests/socket_handler_test.c
+++ b/tests/socket_handler_test.c
@@ -361,7 +361,7 @@ static int s_socket_echo_and_backpressure_test(struct aws_allocator *allocator, 
     aws_mutex_unlock(&mutex);
     ASSERT_SUCCESS(aws_server_bootstrap_destroy_socket_listener(server_bootstrap, listener));
     aws_client_bootstrap_release(client_bootstrap);
-    aws_server_bootstrap_destroy(server_bootstrap);
+    aws_server_bootstrap_release(server_bootstrap);
     aws_event_loop_group_clean_up(&el_group);
 
     return AWS_OP_SUCCESS;
@@ -479,7 +479,7 @@ static int s_socket_close_test(struct aws_allocator *allocator, void *ctx) {
 
     ASSERT_SUCCESS(aws_server_bootstrap_destroy_socket_listener(server_bootstrap, listener));
     aws_client_bootstrap_release(client_bootstrap);
-    aws_server_bootstrap_destroy(server_bootstrap);
+    aws_server_bootstrap_release(server_bootstrap);
     aws_event_loop_group_clean_up(&el_group);
 
     return AWS_OP_SUCCESS;

--- a/tests/socket_handler_test.c
+++ b/tests/socket_handler_test.c
@@ -293,7 +293,11 @@ static int s_socket_echo_and_backpressure_test(struct aws_allocator *allocator, 
         &incoming_args);
     ASSERT_NOT_NULL(listener);
 
-    struct aws_client_bootstrap *client_bootstrap = aws_client_bootstrap_new(allocator, &el_group, NULL, NULL);
+    /* this should never get used for this case. */
+    struct aws_host_resolver dummy_resolver;
+    AWS_ZERO_STRUCT(dummy_resolver);
+    struct aws_client_bootstrap *client_bootstrap =
+        aws_client_bootstrap_new(allocator, &el_group, &dummy_resolver, NULL);
     ASSERT_NOT_NULL(client_bootstrap);
 
     ASSERT_SUCCESS(aws_mutex_lock(&mutex));
@@ -356,7 +360,7 @@ static int s_socket_echo_and_backpressure_test(struct aws_allocator *allocator, 
 
     aws_mutex_unlock(&mutex);
     ASSERT_SUCCESS(aws_server_bootstrap_destroy_socket_listener(server_bootstrap, listener));
-    aws_client_bootstrap_destroy(client_bootstrap);
+    aws_client_bootstrap_release(client_bootstrap);
     aws_server_bootstrap_destroy(server_bootstrap);
     aws_event_loop_group_clean_up(&el_group);
 
@@ -439,7 +443,11 @@ static int s_socket_close_test(struct aws_allocator *allocator, void *ctx) {
         &incoming_args);
     ASSERT_NOT_NULL(listener);
 
-    struct aws_client_bootstrap *client_bootstrap = aws_client_bootstrap_new(allocator, &el_group, NULL, NULL);
+    /* this should not get used for a unix domain socket. */
+    struct aws_host_resolver dummy_resolver;
+    AWS_ZERO_STRUCT(dummy_resolver);
+    struct aws_client_bootstrap *client_bootstrap =
+        aws_client_bootstrap_new(allocator, &el_group, &dummy_resolver, NULL);
     ASSERT_NOT_NULL(client_bootstrap);
 
     ASSERT_SUCCESS(aws_mutex_lock(&mutex));
@@ -470,7 +478,7 @@ static int s_socket_close_test(struct aws_allocator *allocator, void *ctx) {
         AWS_IO_SOCKET_CLOSED == outgoing_args.error_code || AWS_IO_SOCKET_NOT_CONNECTED == outgoing_args.error_code);
 
     ASSERT_SUCCESS(aws_server_bootstrap_destroy_socket_listener(server_bootstrap, listener));
-    aws_client_bootstrap_destroy(client_bootstrap);
+    aws_client_bootstrap_release(client_bootstrap);
     aws_server_bootstrap_destroy(server_bootstrap);
     aws_event_loop_group_clean_up(&el_group);
 

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -229,7 +229,7 @@ static int s_tls_channel_echo_and_backpressure_test_fn(struct aws_allocator *all
     ASSERT_SUCCESS(aws_event_loop_group_default_init(&el_group, allocator, 0));
 
     struct aws_host_resolver resolver;
-    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 64));
+    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 1, &el_group));
 
     struct aws_mutex mutex = AWS_MUTEX_INIT;
     struct aws_condition_variable condition_variable = AWS_CONDITION_VARIABLE_INIT;
@@ -448,7 +448,7 @@ static int s_tls_channel_echo_and_backpressure_test_fn(struct aws_allocator *all
 
     aws_client_bootstrap_release(client_bootstrap);
     ASSERT_SUCCESS(aws_server_bootstrap_destroy_socket_listener(server_bootstrap, listener));
-    aws_server_bootstrap_destroy(server_bootstrap);
+    aws_server_bootstrap_release(server_bootstrap);
     aws_tls_ctx_options_clean_up(&client_ctx_options);
     aws_tls_connection_options_clean_up(&tls_client_conn_options);
     aws_tls_ctx_options_clean_up(&server_ctx_options);
@@ -480,7 +480,7 @@ static int s_verify_negotiation_fails(struct aws_allocator *allocator, const str
     ASSERT_SUCCESS(aws_event_loop_group_default_init(&el_group, allocator, 0));
 
     struct aws_host_resolver resolver;
-    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 64));
+    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 1, &el_group));
 
     struct aws_mutex mutex = AWS_MUTEX_INIT;
     struct aws_condition_variable condition_variable = AWS_CONDITION_VARIABLE_INIT;
@@ -641,7 +641,7 @@ static int s_verify_good_host(struct aws_allocator *allocator, const struct aws_
     ASSERT_SUCCESS(aws_event_loop_group_default_init(&el_group, allocator, 0));
 
     struct aws_host_resolver resolver;
-    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 64));
+    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 1, &el_group));
 
     struct aws_mutex mutex = AWS_MUTEX_INIT;
     struct aws_condition_variable condition_variable = AWS_CONDITION_VARIABLE_INIT;

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -228,6 +228,9 @@ static int s_tls_channel_echo_and_backpressure_test_fn(struct aws_allocator *all
     struct aws_event_loop_group el_group;
     ASSERT_SUCCESS(aws_event_loop_group_default_init(&el_group, allocator, 0));
 
+    struct aws_host_resolver resolver;
+    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 64));
+
     struct aws_mutex mutex = AWS_MUTEX_INIT;
     struct aws_condition_variable condition_variable = AWS_CONDITION_VARIABLE_INIT;
 
@@ -346,7 +349,7 @@ static int s_tls_channel_echo_and_backpressure_test_fn(struct aws_allocator *all
     aws_tls_connection_options_clean_up(&tls_server_conn_options);
     ASSERT_NOT_NULL(listener);
 
-    struct aws_client_bootstrap *client_bootstrap = aws_client_bootstrap_new(allocator, &el_group, NULL, NULL);
+    struct aws_client_bootstrap *client_bootstrap = aws_client_bootstrap_new(allocator, &el_group, &resolver, NULL);
 
     ASSERT_SUCCESS(aws_mutex_lock(&mutex));
 
@@ -443,7 +446,7 @@ static int s_tls_channel_echo_and_backpressure_test_fn(struct aws_allocator *all
     ASSERT_SUCCESS(aws_condition_variable_wait_pred(
         &condition_variable, &mutex, s_tls_channel_shutdown_predicate, &outgoing_args));
 
-    aws_client_bootstrap_destroy(client_bootstrap);
+    aws_client_bootstrap_release(client_bootstrap);
     ASSERT_SUCCESS(aws_server_bootstrap_destroy_socket_listener(server_bootstrap, listener));
     aws_server_bootstrap_destroy(server_bootstrap);
     aws_tls_ctx_options_clean_up(&client_ctx_options);
@@ -452,7 +455,7 @@ static int s_tls_channel_echo_and_backpressure_test_fn(struct aws_allocator *all
     aws_tls_connection_options_clean_up(&tls_server_conn_options);
     aws_tls_ctx_destroy(client_ctx);
     aws_tls_ctx_destroy(server_ctx);
-
+    aws_host_resolver_clean_up(&resolver);
     aws_event_loop_group_clean_up(&el_group);
     aws_tls_clean_up_static_state();
     return AWS_OP_SUCCESS;
@@ -475,6 +478,9 @@ static int s_verify_negotiation_fails(struct aws_allocator *allocator, const str
 
     struct aws_event_loop_group el_group;
     ASSERT_SUCCESS(aws_event_loop_group_default_init(&el_group, allocator, 0));
+
+    struct aws_host_resolver resolver;
+    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 64));
 
     struct aws_mutex mutex = AWS_MUTEX_INIT;
     struct aws_condition_variable condition_variable = AWS_CONDITION_VARIABLE_INIT;
@@ -511,7 +517,7 @@ static int s_verify_negotiation_fails(struct aws_allocator *allocator, const str
 
     aws_mutex_lock(&mutex);
 
-    struct aws_client_bootstrap *client_bootstrap = aws_client_bootstrap_new(allocator, &el_group, NULL, NULL);
+    struct aws_client_bootstrap *client_bootstrap = aws_client_bootstrap_new(allocator, &el_group, &resolver, NULL);
     ASSERT_NOT_NULL(client_bootstrap);
 
     ASSERT_SUCCESS(aws_client_bootstrap_new_tls_socket_channel(
@@ -542,10 +548,11 @@ static int s_verify_negotiation_fails(struct aws_allocator *allocator, const str
             "Warning: the connection timed out and we're not completely certain"
             " that this fails for the right reasons. Maybe run the test again?\n");
     }
-    aws_client_bootstrap_destroy(client_bootstrap);
+    aws_client_bootstrap_release(client_bootstrap);
 
     aws_tls_ctx_destroy(client_ctx);
     aws_tls_ctx_options_clean_up(&client_ctx_options);
+    aws_host_resolver_clean_up(&resolver);
 
     aws_event_loop_group_clean_up(&el_group);
 
@@ -633,6 +640,9 @@ static int s_verify_good_host(struct aws_allocator *allocator, const struct aws_
     struct aws_event_loop_group el_group;
     ASSERT_SUCCESS(aws_event_loop_group_default_init(&el_group, allocator, 0));
 
+    struct aws_host_resolver resolver;
+    ASSERT_SUCCESS(aws_host_resolver_init_default(&resolver, allocator, 64));
+
     struct aws_mutex mutex = AWS_MUTEX_INIT;
     struct aws_condition_variable condition_variable = AWS_CONDITION_VARIABLE_INIT;
 
@@ -669,7 +679,7 @@ static int s_verify_good_host(struct aws_allocator *allocator, const struct aws_
 
     aws_mutex_lock(&mutex);
 
-    struct aws_client_bootstrap *client_bootstrap = aws_client_bootstrap_new(allocator, &el_group, NULL, NULL);
+    struct aws_client_bootstrap *client_bootstrap = aws_client_bootstrap_new(allocator, &el_group, &resolver, NULL);
     ASSERT_NOT_NULL(client_bootstrap);
 
     ASSERT_SUCCESS(aws_client_bootstrap_new_tls_socket_channel(
@@ -707,11 +717,12 @@ static int s_verify_good_host(struct aws_allocator *allocator, const struct aws_
     ASSERT_SUCCESS(aws_condition_variable_wait_pred(
         &condition_variable, &mutex, s_tls_channel_shutdown_predicate, &outgoing_args));
 
-    aws_client_bootstrap_destroy(client_bootstrap);
+    aws_client_bootstrap_release(client_bootstrap);
 
     aws_tls_ctx_destroy(client_ctx);
     aws_tls_ctx_options_clean_up(&client_ctx_options);
 
+    aws_host_resolver_clean_up(&resolver);
     aws_event_loop_group_clean_up(&el_group);
 
     aws_tls_clean_up_static_state();


### PR DESCRIPTION
… make failure/shutdown more graceful from the host resolver.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
