### PR TITLE
Copy host_resolution_config into host_entry to prevent lifetime issues

### DIFF
--- a/include/aws/io/host_resolver.h
+++ b/include/aws/io/host_resolver.h
@@ -188,7 +188,7 @@ AWS_IO_API int aws_host_resolver_init_uv(
 AWS_IO_API void aws_host_resolver_clean_up(struct aws_host_resolver *resolver);
 
 /**
- * calls resolve_host on the vtable.
+ * calls resolve_host on the vtable. config will be copied.
  */
 AWS_IO_API int aws_host_resolver_resolve_host(
     struct aws_host_resolver *resolver,


### PR DESCRIPTION
Otherwise, you get a use after free on the max_ttl in the host resolver thread for each entry

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
