### PR TITLE
pass err_code along to setup_callback

### DIFF
--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -631,7 +631,7 @@ static void s_on_host_resolved(
         "id=%p: dns resolution failed, or all socket connections to the endpoint failed.",
         (void *)client_connection_args->bootstrap);
     client_connection_args->setup_callback(
-        client_connection_args->bootstrap, aws_last_error(), NULL, client_connection_args->user_data);
+        client_connection_args->bootstrap, err_code, NULL, client_connection_args->user_data);
     s_connection_args_release(client_connection_args);
 }
 


### PR DESCRIPTION
aws_last_error() is not likely to have anything useful in it in this case

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
