### PR TITLE
Fixes aws_byte_buf initialization on socket_handler and tls_handler tests

### DIFF
--- a/tests/socket_handler_test.c
+++ b/tests/socket_handler_test.c
@@ -209,24 +209,22 @@ static int s_socket_echo_and_backpressure_test(struct aws_allocator *allocator, 
     struct socket_test_rw_args incoming_rw_args = {
         .mutex = &mutex,
         .condition_variable = &condition_variable,
-        .received_message = aws_byte_buf_from_array(incoming_received_message, sizeof(incoming_received_message)),
+        .received_message = aws_byte_buf_from_empty_array(incoming_received_message, sizeof(incoming_received_message)),
         .invocation_happened = false,
         .shutdown_finished = false,
         .amount_read = 0,
         .expected_read = (int)write_tag.len,
     };
-    incoming_rw_args.received_message.len = 0;
 
     struct socket_test_rw_args outgoing_rw_args = {
         .mutex = &mutex,
         .condition_variable = &condition_variable,
-        .received_message = aws_byte_buf_from_array(outgoing_received_message, 0),
+        .received_message = aws_byte_buf_from_empty_array(outgoing_received_message, sizeof(outgoing_received_message)),
         .invocation_happened = false,
         .shutdown_finished = false,
         .amount_read = 0,
         .expected_read = (int)read_tag.len,
     };
-    outgoing_rw_args.received_message.len = 0;
 
     /* make the windows small to make sure back pressure is honored. */
     static size_t s_outgoing_initial_read_window = 9;

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -243,7 +243,7 @@ static int s_tls_channel_echo_and_backpressure_test_fn(struct aws_allocator *all
     struct tls_test_rw_args incoming_rw_args = {
         .mutex = &mutex,
         .condition_variable = &condition_variable,
-        .received_message = aws_byte_buf_from_array(incoming_received_message, 0),
+        .received_message = aws_byte_buf_from_empty_array(incoming_received_message, sizeof(incoming_received_message)),
         .invocation_happened = false,
         .read_invocations = 0,
     };
@@ -251,7 +251,7 @@ static int s_tls_channel_echo_and_backpressure_test_fn(struct aws_allocator *all
     struct tls_test_rw_args outgoing_rw_args = {
         .mutex = &mutex,
         .condition_variable = &condition_variable,
-        .received_message = aws_byte_buf_from_array(outgoing_received_message, 0),
+        .received_message = aws_byte_buf_from_empty_array(outgoing_received_message, sizeof(outgoing_received_message)),
         .invocation_happened = false,
         .read_invocations = 0,
     };


### PR DESCRIPTION
Signed-off-by: Felipe R. Monteiro <felisous@amazon.com>

*Description of changes:*

Both socket_handler and tls_handler tests initialize an aws_byte_buf from an empty array. So, the appropriate function to initialize these aws_byte_buf would be `aws_byte_buf_from_empty_array` instead of `aws_byte_buf_from_array`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
