### PR TITLE
URI Encoding variants moved from auth to io

### DIFF
--- a/include/aws/io/uri.h
+++ b/include/aws/io/uri.h
@@ -127,6 +127,19 @@ AWS_IO_API const struct aws_byte_cursor *aws_uri_path_and_query(const struct aws
  */
 AWS_IO_API int aws_uri_query_string_params(const struct aws_uri *uri, struct aws_array_list *out_params);
 
+/**
+ * Writes the uri path encoding of a cursor to a buffer.  This is the modified version of rfc3986 used by
+ * sigv4 signing.
+ */
+AWS_IO_API int aws_byte_buf_append_encoding_uri_path(struct aws_byte_buf *buffer, const struct aws_byte_cursor *cursor);
+
+/**
+ * Writes the uri query param encoding (passthrough alnum + '-' '_' '~' '.') of a cursor to a buffer
+ */
+AWS_IO_API int aws_byte_buf_append_encoding_uri_param(
+    struct aws_byte_buf *buffer,
+    const struct aws_byte_cursor *cursor);
+
 AWS_EXTERN_C_END
 
 #endif /* AWS_IO_URI_H */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -166,6 +166,8 @@ add_test_case(uri_invalid_port_parse)
 add_test_case(uri_port_too_large_parse)
 add_test_case(uri_builder)
 add_test_case(uri_builder_from_string)
+add_test_case(test_uri_encode_path_rfc3986)
+add_test_case(test_uri_encode_query)
 
 add_test_case(test_home_directory_not_null)
 


### PR DESCRIPTION
Per henso's request, this moves uri encoding functionality from auth to io.  

The tests end up being essentially self-referential which kind of sucks, but I don't see a better way to getting decent coverage.

I admit I may be getting rfc3986 vs modified-rfc3986 backwards in the comments/naming.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
