### PR TITLE
Socket close

### DIFF
--- a/source/socket_channel_handler.c
+++ b/source/socket_channel_handler.c
@@ -268,9 +268,9 @@ static void s_close_task(struct aws_channel_task *task, void *arg, aws_task_stat
     struct socket_handler *socket_handler = handler->impl;
 
     /*
-    * Run this unconditionally regardless of status, otherwise channel will not
-    * finish shutting down properly
-    */
+     * Run this unconditionally regardless of status, otherwise channel will not
+     * finish shutting down properly
+     */
 
     /* this only happens in write direction. */
     /* we also don't care about the free_scarce_resource_immediately

--- a/source/socket_channel_handler.c
+++ b/source/socket_channel_handler.c
@@ -262,17 +262,21 @@ static int s_socket_increment_read_window(
 
 static void s_close_task(struct aws_channel_task *task, void *arg, aws_task_status status) {
     (void)task;
+    (void)status;
 
     struct aws_channel_handler *handler = arg;
     struct socket_handler *socket_handler = handler->impl;
 
-    if (status == AWS_TASK_STATUS_RUN_READY) {
-        /* this only happens in write direction. */
-        /* we also don't care about the free_scarce_resource_immediately
-         * code since we're always the last one in the shutdown sequence. */
-        aws_channel_slot_on_handler_shutdown_complete(
-            socket_handler->slot, AWS_CHANNEL_DIR_WRITE, socket_handler->shutdown_err_code, false);
-    }
+    /*
+    * Run this unconditionally regardless of status, otherwise channel will not
+    * finish shutting down properly
+    */
+
+    /* this only happens in write direction. */
+    /* we also don't care about the free_scarce_resource_immediately
+     * code since we're always the last one in the shutdown sequence. */
+    aws_channel_slot_on_handler_shutdown_complete(
+        socket_handler->slot, AWS_CHANNEL_DIR_WRITE, socket_handler->shutdown_err_code, false);
 }
 
 static int s_socket_shutdown(


### PR DESCRIPTION
If these tasks were run after the event loop itself had finished running (and thus were cancelled) then the channels would leak.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
