### PR TITLE
Enforce that setup_callback is always called exactly once

### DIFF
--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -524,8 +524,7 @@ static void s_on_client_connection_established(struct aws_socket *socket, int er
                 error_code);
             /* connection_args will be released after setup_callback */
             s_connection_args_setup_callback(connection_args, error_code, NULL);
-        } 
-        else {
+        } else {
             /* this socket will die silently, free up the ref to the connection_args */
             s_connection_args_release(connection_args);
         }

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -612,10 +612,10 @@ socket_init_failed:
 socket_alloc_failed:
     err_code = aws_last_error();
     AWS_LOGF_ERROR(
-            AWS_LS_IO_CHANNEL_BOOTSTRAP,
-            "id=%p: failed to create socket with error %d",
-            (void *)task_data->args->bootstrap,
-            err_code);
+        AWS_LS_IO_CHANNEL_BOOTSTRAP,
+        "id=%p: failed to create socket with error %d",
+        (void *)task_data->args->bootstrap,
+        err_code);
 task_cancelled:
     task_data->args->failed_count++;
     /* if this is the last attempted connection and it failed, notify the user */

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -602,7 +602,11 @@ static void s_attempt_connection(struct aws_task *task, void *arg, enum aws_task
 error:
     task_data->args->failed_count++;
     int err_code = aws_last_error();
-    AWS_LOGF_ERROR(AWS_LS_IO_CHANNEL_BOOTSTRAP, "id=%p: failed to create socket with error %d", (void*)task_data->args->bootstrap, err_code);
+    AWS_LOGF_ERROR(
+        AWS_LS_IO_CHANNEL_BOOTSTRAP,
+        "id=%p: failed to create socket with error %d",
+        (void *)task_data->args->bootstrap,
+        err_code);
     if (outgoing_socket) {
         aws_mem_release(allocator, outgoing_socket);
     }
@@ -657,9 +661,7 @@ static void s_on_host_resolved(
         task_data->endpoint.port = client_connection_args->outgoing_port;
         AWS_ASSERT(sizeof(task_data->endpoint.address) >= host_address_ptr->address->len + 1);
         memcpy(
-            task_data->endpoint.address,
-            aws_string_bytes(host_address_ptr->address),
-            host_address_ptr->address->len);
+            task_data->endpoint.address, aws_string_bytes(host_address_ptr->address), host_address_ptr->address->len);
         task_data->endpoint.address[host_address_ptr->address->len] = 0;
 
         task_data->options = client_connection_args->outgoing_options;
@@ -671,7 +673,7 @@ static void s_on_host_resolved(
         task_data->connect_loop = connect_loop;
 
         aws_task_init(&task_data->task, s_attempt_connection, task_data);
-        aws_event_loop_schedule_task_now(connect_loop, &task_data->task);            
+        aws_event_loop_schedule_task_now(connect_loop, &task_data->task);
     }
 }
 

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -522,7 +522,12 @@ static void s_on_client_connection_established(struct aws_socket *socket, int er
                 "id=%p: Connection failed with error_code %d.",
                 (void *)connection_args->bootstrap,
                 error_code);
+            /* connection_args will be released after setup_callback */
             s_connection_args_setup_callback(connection_args, error_code, NULL);
+        } 
+        else {
+            /* this socket will die silently, free up the ref to the connection_args */
+            s_connection_args_release(connection_args);
         }
         return;
     }

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -808,8 +808,6 @@ static inline int s_new_client_channel(
         memcpy(endpoint.address, host_name, strlen(host_name));
         endpoint.port = 0;
 
-        s_connection_args_acquire(client_connection_args);
-
         struct aws_socket *outgoing_socket = aws_mem_acquire(bootstrap->allocator, sizeof(struct aws_socket));
 
         if (!outgoing_socket) {
@@ -825,10 +823,12 @@ static inline int s_new_client_channel(
 
         struct aws_event_loop *connect_loop = aws_event_loop_group_get_next_loop(bootstrap->event_loop_group);
 
+        s_connection_args_acquire(client_connection_args);
         if (aws_socket_connect(
                 outgoing_socket, &endpoint, connect_loop, s_on_client_connection_established, client_connection_args)) {
             aws_socket_clean_up(outgoing_socket);
             aws_mem_release(client_connection_args->bootstrap->allocator, outgoing_socket);
+            s_connection_args_release(client_connection_args);
             goto error;
         }
     }

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -270,7 +270,7 @@ static void s_tls_client_on_negotiation_result(
     }
 
     struct aws_channel *channel = connection_args->channel_data.channel;
-    s_connection_args_setup_callback(connection_args, err_code, channel);
+    s_connection_args_setup_callback(connection_args, AWS_ERROR_SUCCESS, channel);
 }
 
 /* in the context of a channel bootstrap, we don't care about these, but since we're hooking into these APIs we have to
@@ -430,14 +430,13 @@ static void s_on_client_channel_on_setup_completed(struct aws_channel *channel, 
         return;
     }
 
+error:
     AWS_LOGF_ERROR(
         AWS_LS_IO_CHANNEL_BOOTSTRAP,
         "id=%p: channel %p setup failed with error %d.",
         (void *)connection_args->bootstrap,
         (void *)channel,
         err_code);
-
-error:
     aws_channel_shutdown(channel, err_code);
     aws_channel_destroy(channel);
     aws_socket_clean_up(connection_args->channel_data.socket);

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -649,6 +649,7 @@ static void s_on_host_resolved(
     }
 
     size_t host_addresses_len = aws_array_list_length(host_addresses);
+    AWS_FATAL_ASSERT(host_addresses_len > 0);
     AWS_LOGF_TRACE(
         AWS_LS_IO_CHANNEL_BOOTSTRAP,
         "id=%p: dns resolution completed. Kicking off connections"

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -189,6 +189,7 @@ struct client_connection_args {
     uint8_t failed_count;
     bool connection_chosen;
     bool negotiating_tls;
+    bool setup_called;
     uint32_t ref_count;
 };
 
@@ -218,6 +219,23 @@ void s_connection_args_release(struct client_connection_args *args) {
     }
 }
 
+void s_connection_args_setup_callback(struct client_connection_args *args, int error_code, struct aws_channel *channel) {
+    if (!args->setup_called) {
+        aws_client_bootstrap_on_channel_setup_fn *setup_callback = args->setup_callback;
+        setup_callback(args->bootstrap, error_code, channel, args->user_data);
+        args->setup_called = true;
+    }
+}
+
+void s_connection_args_shutdown_callback(struct client_connection_args *args, int error_code, struct aws_channel *channel) {
+    if (!args->setup_called) {
+        s_connection_args_setup_callback(args, error_code, channel);
+        return;
+    }
+    aws_client_bootstrap_on_channel_shutdown_fn *shutdown_callback = args->shutdown_callback;
+    shutdown_callback(args->bootstrap, error_code, channel, args->user_data);
+}
+
 static void s_tls_client_on_negotiation_result(
     struct aws_channel_handler *handler,
     struct aws_channel_slot *slot,
@@ -231,7 +249,6 @@ static void s_tls_client_on_negotiation_result(
             handler, slot, err_code, connection_args->channel_data.tls_user_data);
     }
 
-    struct aws_channel *channel = (err_code == AWS_OP_SUCCESS) ? connection_args->channel_data.channel : NULL;
     AWS_LOGF_DEBUG(
         AWS_LS_IO_CHANNEL_BOOTSTRAP,
         "id=%p: tls negotiation result %d on channel %p",
@@ -239,8 +256,8 @@ static void s_tls_client_on_negotiation_result(
         err_code,
         (void *)slot->channel);
 
-    aws_client_bootstrap_on_channel_setup_fn *setup_callback = connection_args->setup_callback;
-    setup_callback(connection_args->bootstrap, err_code, channel, connection_args->user_data);
+    struct aws_channel *channel = (err_code == AWS_OP_SUCCESS) ? connection_args->channel_data.channel : NULL;
+    s_connection_args_setup_callback(connection_args, err_code, channel);
 }
 
 /* in the context of a channel bootstrap, we don't care about these, but since we're hooking into these APIs we have to
@@ -395,8 +412,7 @@ static void s_on_client_channel_on_setup_completed(struct aws_channel *channel, 
                 goto error;
             }
         } else {
-            connection_args->setup_callback(
-                connection_args->bootstrap, AWS_OP_SUCCESS, channel, connection_args->user_data);
+            s_connection_args_setup_callback(connection_args, AWS_OP_SUCCESS, channel);
         }
 
         return;
@@ -410,7 +426,7 @@ static void s_on_client_channel_on_setup_completed(struct aws_channel *channel, 
         err_code);
 
 error:
-    connection_args->setup_callback(connection_args->bootstrap, err_code, NULL, connection_args->user_data);
+    s_connection_args_setup_callback(connection_args, err_code, NULL);
 
     aws_channel_destroy(channel);
     aws_socket_clean_up(connection_args->channel_data.socket);
@@ -428,21 +444,16 @@ static void s_on_client_channel_on_shutdown(struct aws_channel *channel, int err
         (void *)channel,
         error_code);
 
+    /* note it's not safe to reference the bootstrap after this scope. */
     struct aws_allocator *allocator = connection_args->bootstrap->allocator;
     {
-        /* note it's not safe to reference the bootstrap outside of this scope. */
-        struct aws_client_bootstrap *bootstrap = connection_args->bootstrap;
-
         /* If the connection setup_callback has not been called for this connect attempt (because it
          * was intercepted for TLS setup), call it instead. This usually means a connection failure
          * occurred during TLS negotation */
         if (connection_args->negotiating_tls) {
-            connection_args->setup_callback(
-                connection_args->bootstrap, error_code, channel, connection_args->user_data);
+            s_connection_args_setup_callback(connection_args, error_code, channel);
         } else {
-            void *shutdown_user_data = connection_args->user_data;
-            aws_client_bootstrap_on_channel_shutdown_fn *shutdown_callback = connection_args->shutdown_callback;
-            shutdown_callback(bootstrap, error_code, channel, shutdown_user_data);
+            s_connection_args_shutdown_callback(connection_args, error_code, channel);
         }
     }
 
@@ -504,7 +515,7 @@ static void s_on_client_connection_established(struct aws_socket *socket, int er
                 "id=%p: Connection failed with error_code %d.",
                 (void *)connection_args->bootstrap,
                 error_code);
-            connection_args->setup_callback(connection_args->bootstrap, error_code, NULL, connection_args->user_data);
+            s_connection_args_setup_callback(connection_args, error_code, NULL);
         }
         /* release the ref from s_on_host_resolved */
         s_connection_args_release(connection_args);
@@ -535,7 +546,7 @@ static void s_on_client_connection_established(struct aws_socket *socket, int er
         connection_args->failed_count++;
 
         if (connection_args->failed_count == connection_args->addresses_count) {
-            connection_args->setup_callback(connection_args->bootstrap, error_code, NULL, connection_args->user_data);
+            s_connection_args_setup_callback(connection_args, error_code, NULL);
         }
         /* release the ref from s_on_host_resolved */
         s_connection_args_release(connection_args);
@@ -635,8 +646,7 @@ static void s_on_host_resolved(
     if (err_code == 0) {
         err_code = AWS_IO_SOCKET_NOT_CONNECTED;
     }
-    client_connection_args->setup_callback(
-        client_connection_args->bootstrap, err_code, NULL, client_connection_args->user_data);
+    s_connection_args_setup_callback(client_connection_args, err_code, NULL);
     s_connection_args_release(client_connection_args);
 }
 

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -603,8 +603,7 @@ static void s_attempt_connection(struct aws_task *task, void *arg, enum aws_task
     goto cleanup_task;
 
 socket_connect_failed:
-    aws_host_resolver_record_connection_failure(
-            task_data->args->bootstrap->host_resolver, &task_data->host_address);
+    aws_host_resolver_record_connection_failure(task_data->args->bootstrap->host_resolver, &task_data->host_address);
     aws_socket_clean_up(outgoing_socket);
 socket_init_failed:
     aws_mem_release(allocator, outgoing_socket);
@@ -613,10 +612,10 @@ task_cancelled:
     task_data->args->failed_count++;
     int err_code = aws_last_error();
     AWS_LOGF_ERROR(
-            AWS_LS_IO_CHANNEL_BOOTSTRAP,
-            "id=%p: failed to create socket with error %d",
-            (void *)task_data->args->bootstrap,
-            err_code);
+        AWS_LS_IO_CHANNEL_BOOTSTRAP,
+        "id=%p: failed to create socket with error %d",
+        (void *)task_data->args->bootstrap,
+        err_code);
     /* if this is the last attempted connection and it failed, notify the user */
     if (task_data->args->failed_count == task_data->args->addresses_count) {
         s_connection_args_setup_callback(task_data->args, err_code, NULL);
@@ -662,9 +661,10 @@ static void s_on_host_resolved(
     client_connection_args->addresses_count = (uint8_t)host_addresses_len;
 
     /* allocate all the task data first, in case it fails... */
-    AWS_VARIABLE_LENGTH_ARRAY(struct connection_task_data*, tasks, host_addresses_len);
+    AWS_VARIABLE_LENGTH_ARRAY(struct connection_task_data *, tasks, host_addresses_len);
     for (size_t i = 0; i < host_addresses_len; ++i) {
-        struct connection_task_data *task_data = tasks[i] = aws_mem_calloc(allocator, 1, sizeof(struct connection_task_data));
+        struct connection_task_data *task_data = tasks[i] =
+            aws_mem_calloc(allocator, 1, sizeof(struct connection_task_data));
         bool failed = task_data == NULL;
         if (!failed) {
             struct aws_host_address *host_address_ptr = NULL;
@@ -673,12 +673,14 @@ static void s_on_host_resolved(
             task_data->endpoint.port = client_connection_args->outgoing_port;
             AWS_ASSERT(sizeof(task_data->endpoint.address) >= host_address_ptr->address->len + 1);
             memcpy(
-                    task_data->endpoint.address, aws_string_bytes(host_address_ptr->address), host_address_ptr->address->len);
+                task_data->endpoint.address,
+                aws_string_bytes(host_address_ptr->address),
+                host_address_ptr->address->len);
             task_data->endpoint.address[host_address_ptr->address->len] = 0;
 
             task_data->options = client_connection_args->outgoing_options;
             task_data->options.domain =
-                    host_address_ptr->record_type == AWS_ADDRESS_RECORD_TYPE_AAAA ? AWS_SOCKET_IPV6 : AWS_SOCKET_IPV4;
+                host_address_ptr->record_type == AWS_ADDRESS_RECORD_TYPE_AAAA ? AWS_SOCKET_IPV6 : AWS_SOCKET_IPV4;
 
             failed = aws_host_address_copy(host_address_ptr, &task_data->host_address) != AWS_OP_SUCCESS;
             task_data->args = client_connection_args;
@@ -691,7 +693,11 @@ static void s_on_host_resolved(
                     aws_mem_release(allocator, tasks[j]);
                 }
             }
-            AWS_LOGF_ERROR(AWS_LS_IO_CHANNEL_BOOTSTRAP, "id=%p: failed to allocate connection task data: err=%d", (void*)client_connection_args->bootstrap, aws_last_error());
+            AWS_LOGF_ERROR(
+                AWS_LS_IO_CHANNEL_BOOTSTRAP,
+                "id=%p: failed to allocate connection task data: err=%d",
+                (void *)client_connection_args->bootstrap,
+                aws_last_error());
             return;
         }
     }

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -218,7 +218,10 @@ void s_connection_args_release(struct client_connection_args *args) {
     }
 }
 
-void s_connection_args_setup_callback(struct client_connection_args *args, int error_code, struct aws_channel *channel) {
+void s_connection_args_setup_callback(
+    struct client_connection_args *args,
+    int error_code,
+    struct aws_channel *channel) {
     if (!args->setup_called) {
         aws_client_bootstrap_on_channel_setup_fn *setup_callback = args->setup_callback;
         setup_callback(args->bootstrap, error_code, channel, args->user_data);
@@ -226,7 +229,10 @@ void s_connection_args_setup_callback(struct client_connection_args *args, int e
     }
 }
 
-void s_connection_args_shutdown_callback(struct client_connection_args *args, int error_code, struct aws_channel *channel) {
+void s_connection_args_shutdown_callback(
+    struct client_connection_args *args,
+    int error_code,
+    struct aws_channel *channel) {
     if (!args->setup_called) {
         s_connection_args_setup_callback(args, error_code, channel);
         return;


### PR DESCRIPTION
Additionally, if setup_callback is called with an error, then shutdown will never be called.

In order to make this work, the happy eyeballs algorithm was moved into the event loop from the dns resolver thread.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
