### PR TITLE
aws_uri_init() zeroes out earlier

### DIFF
--- a/source/uri.c
+++ b/source/uri.c
@@ -94,11 +94,12 @@ int aws_uri_init_from_builder_options(
     struct aws_allocator *allocator,
     struct aws_uri_builder_options *options) {
 
+    AWS_ZERO_STRUCT(*uri);
+
     if (options->query_string.len && options->query_params) {
         return aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
     }
 
-    AWS_ZERO_STRUCT(*uri);
     uri->self_size = sizeof(struct aws_uri);
     uri->allocator = allocator;
 


### PR DESCRIPTION
This ensures we can call aws_uri_clean_up() on a URI that failed to initialize

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
