### PR TITLE
Remove amount_read param from stream_read

### DIFF
--- a/include/aws/io/stream.h
+++ b/include/aws/io/stream.h
@@ -34,11 +34,11 @@ struct aws_stream_status {
 };
 
 struct aws_input_stream_vtable {
-    int(*seek)(struct aws_input_stream *stream, aws_off_t offset, enum aws_stream_seek_basis basis);
-    int(*read)(struct aws_input_stream *stream, struct aws_byte_buf *dest);
-    int(*get_status)(struct aws_input_stream *stream, struct aws_stream_status *status);
-    int(*get_length)(struct aws_input_stream *stream, int64_t *out_length);
-    void(*clean_up)(struct aws_input_stream *stream);
+    int (*seek)(struct aws_input_stream *stream, aws_off_t offset, enum aws_stream_seek_basis basis);
+    int (*read)(struct aws_input_stream *stream, struct aws_byte_buf *dest);
+    int (*get_status)(struct aws_input_stream *stream, struct aws_stream_status *status);
+    int (*get_length)(struct aws_input_stream *stream, int64_t *out_length);
+    void (*clean_up)(struct aws_input_stream *stream);
 };
 
 struct aws_input_stream {

--- a/include/aws/io/stream.h
+++ b/include/aws/io/stream.h
@@ -33,19 +33,12 @@ struct aws_stream_status {
     bool is_valid;
 };
 
-typedef int(
-    aws_input_stream_seek_fn)(struct aws_input_stream *stream, aws_off_t offset, enum aws_stream_seek_basis basis);
-typedef int(aws_input_stream_read_fn)(struct aws_input_stream *stream, struct aws_byte_buf *dest, size_t *amount_read);
-typedef int(aws_input_stream_get_status_fn)(struct aws_input_stream *stream, struct aws_stream_status *status);
-typedef int(aws_input_stream_get_length_fn)(struct aws_input_stream *stream, int64_t *out_length);
-typedef void(aws_input_stream_clean_up_fn)(struct aws_input_stream *stream);
-
 struct aws_input_stream_vtable {
-    aws_input_stream_seek_fn *seek;
-    aws_input_stream_read_fn *read;
-    aws_input_stream_get_status_fn *get_status;
-    aws_input_stream_get_length_fn *get_length;
-    aws_input_stream_clean_up_fn *clean_up;
+    int(*seek)(struct aws_input_stream *stream, aws_off_t offset, enum aws_stream_seek_basis basis);
+    int(*read)(struct aws_input_stream *stream, struct aws_byte_buf *dest);
+    int(*get_status)(struct aws_input_stream *stream, struct aws_stream_status *status);
+    int(*get_length)(struct aws_input_stream *stream, int64_t *out_length);
+    void(*clean_up)(struct aws_input_stream *stream);
 };
 
 struct aws_input_stream {
@@ -68,7 +61,7 @@ AWS_IO_API int aws_input_stream_seek(
  * Read data from a stream.  If data is available, will read up to the (capacity - len) open bytes
  * in the destination buffer.
  */
-AWS_IO_API int aws_input_stream_read(struct aws_input_stream *stream, struct aws_byte_buf *dest, size_t *amount_read);
+AWS_IO_API int aws_input_stream_read(struct aws_input_stream *stream, struct aws_byte_buf *dest);
 
 /*
  * Queries miscellaneous properties of the stream

--- a/source/stream.c
+++ b/source/stream.c
@@ -29,10 +29,10 @@ int aws_input_stream_seek(struct aws_input_stream *stream, aws_off_t offset, enu
     return stream->vtable->seek(stream, offset, basis);
 }
 
-int aws_input_stream_read(struct aws_input_stream *stream, struct aws_byte_buf *dest, size_t *amount_read) {
+int aws_input_stream_read(struct aws_input_stream *stream, struct aws_byte_buf *dest) {
     AWS_ASSERT(stream && stream->vtable && stream->vtable->read);
 
-    return stream->vtable->read(stream, dest, amount_read);
+    return stream->vtable->read(stream, dest);
 }
 
 int aws_input_stream_get_status(struct aws_input_stream *stream, struct aws_stream_status *status) {
@@ -140,13 +140,8 @@ static int s_aws_input_stream_byte_cursor_seek(
 
 static int s_aws_input_stream_byte_cursor_read(
     struct aws_input_stream *stream,
-    struct aws_byte_buf *dest,
-    size_t *amount_read) {
+    struct aws_byte_buf *dest) {
     struct aws_input_stream_byte_cursor_impl *impl = stream->impl;
-
-    if (amount_read != NULL) {
-        *amount_read = 0;
-    }
 
     size_t actually_read = dest->capacity - dest->len;
     if (actually_read > impl->current_cursor.len) {
@@ -158,10 +153,6 @@ static int s_aws_input_stream_byte_cursor_read(
     }
 
     aws_byte_cursor_advance(&impl->current_cursor, actually_read);
-
-    if (amount_read != NULL) {
-        *amount_read = actually_read;
-    }
 
     return AWS_OP_SUCCESS;
 }
@@ -259,11 +250,8 @@ static int s_aws_input_stream_file_seek(
 
 static int s_aws_input_stream_file_read(
     struct aws_input_stream *stream,
-    struct aws_byte_buf *dest,
-    size_t *amount_read) {
+    struct aws_byte_buf *dest) {
     struct aws_input_stream_file_impl *impl = stream->impl;
-
-    *amount_read = 0;
 
     size_t max_read = dest->capacity - dest->len;
     size_t actually_read = fread(dest->buffer + dest->len, 1, max_read, impl->file);
@@ -274,8 +262,6 @@ static int s_aws_input_stream_file_read(
     }
 
     dest->len += actually_read;
-
-    *amount_read = actually_read;
 
     return AWS_OP_SUCCESS;
 }

--- a/source/stream.c
+++ b/source/stream.c
@@ -138,9 +138,7 @@ static int s_aws_input_stream_byte_cursor_seek(
     return AWS_OP_SUCCESS;
 }
 
-static int s_aws_input_stream_byte_cursor_read(
-    struct aws_input_stream *stream,
-    struct aws_byte_buf *dest) {
+static int s_aws_input_stream_byte_cursor_read(struct aws_input_stream *stream, struct aws_byte_buf *dest) {
     struct aws_input_stream_byte_cursor_impl *impl = stream->impl;
 
     size_t actually_read = dest->capacity - dest->len;
@@ -248,9 +246,7 @@ static int s_aws_input_stream_file_seek(
     return AWS_OP_SUCCESS;
 }
 
-static int s_aws_input_stream_file_read(
-    struct aws_input_stream *stream,
-    struct aws_byte_buf *dest) {
+static int s_aws_input_stream_file_read(struct aws_input_stream *stream, struct aws_byte_buf *dest) {
     struct aws_input_stream_file_impl *impl = stream->impl;
 
     size_t max_read = dest->capacity - dest->len;

--- a/tests/stream_test.c
+++ b/tests/stream_test.c
@@ -69,10 +69,10 @@ static int s_do_simple_input_stream_test(
     ASSERT_TRUE(status.is_end_of_stream == false);
 
     while (!status.is_end_of_stream) {
-        size_t amount_read = 0;
-        ASSERT_TRUE(aws_input_stream_read(stream, &read_buf, &amount_read) == 0);
+        const size_t starting_len = read_buf.len;
+        ASSERT_SUCCESS(aws_input_stream_read(stream, &read_buf));
 
-        if (amount_read > 0) {
+        if (starting_len - read_buf.len > 0) {
             struct aws_byte_cursor dest_cursor = aws_byte_cursor_from_buf(&read_buf);
             aws_byte_buf_append_dynamic(&result_buf, &dest_cursor);
         }
@@ -160,10 +160,9 @@ static int s_do_input_stream_seek_test(
     struct aws_byte_buf read_buf;
     aws_byte_buf_init(&read_buf, allocator, 1024);
 
-    ASSERT_TRUE(aws_input_stream_seek(stream, offset, basis) == AWS_OP_SUCCESS);
+    ASSERT_SUCCESS(aws_input_stream_seek(stream, offset, basis));
 
-    size_t amount_read = 0;
-    ASSERT_TRUE(aws_input_stream_read(stream, &read_buf, &amount_read) == AWS_OP_SUCCESS);
+    ASSERT_SUCCESS(aws_input_stream_read(stream, &read_buf));
 
     struct aws_byte_cursor read_buf_cursor = aws_byte_cursor_from_buf(&read_buf);
     ASSERT_TRUE(aws_byte_cursor_eq(expected_contents, &read_buf_cursor));


### PR DESCRIPTION
Since the reader must update `dest->len` anyway, there's not much point in making them write this out again.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
