### PR TITLE
Pass default CA path and default CA file if neither are specified

### DIFF
--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -956,13 +956,7 @@ static struct aws_tls_ctx *s_tls_ctx_new(
         }
 
         if (!options->ca_path && !options->ca_file.len) {
-            const char *ca_dir = s_default_ca_dir;
-            const char *ca_file = NULL;
-            if (!ca_dir) {
-                ca_file = s_default_ca_file;
-            }
-
-            if (s2n_config_set_verification_ca_location(s2n_ctx->s2n_config, ca_file, ca_dir)) {
+            if (s2n_config_set_verification_ca_location(s2n_ctx->s2n_config, s_default_ca_file, s_default_ca_dir)) {
                 AWS_LOGF_ERROR(
                     AWS_LS_IO_TLS,
                     "ctx: configuration error %s (%s)",


### PR DESCRIPTION
*Issue #, if available:*
N/A
*Description of changes:*
Previously if a user does not specify a CA path or CA file this function would only pass the default path to s2n which attempts to load the certificates using `X509_STORE_load_locations`. On some systems (such as Amazon Linux) the default path is not a X509_LOOKUP_hash_dir and OpenSSL will fail to load any certificates. By passing in both we have the best chance of working. See https://github.com/openssl/openssl/blob/3e4b43b9e5aba6261b1ceb832c597ce8225782ef/crypto/x509/x509_d2.c#L35

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
