### PR TITLE
Fix Memory Release bug in s2n handler

### DIFF
--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -554,11 +554,12 @@ static int s_s2n_handler_process_write_message(
     AWS_LOGF_TRACE(AWS_LS_IO_TLS, "id=%p: Bytes written: %llu", (void *)handler, (unsigned long long)write_code);
 
     ssize_t message_len = (ssize_t)message->message_data.len;
-    aws_mem_release(message->allocator, message);
 
     if (write_code < message_len) {
         return aws_raise_error(AWS_IO_TLS_ERROR_WRITE_FAILURE);
     }
+
+    aws_mem_release(message->allocator, message);
 
     return AWS_OP_SUCCESS;
 }


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Handlers are allowed to either release a message, or return an error, but not both. Returning an error implies that the handler did not take ownership of the `aws_io_message` and it becomes the caller's responsibility to release the `aws_io_message`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
