### PR TITLE
Elg async cleanup2

### DIFF
--- a/include/aws/io/event_loop.h
+++ b/include/aws/io/event_loop.h
@@ -115,6 +115,8 @@ struct aws_event_loop_group {
     struct aws_atomic_var current_index;
 };
 
+typedef void(aws_event_loop_group_cleanup_complete_fn)(void *user_data);
+
 AWS_EXTERN_C_BEGIN
 
 #ifdef AWS_USE_IO_COMPLETION_PORTS
@@ -348,6 +350,18 @@ int aws_event_loop_group_default_init(
  */
 AWS_IO_API
 void aws_event_loop_group_clean_up(struct aws_event_loop_group *el_group);
+
+/**
+ * Asynchronously invokes the cleanup() fn for the event loop group.
+ * Spawns a background thread to run aws_event_loop_group_cleanup().
+ * When the cleanup function completes, the completion callback is invoked with the supplied user data
+ * Used in complex cases where the cleanup call can happen on one of the event loop group's threads.
+ */
+AWS_IO_API
+void aws_event_loop_group_cleanup_async(
+    struct aws_event_loop_group *event_loop,
+    aws_event_loop_group_cleanup_complete_fn completion_callback,
+    void *user_data);
 
 AWS_IO_API
 struct aws_event_loop *aws_event_loop_group_get_loop_at(struct aws_event_loop_group *el_group, size_t index);

--- a/include/aws/io/event_loop.h
+++ b/include/aws/io/event_loop.h
@@ -359,7 +359,7 @@ void aws_event_loop_group_clean_up(struct aws_event_loop_group *el_group);
  */
 AWS_IO_API
 void aws_event_loop_group_cleanup_async(
-    struct aws_event_loop_group *event_loop,
+    struct aws_event_loop_group *el_group,
     aws_event_loop_group_cleanup_complete_fn completion_callback,
     void *user_data);
 

--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -17,6 +17,7 @@
 
 #include <aws/common/clock.h>
 #include <aws/common/system_info.h>
+#include <aws/common/thread.h>
 
 int aws_event_loop_group_init(
     struct aws_event_loop_group *el_group,
@@ -92,6 +93,51 @@ void aws_event_loop_group_clean_up(struct aws_event_loop_group *el_group) {
     }
 
     aws_array_list_clean_up(&el_group->event_loops);
+}
+
+struct aws_event_loop_group_destroy_async_data {
+    struct aws_allocator *allocator;
+    struct aws_event_loop_group *el_group;
+    aws_event_loop_group_cleanup_complete_fn *completion_callback;
+    void *user_data;
+};
+
+static void s_event_loop_destroy_async_thread_fn(void *thread_data) {
+    struct aws_event_loop_group_destroy_async_data *completion_data = thread_data;
+
+    aws_event_loop_group_clean_up(completion_data->el_group);
+
+    completion_data->completion_callback(completion_data->user_data);
+
+    aws_mem_release(completion_data->allocator, thread_data);
+}
+
+void aws_event_loop_group_cleanup_async(
+    struct aws_event_loop_group *el_group,
+    aws_event_loop_group_cleanup_complete_fn completion_callback,
+    void *user_data) {
+    struct aws_thread cleanup_thread;
+    AWS_ZERO_STRUCT(cleanup_thread);
+
+    struct aws_event_loop_group_destroy_async_data *data =
+        aws_mem_calloc(el_group->allocator, 1, sizeof(struct aws_event_loop_group_destroy_async_data));
+    AWS_FATAL_ASSERT(data != NULL);
+
+    data->allocator = el_group->allocator;
+    data->el_group = el_group;
+    data->completion_callback = completion_callback;
+    data->user_data = user_data;
+
+    AWS_FATAL_ASSERT(aws_thread_init(&cleanup_thread, el_group->allocator) == AWS_OP_SUCCESS);
+
+    struct aws_thread_options thread_options;
+    AWS_ZERO_STRUCT(thread_options);
+
+    AWS_FATAL_ASSERT(
+        aws_thread_launch(&cleanup_thread, s_event_loop_destroy_async_thread_fn, data, &thread_options) ==
+        AWS_OP_SUCCESS);
+
+    aws_thread_clean_up(&cleanup_thread);
 }
 
 size_t aws_event_loop_group_get_loop_count(struct aws_event_loop_group *el_group) {

--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -104,10 +104,11 @@ struct aws_event_loop_group_destroy_async_data {
 
 static void s_event_loop_destroy_async_thread_fn(void *thread_data) {
     struct aws_event_loop_group_destroy_async_data *completion_data = thread_data;
+    void *user_data = completion_data->user_data;
+
+    aws_thread_current_at_exit(completion_data->completion_callback, user_data);
 
     aws_event_loop_group_clean_up(completion_data->el_group);
-
-    completion_data->completion_callback(completion_data->user_data);
 
     aws_mem_release(completion_data->allocator, thread_data);
 }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -42,6 +42,7 @@ endif ()
 
 add_test_case(event_loop_stop_then_restart)
 add_test_case(event_loop_group_setup_and_shutdown)
+add_test_case(event_loop_group_setup_and_shutdown_async)
 
 add_test_case(io_testing_channel)
 

--- a/tests/event_loop_test.c
+++ b/tests/event_loop_test.c
@@ -1063,6 +1063,7 @@ static void s_async_shutdown_complete_callback(void *user_data) {
 
 static void s_async_shutdown_task(struct aws_task *task, void *user_data, enum aws_task_status status) {
     (void)task;
+    (void)status;
 
     struct task_args *args = user_data;
 

--- a/tests/event_loop_test.c
+++ b/tests/event_loop_test.c
@@ -1050,8 +1050,6 @@ static int test_event_loop_group_setup_and_shutdown(struct aws_allocator *alloca
 
 AWS_TEST_CASE(event_loop_group_setup_and_shutdown, test_event_loop_group_setup_and_shutdown)
 
-#define TEST_CPU_COUNT 8
-
 static void s_async_shutdown_complete_callback(void *user_data) {
 
     struct task_args *args = user_data;
@@ -1075,7 +1073,7 @@ static int test_event_loop_group_setup_and_shutdown_async(struct aws_allocator *
 
     (void)ctx;
     struct aws_event_loop_group event_loop_group;
-    ASSERT_SUCCESS(aws_event_loop_group_default_init(&event_loop_group, allocator, TEST_CPU_COUNT));
+    ASSERT_SUCCESS(aws_event_loop_group_default_init(&event_loop_group, allocator, 0));
 
     struct aws_event_loop *event_loop = aws_event_loop_group_get_next_loop(&event_loop_group);
 

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -987,10 +987,10 @@ struct shutdown_listener_tester {
 static void s_shutdown_listener_task(struct aws_task *task, void *arg, enum aws_task_status status) {
     (void)status;
     struct shutdown_listener_tester *tester = arg;
+    AWS_FATAL_ASSERT(aws_socket_close(&tester->client_socket) == AWS_OP_SUCCESS);
     /* destroy the listener */
     aws_server_bootstrap_destroy_socket_listener(tester->server_bootstrap, tester->listener);
     aws_mem_release(tester->outgoing_args->allocator, task);
-    AWS_FATAL_ASSERT(aws_socket_close(&tester->client_socket) == AWS_OP_SUCCESS);
 }
 
 static void s_tester_client_connection_established_fool(struct aws_socket *socket, int error_code, void *user_data) {


### PR DESCRIPTION
Allows for event loop cleanup to be safely invoked and resolved from an event loop thread.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
