### PR TITLE
aws_input_stream impl (not base) must free memory

### DIFF
--- a/include/aws/io/stream.h
+++ b/include/aws/io/stream.h
@@ -48,7 +48,7 @@ struct aws_input_stream_vtable {
     int (*read)(struct aws_input_stream *stream, struct aws_byte_buf *dest);
     int (*get_status)(struct aws_input_stream *stream, struct aws_stream_status *status);
     int (*get_length)(struct aws_input_stream *stream, int64_t *out_length);
-    void (*clean_up)(struct aws_input_stream *stream);
+    void (*destroy)(struct aws_input_stream *stream);
 };
 
 struct aws_input_stream {


### PR DESCRIPTION
If an impl class allocates memory, the impl class should free it.

renaming the vtable function to be more accurate, and to ensure downstream dependencies don't miss this change

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
