### PR TITLE
Enable clang-tidy on header files (fix broken regex)

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,7 +1,7 @@
 ---
 Checks:          'clang-diagnostic-*,clang-analyzer-*,readability-*,modernize-*,bugprone-*,misc-*,google-runtime-int,fuchsia-restrict-system-includes,-clang-analyzer-valist.Uninitialized,-clang-analyzer-security.insecureAPI.rand,-clang-analyzer-alpha.*,-readability-magic-numbers,-readability-non-const-parameter,-readability-isolate-declaration,-readability-uppercase-literal-suffix'
 WarningsAsErrors: '*'
-HeaderFilterRegex: '\./*'
+HeaderFilterRegex: '.*\.[h|inl]$'
 FormatStyle: 'file'
 # Use empty line filter to skip linting code we don't own
 CheckOptions:


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
