### PR TITLE
Wait for alert to send before continuing shutdown.

### DIFF
--- a/source/windows/iocp/socket.c
+++ b/source/windows/iocp/socket.c
@@ -405,6 +405,7 @@ void aws_socket_clean_up(struct aws_socket *socket) {
         /* protect from double clean */
         return;
     }
+
     AWS_LOGF_DEBUG(
         AWS_LS_IO_SOCKET,
         "id=%p, handle=%p: cleaning up socket.",


### PR DESCRIPTION
Make sure the outgoing TLS alert actually gets sent before letting the channel go away.

This isn't necessary on non-windows platforms, since we own the flushing logic on the underlying socket.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
