### PR TITLE
fix epoll data race

### DIFF
--- a/source/linux/epoll_event_loop.c
+++ b/source/linux/epoll_event_loop.c
@@ -406,8 +406,8 @@ static int s_subscribe_to_io_events(
     if (epoll_ctl(epoll_loop->epoll_fd, EPOLL_CTL_ADD, handle->data.fd, &epoll_event)) {
         AWS_LOGF_ERROR(
             AWS_LS_IO_EVENT_LOOP, "id=%p: failed to subscribe to events on fd %d", (void *)event_loop, handle->data.fd);
-        aws_mem_release(event_loop->alloc, epoll_event_data);
         handle->additional_data = NULL;
+        aws_mem_release(event_loop->alloc, epoll_event_data);
         return aws_raise_error(AWS_ERROR_SYS_CALL_FAILURE);
     }
 

--- a/source/linux/epoll_event_loop.c
+++ b/source/linux/epoll_event_loop.c
@@ -106,7 +106,7 @@ struct epoll_event_data {
     aws_event_loop_on_event_fn *on_event;
     void *user_data;
     struct aws_task cleanup_task;
-    bool is_subscribed; /* false when handle is unsubscribed, but this struct hasn't beeen cleaned up yet */
+    bool is_subscribed; /* false when handle is unsubscribed, but this struct hasn't been cleaned up yet */
 };
 
 /* default timeout is 100 seconds */
@@ -374,7 +374,7 @@ static int s_subscribe_to_io_events(
 
     AWS_LOGF_TRACE(AWS_LS_IO_EVENT_LOOP, "id=%p: subscribing to events on fd %d", (void *)event_loop, handle->data.fd);
     struct epoll_event_data *epoll_event_data = aws_mem_calloc(event_loop->alloc, 1, sizeof(struct epoll_event_data));
-    handle->additional_data = NULL;
+    handle->additional_data = epoll_event_data;
     if (!epoll_event_data) {
         return AWS_OP_ERR;
     }
@@ -407,10 +407,9 @@ static int s_subscribe_to_io_events(
         AWS_LOGF_ERROR(
             AWS_LS_IO_EVENT_LOOP, "id=%p: failed to subscribe to events on fd %d", (void *)event_loop, handle->data.fd);
         aws_mem_release(event_loop->alloc, epoll_event_data);
+        handle->additional_data = NULL;
         return aws_raise_error(AWS_ERROR_SYS_CALL_FAILURE);
     }
-
-    handle->additional_data = epoll_event_data;
 
     return AWS_OP_SUCCESS;
 }


### PR DESCRIPTION
@nchong-at-aws found this. Thanks Nathan!

If the user subscribes from a different thread, it was possible for the event-loop-thread to process an event before `handle->additional_data` was set.

This bug is not present in the kqueue or IOCP event-loops:
- kqueue uses a task to always do the actual subscription on the event-loop-thread.
- IOCP doesn't make use of `handle->additional_data`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
