### PR TITLE
get event loop for aws_channel

### DIFF
--- a/include/aws/io/channel.h
+++ b/include/aws/io/channel.h
@@ -204,6 +204,12 @@ AWS_IO_API
 struct aws_channel_slot *aws_channel_slot_new(struct aws_channel *channel);
 
 /**
+ * Fetches the event loop the channel is a part of.
+ */
+AWS_IO_API
+struct aws_event_loop *aws_channel_get_event_loop(struct aws_channel *channel);
+
+/**
  * Fetches the current timestamp from the event-loop's clock, in nanoseconds.
  */
 AWS_IO_API

--- a/source/channel.c
+++ b/source/channel.c
@@ -963,3 +963,7 @@ size_t aws_channel_handler_initial_window_size(struct aws_channel_handler *handl
 struct aws_channel_slot *aws_channel_get_first_slot(struct aws_channel *channel) {
     return channel->first;
 }
+
+struct aws_event_loop *aws_channel_get_event_loop(struct aws_channel *channel) {
+    return channel->loop;
+}


### PR DESCRIPTION
Adds get accessor to go from channel (hidden impl) to the owning event loop.  Needed in order to cancel tasks from a channel handler.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
