### PR TITLE
Remove non portable use of pthread_t

### DIFF
--- a/include/aws/io/event_loop.h
+++ b/include/aws/io/event_loop.h
@@ -147,6 +147,8 @@ struct aws_event_loop *aws_event_loop_new_default(struct aws_allocator *alloc, a
  * Invokes the destroy() fn for the event loop implementation.
  * If the event loop is still in a running state, this function will block waiting on the event loop to shutdown.
  * If you do not want this function to block, call aws_event_loop_stop() manually first.
+ * If the event loop is shared by multiple threads then destroy must be called by exactly one thread. All other threads
+ * must ensure their API calls to the event loop happen-before the call to destroy.
  */
 AWS_IO_API
 void aws_event_loop_destroy(struct aws_event_loop *event_loop);

--- a/source/bsd/kqueue_event_loop.c
+++ b/source/bsd/kqueue_event_loop.c
@@ -297,8 +297,8 @@ static void s_destroy(struct aws_event_loop *event_loop) {
         return;
     }
     /* setting this so that canceled tasks don't blow up when asking if they're on the event-loop thread. */
-    aws_thread_id current_thread_id = aws_thread_current_thread_id();
-    aws_atomic_store_ptr(&impl->thread_id, &current_thread_id);
+    impl->thread.thread_id = aws_thread_current_thread_id();
+    aws_atomic_store_ptr(&impl->thread_id, &impl->thread.thread_id);
 
     /* Clean up task-related stuff first. It's possible the a cancelled task adds further tasks to this event_loop.
      * Tasks added in this way will be in cross_thread_data.tasks_to_schedule, so we clean that up last */
@@ -712,7 +712,7 @@ static int s_unsubscribe_from_io_events(struct aws_event_loop *event_loop, struc
 static bool s_is_event_thread(struct aws_event_loop *event_loop) {
     struct kqueue_loop *impl = event_loop->impl_data;
 
-    aws_thread_id *thread_id = aws_atomic_load_ptr(&impl->thread_id);
+    aws_thread_id_t *thread_id = aws_atomic_load_ptr(&impl->thread_id);
     return thread_id && aws_thread_thread_id_equal(*thread_id, aws_thread_current_thread_id());
 }
 

--- a/source/bsd/kqueue_event_loop.c
+++ b/source/bsd/kqueue_event_loop.c
@@ -162,8 +162,8 @@ struct aws_event_loop *aws_event_loop_new_default(struct aws_allocator *alloc, a
     if (!impl) {
         goto clean_up;
     }
-    /* intialize thread id to 0. It will be set when the event loop thread starts. */
-    aws_atomic_init_int(&impl->thread_id, (size_t)0);
+    /* intialize thread id to NULL. It will be set when the event loop thread starts. */
+    aws_atomic_init_ptr(&impl->thread_id, NULL);
     clean_up_impl_mem = true;
 
     err = aws_thread_init(&impl->thread, alloc);
@@ -297,7 +297,8 @@ static void s_destroy(struct aws_event_loop *event_loop) {
         return;
     }
     /* setting this so that canceled tasks don't blow up when asking if they're on the event-loop thread. */
-    aws_atomic_store_int(&impl->thread_id, (size_t)aws_thread_current_thread_id());
+    aws_thread_id current_thread_id = aws_thread_current_thread_id();
+    aws_atomic_store_ptr(&impl->thread_id, &current_thread_id);
 
     /* Clean up task-related stuff first. It's possible the a cancelled task adds further tasks to this event_loop.
      * Tasks added in this way will be in cross_thread_data.tasks_to_schedule, so we clean that up last */
@@ -711,8 +712,8 @@ static int s_unsubscribe_from_io_events(struct aws_event_loop *event_loop, struc
 static bool s_is_event_thread(struct aws_event_loop *event_loop) {
     struct kqueue_loop *impl = event_loop->impl_data;
 
-    uint64_t thread_id = aws_atomic_load_int(&impl->thread_id);
-    return aws_thread_current_thread_id() == thread_id;
+    aws_thread_id *thread_id = aws_atomic_load_ptr(&impl->thread_id);
+    return thread_id && aws_thread_thread_id_equal(*thread_id, aws_thread_current_thread_id());
 }
 
 /* Called from thread.
@@ -798,7 +799,7 @@ static void s_event_thread_main(void *user_data) {
     struct kqueue_loop *impl = event_loop->impl_data;
 
     /* set thread id to the event-loop's thread. */
-    aws_atomic_store_int(&impl->thread_id, (size_t)aws_thread_current_thread_id());
+    aws_atomic_store_ptr(&impl->thread_id, &impl->thread.thread_id);
 
     AWS_ASSERT(impl->thread_data.state == EVENT_THREAD_STATE_READY_TO_RUN);
     impl->thread_data.state = EVENT_THREAD_STATE_RUNNING;
@@ -957,6 +958,6 @@ static void s_event_thread_main(void *user_data) {
     }
 
     AWS_LOGF_INFO(AWS_LS_IO_EVENT_LOOP, "id=%p: exiting main loop", (void *)event_loop);
-    /* reset to 0. This should be updated again during destroy before tasks are canceled. */
-    aws_atomic_store_int(&impl->thread_id, 0);
+    /* reset to NULL. This should be updated again during destroy before tasks are canceled. */
+    aws_atomic_store_ptr(&impl->thread_id, NULL);
 }

--- a/source/linux/epoll_event_loop.c
+++ b/source/linux/epoll_event_loop.c
@@ -135,8 +135,8 @@ struct aws_event_loop *aws_event_loop_new_default(struct aws_allocator *alloc, a
         goto cleanup_base_loop;
     }
 
-    /* initialize thread id to 0, it should be updated when the event loop thread starts. */
-    aws_atomic_init_int(&epoll_loop->thread_id, 0);
+    /* initialize thread id to NULL, it should be updated when the event loop thread starts. */
+    aws_atomic_init_ptr(&epoll_loop->thread_id, NULL);
 
     aws_linked_list_init(&epoll_loop->task_pre_queue);
     epoll_loop->task_pre_queue_mutex = (struct aws_mutex)AWS_MUTEX_INIT;
@@ -236,7 +236,8 @@ static void s_destroy(struct aws_event_loop *event_loop) {
     s_wait_for_stop_completion(event_loop);
 
     /* setting this so that canceled tasks don't blow up when asking if they're on the event-loop thread. */
-    aws_atomic_store_int(&epoll_loop->thread_id, (size_t)aws_thread_current_thread_id());
+    aws_thread_id current_thread_id = aws_thread_current_thread_id();
+    aws_atomic_store_ptr(&epoll_loop->thread_id, &current_thread_id);
     aws_task_scheduler_clean_up(&epoll_loop->scheduler);
 
     while (!aws_linked_list_empty(&epoll_loop->task_pre_queue)) {
@@ -474,8 +475,8 @@ static int s_unsubscribe_from_io_events(struct aws_event_loop *event_loop, struc
 static bool s_is_on_callers_thread(struct aws_event_loop *event_loop) {
     struct epoll_loop *epoll_loop = event_loop->impl_data;
 
-    uint64_t thread_id = aws_atomic_load_int(&epoll_loop->thread_id);
-    return aws_thread_current_thread_id() == thread_id;
+    aws_thread_id *thread_id = aws_atomic_load_ptr(&epoll_loop->thread_id);
+    return thread_id && aws_thread_thread_id_equal(*thread_id, aws_thread_current_thread_id());
 }
 
 /* We treat the pipe fd with a subscription to io events just like any other managed file descriptor.
@@ -545,7 +546,7 @@ static void s_main_loop(void *args) {
     struct epoll_loop *epoll_loop = event_loop->impl_data;
 
     /* set thread id to the thread of the event loop */
-    aws_atomic_store_int(&epoll_loop->thread_id, (size_t)aws_thread_current_thread_id());
+    aws_atomic_store_ptr(&epoll_loop->thread_id, &epoll_loop->thread.thread_id);
 
     int err = s_subscribe_to_io_events(
         event_loop, &epoll_loop->read_task_handle, AWS_IO_EVENT_TYPE_READABLE, s_on_tasks_to_schedule, NULL);
@@ -658,6 +659,6 @@ static void s_main_loop(void *args) {
 
     AWS_LOGF_DEBUG(AWS_LS_IO_EVENT_LOOP, "id=%p: exiting main loop", (void *)event_loop);
     s_unsubscribe_from_io_events(event_loop, &epoll_loop->read_task_handle);
-    /* set thread id back to 0. This should be updated again in destroy, before tasks are canceled. */
-    aws_atomic_store_int(&epoll_loop->thread_id, (size_t)0);
+    /* set thread id back to NULL. This should be updated again in destroy, before tasks are canceled. */
+    aws_atomic_store_ptr(&epoll_loop->thread_id, NULL);
 }

--- a/source/linux/epoll_event_loop.c
+++ b/source/linux/epoll_event_loop.c
@@ -236,8 +236,8 @@ static void s_destroy(struct aws_event_loop *event_loop) {
     s_wait_for_stop_completion(event_loop);
 
     /* setting this so that canceled tasks don't blow up when asking if they're on the event-loop thread. */
-    aws_thread_id current_thread_id = aws_thread_current_thread_id();
-    aws_atomic_store_ptr(&epoll_loop->thread_id, &current_thread_id);
+    epoll_loop->thread.thread_id = aws_thread_current_thread_id();
+    aws_atomic_store_ptr(&epoll_loop->thread_id, &epoll_loop->thread.thread_id);
     aws_task_scheduler_clean_up(&epoll_loop->scheduler);
 
     while (!aws_linked_list_empty(&epoll_loop->task_pre_queue)) {
@@ -475,7 +475,7 @@ static int s_unsubscribe_from_io_events(struct aws_event_loop *event_loop, struc
 static bool s_is_on_callers_thread(struct aws_event_loop *event_loop) {
     struct epoll_loop *epoll_loop = event_loop->impl_data;
 
-    aws_thread_id *thread_id = aws_atomic_load_ptr(&epoll_loop->thread_id);
+    aws_thread_id_t *thread_id = aws_atomic_load_ptr(&epoll_loop->thread_id);
     return thread_id && aws_thread_thread_id_equal(*thread_id, aws_thread_current_thread_id());
 }
 

--- a/source/linux/epoll_event_loop.c
+++ b/source/linux/epoll_event_loop.c
@@ -88,8 +88,9 @@ static struct aws_event_loop_vtable s_vtable = {
 
 struct epoll_loop {
     struct aws_task_scheduler scheduler;
-    struct aws_thread thread;
-    struct aws_atomic_var thread_id;
+    struct aws_thread thread_created_on;
+    aws_thread_id_t thread_joined_to;
+    struct aws_atomic_var running_thread_id;
     struct aws_io_handle read_task_handle;
     struct aws_io_handle write_task_handle;
     struct aws_mutex task_pre_queue_mutex;
@@ -136,7 +137,7 @@ struct aws_event_loop *aws_event_loop_new_default(struct aws_allocator *alloc, a
     }
 
     /* initialize thread id to NULL, it should be updated when the event loop thread starts. */
-    aws_atomic_init_ptr(&epoll_loop->thread_id, NULL);
+    aws_atomic_init_ptr(&epoll_loop->running_thread_id, NULL);
 
     aws_linked_list_init(&epoll_loop->task_pre_queue);
     epoll_loop->task_pre_queue_mutex = (struct aws_mutex)AWS_MUTEX_INIT;
@@ -149,7 +150,7 @@ struct aws_event_loop *aws_event_loop_new_default(struct aws_allocator *alloc, a
         goto clean_up_epoll;
     }
 
-    if (aws_thread_init(&epoll_loop->thread, alloc)) {
+    if (aws_thread_init(&epoll_loop->thread_created_on, alloc)) {
         goto clean_up_epoll;
     }
 
@@ -207,7 +208,7 @@ clean_up_pipe:
 #endif
 
 clean_up_thread:
-    aws_thread_clean_up(&epoll_loop->thread);
+    aws_thread_clean_up(&epoll_loop->thread_created_on);
 
 clean_up_epoll:
     if (epoll_loop->epoll_fd >= 0) {
@@ -236,8 +237,8 @@ static void s_destroy(struct aws_event_loop *event_loop) {
     s_wait_for_stop_completion(event_loop);
 
     /* setting this so that canceled tasks don't blow up when asking if they're on the event-loop thread. */
-    epoll_loop->thread.thread_id = aws_thread_current_thread_id();
-    aws_atomic_store_ptr(&epoll_loop->thread_id, &epoll_loop->thread.thread_id);
+    epoll_loop->thread_joined_to = aws_thread_current_thread_id();
+    aws_atomic_store_ptr(&epoll_loop->running_thread_id, &epoll_loop->thread_joined_to);
     aws_task_scheduler_clean_up(&epoll_loop->scheduler);
 
     while (!aws_linked_list_empty(&epoll_loop->task_pre_queue)) {
@@ -246,7 +247,7 @@ static void s_destroy(struct aws_event_loop *event_loop) {
         task->fn(task, task->arg, AWS_TASK_STATUS_CANCELED);
     }
 
-    aws_thread_clean_up(&epoll_loop->thread);
+    aws_thread_clean_up(&epoll_loop->thread_created_on);
 #if USE_EFD
     close(epoll_loop->write_task_handle.data.fd);
     epoll_loop->write_task_handle.data.fd = -1;
@@ -268,7 +269,7 @@ static int s_run(struct aws_event_loop *event_loop) {
     AWS_LOGF_INFO(AWS_LS_IO_EVENT_LOOP, "id=%p: Starting event-loop thread.", (void *)event_loop);
 
     epoll_loop->should_continue = true;
-    if (aws_thread_launch(&epoll_loop->thread, &s_main_loop, event_loop, NULL)) {
+    if (aws_thread_launch(&epoll_loop->thread_created_on, &s_main_loop, event_loop, NULL)) {
         AWS_LOGF_FATAL(AWS_LS_IO_EVENT_LOOP, "id=%p: thread creation failed.", (void *)event_loop);
         epoll_loop->should_continue = false;
         return AWS_OP_ERR;
@@ -312,7 +313,7 @@ static int s_stop(struct aws_event_loop *event_loop) {
 
 static int s_wait_for_stop_completion(struct aws_event_loop *event_loop) {
     struct epoll_loop *epoll_loop = event_loop->impl_data;
-    return aws_thread_join(&epoll_loop->thread);
+    return aws_thread_join(&epoll_loop->thread_created_on);
 }
 
 static void s_schedule_task_common(struct aws_event_loop *event_loop, struct aws_task *task, uint64_t run_at_nanos) {
@@ -475,7 +476,7 @@ static int s_unsubscribe_from_io_events(struct aws_event_loop *event_loop, struc
 static bool s_is_on_callers_thread(struct aws_event_loop *event_loop) {
     struct epoll_loop *epoll_loop = event_loop->impl_data;
 
-    aws_thread_id_t *thread_id = aws_atomic_load_ptr(&epoll_loop->thread_id);
+    aws_thread_id_t *thread_id = aws_atomic_load_ptr(&epoll_loop->running_thread_id);
     return thread_id && aws_thread_thread_id_equal(*thread_id, aws_thread_current_thread_id());
 }
 
@@ -546,7 +547,7 @@ static void s_main_loop(void *args) {
     struct epoll_loop *epoll_loop = event_loop->impl_data;
 
     /* set thread id to the thread of the event loop */
-    aws_atomic_store_ptr(&epoll_loop->thread_id, &epoll_loop->thread.thread_id);
+    aws_atomic_store_ptr(&epoll_loop->running_thread_id, &epoll_loop->thread_created_on.thread_id);
 
     int err = s_subscribe_to_io_events(
         event_loop, &epoll_loop->read_task_handle, AWS_IO_EVENT_TYPE_READABLE, s_on_tasks_to_schedule, NULL);
@@ -660,5 +661,5 @@ static void s_main_loop(void *args) {
     AWS_LOGF_DEBUG(AWS_LS_IO_EVENT_LOOP, "id=%p: exiting main loop", (void *)event_loop);
     s_unsubscribe_from_io_events(event_loop, &epoll_loop->read_task_handle);
     /* set thread id back to NULL. This should be updated again in destroy, before tasks are canceled. */
-    aws_atomic_store_ptr(&epoll_loop->thread_id, NULL);
+    aws_atomic_store_ptr(&epoll_loop->running_thread_id, NULL);
 }

--- a/source/windows/iocp/iocp_event_loop.c
+++ b/source/windows/iocp/iocp_event_loop.c
@@ -192,8 +192,8 @@ struct aws_event_loop *aws_event_loop_new_default(struct aws_allocator *alloc, a
         goto clean_up;
     }
 
-    /* initialize thread id to 0. This will be updated once the event loop thread starts. */
-    aws_atomic_init_int(&impl->thread_id, 0);
+    /* initialize thread id to NULL. This will be updated once the event loop thread starts. */
+    aws_atomic_init_ptr(&impl->thread_id, NULL);
 
     impl->iocp_handle = CreateIoCompletionPort(
         INVALID_HANDLE_VALUE, /* FileHandle: passing invalid handle creates a new IOCP */
@@ -290,7 +290,8 @@ static void s_destroy(struct aws_event_loop *event_loop) {
     }
 
     /* setting this so that canceled tasks don't blow up when asking if they're on the event-loop thread. */
-    aws_atomic_store_int(&impl->thread_id, (size_t)aws_thread_current_thread_id());
+    aws_thread_id current_thread_id = aws_thread_current_thread_id();
+    aws_atomic_store_ptr(&impl->thread_id, &current_thread_id);
 
     /* Clean up task-related stuff first.
      * It's possible the a cancelled task adds further tasks to this event_loop, these new tasks would end up in
@@ -483,8 +484,8 @@ static bool s_is_event_thread(struct aws_event_loop *event_loop) {
     struct iocp_loop *impl = event_loop->impl_data;
     AWS_ASSERT(impl);
 
-    uint64_t el_thread_id = aws_atomic_load_int(&impl->thread_id);
-    return el_thread_id == aws_thread_current_thread_id();
+    aws_thread_id *el_thread_id = aws_atomic_load_ptr(&impl->thread_id);
+    return el_thread_id && aws_thread_thread_id_equal(*el_thread_id, aws_thread_current_thread_id());
 }
 
 /* Called from any thread */
@@ -617,7 +618,7 @@ static void s_event_thread_main(void *user_data) {
     struct iocp_loop *impl = event_loop->impl_data;
 
     /* Set thread id to event loop thread id. */
-    aws_atomic_store_int(&impl->thread_id, (size_t)aws_thread_current_thread_id());
+    aws_atomic_store_ptr(&impl->thread_id, &impl->thread.thread_id);
 
     AWS_ASSERT(impl->thread_data.state == EVENT_THREAD_STATE_READY_TO_RUN);
     impl->thread_data.state = EVENT_THREAD_STATE_RUNNING;
@@ -721,6 +722,6 @@ static void s_event_thread_main(void *user_data) {
         }
     }
     AWS_LOGF_DEBUG(AWS_LS_IO_EVENT_LOOP, "id=%p: exiting main loop", (void *)event_loop);
-    /* set back to 0. This should be updated again in destroy, right before task cancelation happens. */
-    aws_atomic_store_int(&impl->thread_id, (size_t)0);
+    /* set back to NULL. This should be updated again in destroy, right before task cancelation happens. */
+    aws_atomic_store_ptr(&impl->thread_id, NULL);
 }

--- a/source/windows/iocp/iocp_event_loop.c
+++ b/source/windows/iocp/iocp_event_loop.c
@@ -290,8 +290,8 @@ static void s_destroy(struct aws_event_loop *event_loop) {
     }
 
     /* setting this so that canceled tasks don't blow up when asking if they're on the event-loop thread. */
-    aws_thread_id current_thread_id = aws_thread_current_thread_id();
-    aws_atomic_store_ptr(&impl->thread_id, &current_thread_id);
+    impl->thread.thread_id = aws_thread_current_thread_id();
+    aws_atomic_store_ptr(&impl->thread_id, &impl->thread.thread_id);
 
     /* Clean up task-related stuff first.
      * It's possible the a cancelled task adds further tasks to this event_loop, these new tasks would end up in
@@ -484,7 +484,7 @@ static bool s_is_event_thread(struct aws_event_loop *event_loop) {
     struct iocp_loop *impl = event_loop->impl_data;
     AWS_ASSERT(impl);
 
-    aws_thread_id *el_thread_id = aws_atomic_load_ptr(&impl->thread_id);
+    aws_thread_id_t *el_thread_id = aws_atomic_load_ptr(&impl->thread_id);
     return el_thread_id && aws_thread_thread_id_equal(*el_thread_id, aws_thread_current_thread_id());
 }
 

--- a/tests/event_loop_test.c
+++ b/tests/event_loop_test.c
@@ -25,7 +25,7 @@
 struct task_args {
     bool invoked;
     bool was_in_thread;
-    uint64_t thread_id;
+    aws_thread_id thread_id;
     struct aws_event_loop *loop;
     struct aws_event_loop_group *el_group;
     enum aws_task_status status;
@@ -85,7 +85,7 @@ static int s_test_event_loop_xthread_scheduled_tasks_execute(struct aws_allocato
     ASSERT_TRUE(task_args.invoked);
     aws_mutex_unlock(&task_args.mutex);
 
-    ASSERT_FALSE(task_args.thread_id == aws_thread_current_thread_id());
+    ASSERT_FALSE(aws_thread_thread_id_equal(task_args.thread_id, aws_thread_current_thread_id()));
 
     /* Test "now" tasks */
     task_args.invoked = false;
@@ -152,7 +152,7 @@ static int s_test_event_loop_canceled_tasks_run_in_el_thread(struct aws_allocato
         &task1_args.condition_variable, &task1_args.mutex, s_task_ran_predicate, &task1_args));
     ASSERT_TRUE(task1_args.invoked);
     ASSERT_TRUE(task1_args.was_in_thread);
-    ASSERT_FALSE(task1_args.thread_id == aws_thread_current_thread_id());
+    ASSERT_FALSE(aws_thread_thread_id_equal(task1_args.thread_id, aws_thread_current_thread_id()));
     ASSERT_INT_EQUALS(AWS_TASK_STATUS_RUN_READY, task1_args.status);
     aws_mutex_unlock(&task1_args.mutex);
 
@@ -166,7 +166,7 @@ static int s_test_event_loop_canceled_tasks_run_in_el_thread(struct aws_allocato
     aws_mutex_unlock(&task2_args.mutex);
 
     ASSERT_TRUE(task2_args.was_in_thread);
-    ASSERT_TRUE(task2_args.thread_id == aws_thread_current_thread_id());
+    ASSERT_TRUE(aws_thread_thread_id_equal(task2_args.thread_id, aws_thread_current_thread_id()));
     ASSERT_INT_EQUALS(AWS_TASK_STATUS_CANCELED, task2_args.status);
 
     return AWS_OP_SUCCESS;

--- a/tests/event_loop_test.c
+++ b/tests/event_loop_test.c
@@ -25,7 +25,7 @@
 struct task_args {
     bool invoked;
     bool was_in_thread;
-    aws_thread_id thread_id;
+    aws_thread_id_t thread_id;
     struct aws_event_loop *loop;
     struct aws_event_loop_group *el_group;
     enum aws_task_status status;


### PR DESCRIPTION
*Issue #, if available:* #217 

*Description of changes:*

Use portable thread id comparison functions from proposed c common changes

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
