### PR TITLE
Fix ThreadSan failures

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,9 +76,9 @@ add_test_case(channel_cancels_pending_tasks)
 add_test_case(channel_duplicate_shutdown)
 add_net_test_case(channel_connect_some_hosts_timeout)
 
-#if (NOT WIN32)
-#    add_test_case(channel_message_passing)
-#endif ()
+if (NOT WIN32)
+    add_test_case(channel_message_passing)
+endif ()
 
 add_net_test_case(test_default_with_ipv6_lookup)
 add_test_case(test_resolver_ipv6_address_lookup)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -76,9 +76,9 @@ add_test_case(channel_cancels_pending_tasks)
 add_test_case(channel_duplicate_shutdown)
 add_net_test_case(channel_connect_some_hosts_timeout)
 
-if (NOT WIN32)
-    add_test_case(channel_message_passing)
-endif ()
+#if (NOT WIN32)
+#    add_test_case(channel_message_passing)
+#endif ()
 
 add_net_test_case(test_default_with_ipv6_lookup)
 add_test_case(test_resolver_ipv6_address_lookup)

--- a/tests/channel_test.c
+++ b/tests/channel_test.c
@@ -299,7 +299,7 @@ struct channel_rw_test_args {
     bool write_on_read;
     struct aws_condition_variable *condition_variable;
 };
-#if 0
+
 static bool s_rw_test_shutdown_predicate(void *arg) {
     struct channel_rw_test_args *rw_test_args = (struct channel_rw_test_args *)arg;
     return aws_atomic_load_int(&rw_test_args->shutdown_completed);
@@ -390,6 +390,7 @@ static int s_test_channel_message_passing(struct aws_allocator *allocator, void 
     struct aws_condition_variable shutdown_condition = AWS_CONDITION_VARIABLE_INIT;
     struct aws_mutex shutdown_mutex = AWS_MUTEX_INIT;
 
+    ASSERT_SUCCESS(aws_mutex_lock(&shutdown_mutex));
     struct channel_rw_test_args handler_1_args = {
         .shutdown_completed = AWS_ATOMIC_INIT_INT(false),
         .latest_message = aws_byte_buf_from_array(handler_1_latest_message, sizeof(handler_1_latest_message)),
@@ -484,7 +485,6 @@ static int s_test_channel_message_passing(struct aws_allocator *allocator, void 
 }
 
 AWS_TEST_CASE(channel_message_passing, s_test_channel_message_passing)
-#endif
 
 static void s_channel_post_shutdown_task(struct aws_channel_task *task, void *arg, enum aws_task_status status) {
     (void)task;

--- a/tests/channel_test.c
+++ b/tests/channel_test.c
@@ -206,18 +206,17 @@ static void s_wait_a_bit_task(struct aws_task *task, void *arg, enum aws_task_st
     aws_condition_variable_notify_one(cv);
 }
 
-static int s_wait_a_bit(struct aws_event_loop *loop) {
+static int s_wait_a_bit(struct aws_event_loop *loop, struct aws_task *task) {
     struct aws_mutex mutex = AWS_MUTEX_INIT;
     struct aws_condition_variable cv = AWS_CONDITION_VARIABLE_INIT;
     ASSERT_SUCCESS(aws_mutex_lock(&mutex));
 
-    struct aws_task task;
-    aws_task_init(&task, s_wait_a_bit_task, &cv, "wait_a_bit");
+    aws_task_init(task, s_wait_a_bit_task, &cv, "wait_a_bit");
 
     uint64_t run_at_ns;
     ASSERT_SUCCESS(aws_event_loop_current_clock_time(loop, &run_at_ns));
     run_at_ns += aws_timestamp_convert(1, AWS_TIMESTAMP_SECS, AWS_TIMESTAMP_NANOS, NULL);
-    aws_event_loop_schedule_task_future(loop, &task, run_at_ns);
+    aws_event_loop_schedule_task_future(loop, task, run_at_ns);
 
     return aws_condition_variable_wait(&cv, &mutex);
 }
@@ -271,12 +270,14 @@ static int s_test_channel_refcount(struct aws_allocator *allocator, void *ctx) {
     aws_channel_acquire_hold(channel);
     aws_channel_acquire_hold(channel);
     aws_channel_destroy(channel);
-    ASSERT_SUCCESS(s_wait_a_bit(event_loop));
+    struct aws_task task1;
+    ASSERT_SUCCESS(s_wait_a_bit(event_loop, &task1));
     ASSERT_FALSE(aws_atomic_load_int(&destroy_called));
 
     /* Release hold 1/2. Handler shouldn't get destroyed. */
     aws_channel_release_hold(channel);
-    ASSERT_SUCCESS(s_wait_a_bit(event_loop));
+    struct aws_task task2;
+    ASSERT_SUCCESS(s_wait_a_bit(event_loop, &task2));
     ASSERT_FALSE(aws_atomic_load_int(&destroy_called));
 
     /* Release hold 2/2. The handler and channel should be destroyed. */
@@ -294,14 +295,14 @@ struct channel_rw_test_args {
     struct aws_byte_buf read_tag;
     struct aws_byte_buf write_tag;
     struct aws_byte_buf latest_message;
-    bool shutdown_completed;
+    struct aws_atomic_var shutdown_completed;
     bool write_on_read;
     struct aws_condition_variable *condition_variable;
 };
-
+#if 0
 static bool s_rw_test_shutdown_predicate(void *arg) {
     struct channel_rw_test_args *rw_test_args = (struct channel_rw_test_args *)arg;
-    return rw_test_args->shutdown_completed;
+    return aws_atomic_load_int(&rw_test_args->shutdown_completed);
 }
 
 static void s_rw_test_on_shutdown_completed(struct aws_channel *channel, int error_code, void *user_data) {
@@ -309,7 +310,7 @@ static void s_rw_test_on_shutdown_completed(struct aws_channel *channel, int err
     (void)error_code;
     struct channel_rw_test_args *rw_test_args = (struct channel_rw_test_args *)user_data;
 
-    rw_test_args->shutdown_completed = true;
+    aws_atomic_store_int(&rw_test_args->shutdown_completed, true);
 
     if (rw_test_args->condition_variable) {
         aws_condition_variable_notify_one(rw_test_args->condition_variable);
@@ -390,7 +391,7 @@ static int s_test_channel_message_passing(struct aws_allocator *allocator, void 
     struct aws_mutex shutdown_mutex = AWS_MUTEX_INIT;
 
     struct channel_rw_test_args handler_1_args = {
-        .shutdown_completed = false,
+        .shutdown_completed = AWS_ATOMIC_INIT_INT(false),
         .latest_message = aws_byte_buf_from_array(handler_1_latest_message, sizeof(handler_1_latest_message)),
 
         .read_tag = aws_byte_buf_from_c_str("handler 1 read, "),
@@ -401,7 +402,7 @@ static int s_test_channel_message_passing(struct aws_allocator *allocator, void 
     };
 
     struct channel_rw_test_args handler_3_args = {
-        .shutdown_completed = false,
+        .shutdown_completed = AWS_ATOMIC_INIT_INT(false),
         .latest_message = aws_byte_buf_from_array(handler_3_latest_message, sizeof(handler_1_latest_message)),
         .read_tag = aws_byte_buf_from_c_str("handler 3 read, "),
         .write_tag = aws_byte_buf_from_c_str("handler 3 written, "),
@@ -439,7 +440,7 @@ static int s_test_channel_message_passing(struct aws_allocator *allocator, void 
     ASSERT_SUCCESS(aws_channel_slot_set_handler(slot_1, handler_1));
 
     struct channel_rw_test_args handler_2_args = {
-        .shutdown_completed = false,
+        .shutdown_completed = AWS_ATOMIC_INIT_INT(false),
         .latest_message = aws_byte_buf_from_array(handler_2_latest_message, sizeof(handler_1_latest_message)),
         .read_tag = aws_byte_buf_from_c_str("handler 2 read, "),
         .write_tag = aws_byte_buf_from_c_str("handler 2 written, "),
@@ -468,7 +469,7 @@ static int s_test_channel_message_passing(struct aws_allocator *allocator, void 
     ASSERT_SUCCESS(aws_condition_variable_wait_pred(
         &shutdown_condition, &shutdown_mutex, s_rw_test_shutdown_predicate, &handler_1_args));
 
-    ASSERT_TRUE(handler_1_args.shutdown_completed);
+    ASSERT_TRUE(aws_atomic_load_int(&handler_1_args.shutdown_completed));
 
     ASSERT_TRUE(rw_handler_shutdown_called(handler_1));
     ASSERT_TRUE(rw_handler_shutdown_called(handler_2));
@@ -483,6 +484,7 @@ static int s_test_channel_message_passing(struct aws_allocator *allocator, void 
 }
 
 AWS_TEST_CASE(channel_message_passing, s_test_channel_message_passing)
+#endif
 
 static void s_channel_post_shutdown_task(struct aws_channel_task *task, void *arg, enum aws_task_status status) {
     (void)task;

--- a/tests/event_loop_test.c
+++ b/tests/event_loop_test.c
@@ -158,7 +158,7 @@ static int s_test_event_loop_canceled_tasks_run_in_el_thread(struct aws_allocato
 
     aws_event_loop_destroy(event_loop);
 
-    aws_mutex_lock(&task1_args.mutex);
+    aws_mutex_lock(&task2_args.mutex);
 
     ASSERT_SUCCESS(aws_condition_variable_wait_pred(
         &task2_args.condition_variable, &task2_args.mutex, s_test_cancel_thread_task_predicate, &task2_args));

--- a/tests/socket_handler_test.c
+++ b/tests/socket_handler_test.c
@@ -17,6 +17,7 @@
 #include <aws/io/socket.h>
 #include <aws/io/socket_channel_handler.h>
 
+#include <aws/common/atomics.h>
 #include <aws/common/clock.h>
 #include <aws/common/condition_variable.h>
 
@@ -36,7 +37,8 @@ struct socket_test_args {
     struct aws_condition_variable *condition_variable;
     struct aws_channel *channel;
     struct aws_channel_handler *rw_handler;
-    struct aws_channel_slot *rw_slot;
+
+    struct aws_atomic_var rw_slot; /* pointer-to struct aws_channel_slot */
     int error_code;
     bool shutdown_invoked;
     bool error_invoked;
@@ -77,7 +79,7 @@ struct local_server_tester {
 
 static bool s_channel_setup_predicate(void *user_data) {
     struct socket_test_args *setup_test_args = (struct socket_test_args *)user_data;
-    return setup_test_args->rw_slot != NULL;
+    return aws_atomic_load_ptr(&setup_test_args->rw_slot) != NULL;
 }
 
 static bool s_channel_shutdown_predicate(void *user_data) {
@@ -109,7 +111,7 @@ static void s_socket_handler_test_client_setup_callback(
     aws_channel_slot_insert_end(channel, rw_slot);
 
     aws_channel_slot_set_handler(rw_slot, setup_test_args->rw_handler);
-    setup_test_args->rw_slot = rw_slot;
+    aws_atomic_store_ptr(&setup_test_args->rw_slot, rw_slot);
 
     aws_condition_variable_notify_one(setup_test_args->condition_variable);
 }
@@ -131,7 +133,7 @@ static void s_socket_handler_test_server_setup_callback(
     aws_channel_slot_insert_end(channel, rw_slot);
 
     aws_channel_slot_set_handler(rw_slot, setup_test_args->rw_handler);
-    setup_test_args->rw_slot = rw_slot;
+    aws_atomic_store_ptr(&setup_test_args->rw_slot, rw_slot);
 
     aws_condition_variable_notify_one(setup_test_args->condition_variable);
 }
@@ -384,11 +386,11 @@ static int s_socket_echo_and_backpressure_test(struct aws_allocator *allocator, 
     ASSERT_SUCCESS(aws_condition_variable_wait_pred(
         &c_tester.condition_variable, &c_tester.mutex, s_channel_setup_predicate, &outgoing_args));
 
-    rw_handler_write(outgoing_args.rw_handler, outgoing_args.rw_slot, &write_tag);
+    rw_handler_write(outgoing_args.rw_handler, aws_atomic_load_ptr(&outgoing_args.rw_slot), &write_tag);
     ASSERT_SUCCESS(aws_condition_variable_wait_pred(
         &c_tester.condition_variable, &c_tester.mutex, s_socket_test_read_predicate, &incoming_rw_args));
 
-    rw_handler_write(incoming_args.rw_handler, incoming_args.rw_slot, &read_tag);
+    rw_handler_write(incoming_args.rw_handler, aws_atomic_load_ptr(&incoming_args.rw_slot), &read_tag);
     ASSERT_SUCCESS(aws_condition_variable_wait_pred(
         &c_tester.condition_variable, &c_tester.mutex, s_socket_test_read_predicate, &outgoing_rw_args));
     incoming_rw_args.invocation_happened = false;
@@ -398,11 +400,13 @@ static int s_socket_echo_and_backpressure_test(struct aws_allocator *allocator, 
     ASSERT_INT_EQUALS(s_incoming_initial_read_window, incoming_rw_args.amount_read);
 
     /* Go ahead and verify back-pressure works*/
-    rw_handler_trigger_increment_read_window(incoming_args.rw_handler, incoming_args.rw_slot, 100);
+    rw_handler_trigger_increment_read_window(
+        incoming_args.rw_handler, aws_atomic_load_ptr(&incoming_args.rw_slot), 100);
     ASSERT_SUCCESS(aws_condition_variable_wait_pred(
         &c_tester.condition_variable, &c_tester.mutex, s_socket_test_full_read_predicate, &incoming_rw_args));
 
-    rw_handler_trigger_increment_read_window(outgoing_args.rw_handler, outgoing_args.rw_slot, 100);
+    rw_handler_trigger_increment_read_window(
+        outgoing_args.rw_handler, aws_atomic_load_ptr(&outgoing_args.rw_slot), 100);
     ASSERT_SUCCESS(aws_condition_variable_wait_pred(
         &c_tester.condition_variable, &c_tester.mutex, s_socket_test_full_read_predicate, &outgoing_rw_args));
 


### PR DESCRIPTION
*Issue #, if available:* 220

*Description of changes:*

- Fix missing lock in channel_message_passing
- Fix mismatched lock/unlock in event_loop_test
- Fix racy reuse of aws_task in channel_test
- Make following variables atomic
   - keep_active in host_resolver
   - last_use in host_resolver
   - shutdown_called in read_write_test_handler
   - shutdown_completed in channel_test
   - rw_slot in socker_handler_test

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
