### PR TITLE
Fix use of condvar and mutex

### DIFF
--- a/source/posix/socket.c
+++ b/source/posix/socket.c
@@ -1045,6 +1045,7 @@ int aws_socket_stop_accept(struct aws_socket *socket) {
         aws_mutex_lock(&args.mutex);
         aws_event_loop_schedule_task_now(socket->event_loop, &args.task);
         aws_condition_variable_wait_pred(&args.condition_variable, &args.mutex, s_stop_accept_pred, &args);
+        aws_mutex_unlock(&args.mutex);
         AWS_LOGF_INFO(
             AWS_LS_IO_SOCKET,
             "id=%p fd=%d: stop accept task finished running.",
@@ -1237,6 +1238,7 @@ int aws_socket_close(struct aws_socket *socket) {
             aws_mutex_lock(&args.mutex);
             aws_event_loop_schedule_task_now(socket->event_loop, &close_task);
             aws_condition_variable_wait_pred(&args.condition_variable, &args.mutex, s_close_predicate, &args);
+            aws_mutex_unlock(&args.mutex);
             AWS_LOGF_INFO(
                 AWS_LS_IO_SOCKET, "id=%p fd=%d: close task completed.", (void *)socket, socket->io_handle.data.fd);
             if (args.ret_code) {

--- a/source/windows/iocp/socket.c
+++ b/source/windows/iocp/socket.c
@@ -2018,6 +2018,7 @@ static int s_stream_stop_accept(struct aws_socket *socket) {
         aws_mutex_lock(&args.mutex);
         aws_event_loop_schedule_task_now(socket->event_loop, &stop_accept_task);
         aws_condition_variable_wait_pred(&args.condition_var, &args.mutex, s_stop_accept_predicate, &args);
+        aws_mutex_unlock(&args.mutex);
         AWS_LOGF_DEBUG(
             AWS_LS_IO_SOCKET,
             "id=%p handle=%p: accept shutdown completed",
@@ -2341,6 +2342,7 @@ static int s_wait_on_close(struct aws_socket *socket) {
     aws_mutex_lock(&args.mutex);
     aws_event_loop_schedule_task_now(socket->event_loop, &close_task);
     aws_condition_variable_wait_pred(&args.condition_var, &args.mutex, s_close_predicate, &args);
+    aws_mutex_unlock(&args.mutex);
     AWS_LOGF_INFO(
         AWS_LS_IO_SOCKET,
         "id=%p handle=%p: close task completed.",

--- a/tests/event_loop_test.c
+++ b/tests/event_loop_test.c
@@ -1113,6 +1113,7 @@ static int test_event_loop_group_setup_and_shutdown_async(struct aws_allocator *
                                   .loop = event_loop,
                                   .el_group = &event_loop_group,
                                   .thread_id = 0};
+    aws_atomic_init_int(&task_args.thread_complete, false);
 
     struct aws_task task;
     aws_task_init(&task, s_async_shutdown_task, &task_args, "async elg shutdown invoked from an event loop thread");

--- a/tests/read_write_test_handler.c
+++ b/tests/read_write_test_handler.c
@@ -302,14 +302,3 @@ int rw_handler_last_error_code(struct aws_channel_handler *handler) {
     struct rw_test_handler_impl *handler_impl = handler->impl;
     return aws_atomic_load_int(&handler_impl->shutdown_error);
 }
-
-static bool s_rw_test_handler_shutdown_predicate(void *arg) {
-    struct rw_test_handler_impl *handler_impl = arg;
-    return aws_atomic_load_int(&handler_impl->shutdown_called);
-}
-
-int rw_handler_wait_on_shutdown(struct aws_channel_handler *handler) {
-    struct rw_test_handler_impl *handler_impl = handler->impl;
-    return aws_condition_variable_wait_pred(
-        &handler_impl->condition_variable, &handler_impl->mutex, s_rw_test_handler_shutdown_predicate, handler_impl);
-}

--- a/tests/read_write_test_handler.h
+++ b/tests/read_write_test_handler.h
@@ -61,6 +61,4 @@ void increment_read_window_task(void *arg, enum aws_task_status task_status);
 
 int rw_handler_last_error_code(struct aws_channel_handler *handler);
 
-int rw_handler_wait_on_shutdown(struct aws_channel_handler *handler);
-
 #endif /* AWS_READ_WRITE_TEST_HANDLER */

--- a/tests/socket_handler_test.c
+++ b/tests/socket_handler_test.c
@@ -61,6 +61,7 @@ static struct socket_common_tester c_tester;
 
 static int s_socket_common_tester_init(struct aws_allocator *allocator, struct socket_common_tester *tester) {
     AWS_ZERO_STRUCT(*tester);
+    aws_io_library_init(allocator);
     ASSERT_SUCCESS(aws_event_loop_group_default_init(&tester->el_group, allocator, 0));
     struct aws_mutex mutex = AWS_MUTEX_INIT;
     struct aws_condition_variable condition_variable = AWS_CONDITION_VARIABLE_INIT;
@@ -68,8 +69,6 @@ static int s_socket_common_tester_init(struct aws_allocator *allocator, struct s
     tester->condition_variable = condition_variable;
     aws_atomic_store_int(&tester->current_time_ns, 0);
     aws_atomic_store_ptr(&tester->stats_handler, NULL);
-
-    aws_io_library_init(allocator);
 
     return AWS_OP_SUCCESS;
 }

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -482,7 +482,6 @@ static int s_tls_channel_echo_and_backpressure_test_fn(struct aws_allocator *all
     ASSERT_SUCCESS(aws_condition_variable_wait_pred(
         &c_tester.condition_variable, &c_tester.mutex, s_tls_channel_setup_predicate, &incoming_args));
     ASSERT_SUCCESS(aws_mutex_unlock(&c_tester.mutex));
-
     ASSERT_FALSE(incoming_args.error_invoked);
 
 /* currently it seems ALPN doesn't work in server mode. Just leaving this check out for now. */
@@ -503,7 +502,6 @@ static int s_tls_channel_echo_and_backpressure_test_fn(struct aws_allocator *all
     ASSERT_SUCCESS(aws_condition_variable_wait_pred(
         &c_tester.condition_variable, &c_tester.mutex, s_tls_channel_setup_predicate, &outgoing_args));
     ASSERT_SUCCESS(aws_mutex_unlock(&c_tester.mutex));
-
     ASSERT_FALSE(outgoing_args.error_invoked);
 
 /* currently it seems ALPN doesn't work in server mode. Just leaving this check out for now. */
@@ -1016,6 +1014,7 @@ static int s_tls_server_multiple_connections_fn(struct aws_allocator *allocator,
     ASSERT_SUCCESS(aws_condition_variable_wait_pred(
         &c_tester.condition_variable, &c_tester.mutex, s_tls_channel_setup_predicate, &incoming_args));
     ASSERT_SUCCESS(aws_mutex_unlock(&c_tester.mutex));
+    ASSERT_FALSE(incoming_args.error_invoked);
 
     /* shut down */
     aws_channel_shutdown(incoming_args.channel, AWS_OP_SUCCESS);


### PR DESCRIPTION
* Use condvar wait_pred to avoid spurious wake-up
* Prefer using locks instead of atomics for wait
* Notify does not need to be in a critical section
* Minimize size of critical sections in tests

* read_write_test_handler: remove dead-code
* posix/socket.c and windows/iocp/socket.c: pair-up lock/unlock even for
  stack-local mutexes
* tls_server_multiple_connections and tls_channel_statistics_test: add assert
  to ensure channel has been setup correctly
* s_socket_common_tester_init: init io library before running event loops to
  avoid a data-race on logger

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
