### PR TITLE
Invalid certs  should not be considered valid

### DIFF
--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -442,8 +442,7 @@ static int s_drive_negotiation(struct aws_channel_handler *handler) {
             CFRelease(trust);
 
             if (status == errSecSuccess &&
-                (trust_eval == kSecTrustResultProceed || trust_eval == kSecTrustResultUnspecified ||
-                 trust_eval == kSecTrustResultRecoverableTrustFailure)) {
+                (trust_eval == kSecTrustResultProceed || trust_eval == kSecTrustResultUnspecified) {
                 return s_drive_negotiation(handler);
             }
 


### PR DESCRIPTION
*Issue #, if available:*
#254
*Description of changes:*
Removed check that considered valid the following [result](https://developer.apple.com/documentation/security/sectrustresulttype/recoverabletrustfailure) 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
