### PR TITLE
Moving g_aws_channel_max_fragment_size to inside of extern "C"

### DIFF
--- a/include/aws/io/channel.h
+++ b/include/aws/io/channel.h
@@ -160,9 +160,9 @@ struct aws_channel_options {
     bool enable_read_back_pressure;
 };
 
-extern AWS_IO_API size_t g_aws_channel_max_fragment_size;
-
 AWS_EXTERN_C_BEGIN
+
+extern AWS_IO_API size_t g_aws_channel_max_fragment_size;
 
 /**
  * Initializes channel_task for use.


### PR DESCRIPTION
*Description of changes:*
Moving g_aws_channel_max_fragment_size to inside extern C so that it links in MSVC.  I'm also open to using a different API here if we don't want people to write to this variable directly--wrapping this in a function call, putting this an options struct somewhere, etc..  We just need a way to set it in the canary.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
