### PR TITLE
Adding setter for Minimum TLS Version

### DIFF
--- a/include/aws/io/tls_channel_handler.h
+++ b/include/aws/io/tls_channel_handler.h
@@ -347,6 +347,13 @@ AWS_IO_API int aws_tls_ctx_options_set_alpn_list(struct aws_tls_ctx_options *opt
 AWS_IO_API void aws_tls_ctx_options_set_verify_peer(struct aws_tls_ctx_options *options, bool verify_peer);
 
 /**
+ * Sets the minimum TLS version to allow.
+ */
+AWS_IO_API void aws_tls_ctx_options_set_minimum_tls_version(
+    struct aws_tls_ctx_options *options,
+    enum aws_tls_versions minimum_tls_version);
+
+/**
  * Override the default trust store. ca_file is a buffer containing a PEM armored chain of trusted CA certificates.
  * ca_file is copied.
  */

--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -275,6 +275,12 @@ void aws_tls_ctx_options_set_verify_peer(struct aws_tls_ctx_options *options, bo
     options->verify_peer = verify_peer;
 }
 
+void aws_tls_ctx_options_set_minimum_tls_version(
+    struct aws_tls_ctx_options *options,
+    enum aws_tls_versions minimum_tls_version) {
+    options->minimum_tls_version = minimum_tls_version;
+}
+
 int aws_tls_ctx_options_override_default_trust_store_from_path(
     struct aws_tls_ctx_options *options,
     const char *ca_path,


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/118

*Description of changes:*
First part of exposing minimum TLS version.  Downstream changes coming soon.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
