### PR TITLE
use aws versions of isspace() isalpha() etc

### DIFF
--- a/source/pki_utils.c
+++ b/source/pki_utils.c
@@ -78,7 +78,7 @@ static int s_convert_pem_to_raw_base64(
 
         /* burn off the padding in the buffer first.
          * Worst case we'll only have to do this once per line in the buffer. */
-        while (current_cur_ptr->len && isspace(*current_cur_ptr->ptr)) {
+        while (current_cur_ptr->len && aws_isspace(*current_cur_ptr->ptr)) {
             aws_byte_cursor_advance(current_cur_ptr, 1);
         }
 

--- a/source/uri.c
+++ b/source/uri.c
@@ -360,7 +360,7 @@ static void s_parse_authority(struct uri_parser *parser, struct aws_byte_cursor 
         size_t port_len = parser->uri->authority.len - parser->uri->host_name.len - 1;
         port_delim += 1;
         for (size_t i = 0; i < port_len; ++i) {
-            if (!isdigit(port_delim[i])) {
+            if (!aws_isdigit(port_delim[i])) {
                 parser->state = ERROR;
                 aws_raise_error(AWS_ERROR_MALFORMED_INPUT_STRING);
                 return;
@@ -449,7 +449,7 @@ static void s_unchecked_append_canonicalized_path_character(struct aws_byte_buf 
 
     uint8_t *dest_ptr = buffer->buffer + buffer->len;
 
-    if (isalnum(value)) {
+    if (aws_isalnum(value)) {
         ++buffer->len;
         *dest_ptr = value;
         return;
@@ -493,7 +493,7 @@ static void s_raw_append_canonicalized_param_character(struct aws_byte_buf *buff
 
     uint8_t *dest_ptr = buffer->buffer + buffer->len;
 
-    if (isalnum(value)) {
+    if (aws_isalnum(value)) {
         ++buffer->len;
         *dest_ptr = value;
         return;


### PR DESCRIPTION
depends on: https://github.com/awslabs/aws-c-common/pull/642

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
