### PR TITLE
clean up the message when error happens in testing channel

### DIFF
--- a/include/aws/testing/io_testing_channel.h
+++ b/include/aws/testing/io_testing_channel.h
@@ -605,11 +605,12 @@ static inline int testing_channel_send_data(
         err = testing_channel_push_write_message(channel, msg);
     }
 
+    if (err) {
+        aws_mem_release(msg->allocator, msg);
+    }
+
     if (!ignore_send_message_errors) {
-        if (err) {
-            aws_mem_release(msg->allocator, msg);
-            ASSERT_SUCCESS(err);
-        }
+        ASSERT_SUCCESS(err);
     }
 
     return AWS_OP_SUCCESS;

--- a/include/aws/testing/io_testing_channel.h
+++ b/include/aws/testing/io_testing_channel.h
@@ -606,7 +606,7 @@ static inline int testing_channel_send_data(
     }
 
     if (!ignore_send_message_errors) {
-        if(err) {
+        if (err) {
             aws_mem_release(msg->allocator, msg);
             ASSERT_SUCCESS(err);
         }

--- a/include/aws/testing/io_testing_channel.h
+++ b/include/aws/testing/io_testing_channel.h
@@ -606,7 +606,10 @@ static inline int testing_channel_send_data(
     }
 
     if (!ignore_send_message_errors) {
-        ASSERT_SUCCESS(err);
+        if(err) {
+            aws_mem_release(msg->allocator, msg);
+            ASSERT_SUCCESS(err);
+        }
     }
 
     return AWS_OP_SUCCESS;

--- a/include/aws/testing/io_testing_channel.h
+++ b/include/aws/testing/io_testing_channel.h
@@ -606,6 +606,7 @@ static inline int testing_channel_send_data(
     }
 
     if (err) {
+        /* If an error happens, clean the message here. Else, the recipient of the message will take the ownership */
         aws_mem_release(msg->allocator, msg);
     }
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- We have testing_channel_push_read_str_ignore_errors(), but it seems it was never invoked with error really happens.
```
/**
 * NOTE: if this function returns an error code, it is the caller's responsibility to release message
 * back to the pool. ...
 */
int aws_channel_slot_send_message(...)
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
