### PR TITLE
Windows 7 TLS/PKI support

### DIFF
--- a/source/windows/iocp/iocp_event_loop.c
+++ b/source/windows/iocp/iocp_event_loop.c
@@ -498,8 +498,7 @@ static int s_connect_to_io_completion_port(struct aws_event_loop *event_loop, st
         1);                  /* NumberOfConcurrentThreads */
 
     /* iocp_handle should be the event loop's handle if this succeeded */
-    bool iocp_associated =
-        iocp_handle == impl->iocp_handle
+    bool iocp_associated = iocp_handle == impl->iocp_handle;
 
 /* clang-format off */
 #if defined(AWS_SUPPORT_WIN7)

--- a/source/windows/iocp/iocp_event_loop.c
+++ b/source/windows/iocp/iocp_event_loop.c
@@ -508,8 +508,7 @@ static int s_connect_to_io_completion_port(struct aws_event_loop *event_loop, st
         GetLastError() == ERROR_INVALID_PARAMETER &&
         /* Both handles should be valid prior to the above call. If they are,
          * and we got ERROR_INVALID_PARAMETER, the file handle already has an IOCP association */
-        handle->data.handle != INVALID_HANDLE_VALUE &&
-        impl->iocp_handle != INVALID_HANDLE_VALUE;
+        handle->data.handle != INVALID_HANDLE_VALUE && impl->iocp_handle != INVALID_HANDLE_VALUE;
     if (!already_associated && iocp_handle != impl->iocp_handle) {
         AWS_LOGF_ERROR(
             AWS_LS_IO_EVENT_LOOP,

--- a/source/windows/iocp/iocp_event_loop.c
+++ b/source/windows/iocp/iocp_event_loop.c
@@ -498,8 +498,10 @@ static int s_connect_to_io_completion_port(struct aws_event_loop *event_loop, st
         1);                  /* NumberOfConcurrentThreads */
 
     /* iocp_handle should be the event loop's handle if this succeeded */
-    bool iocp_associated = iocp_handle == impl->iocp_handle
+    bool iocp_associated =
+        iocp_handle == impl->iocp_handle
 
+/* clang-format off */
 #if defined(AWS_SUPPORT_WIN7)
     /*
      * When associating named pipes, it is possible to open the same pipe in the same
@@ -515,6 +517,7 @@ static int s_connect_to_io_completion_port(struct aws_event_loop *event_loop, st
         handle->data.handle != INVALID_HANDLE_VALUE && impl->iocp_handle != INVALID_HANDLE_VALUE;
     iocp_associated |= already_associated;
 #endif
+    /* clang-format on */
 
     if (!iocp_associated) {
         AWS_LOGF_ERROR(

--- a/source/windows/iocp/iocp_event_loop.c
+++ b/source/windows/iocp/iocp_event_loop.c
@@ -496,7 +496,13 @@ static int s_connect_to_io_completion_port(struct aws_event_loop *event_loop, st
         0,                   /* CompletionKey */
         1);                  /* NumberOfConcurrentThreads */
 
-    if (!success) {
+    /*
+     * Some handles, notably named pipes, don't like to be associated more than
+     * once with the same I/O completion port. Therefore, it's ok if this call
+     * fails as long as there's already a bound iocp_handle.
+     * This will result in a last error of ERROR_INVALID_PARAMETER.
+     */
+    if (!success && impl->iocp_handle == INVALID_HANDLE_VALUE) {
         AWS_LOGF_ERROR(
             AWS_LS_IO_EVENT_LOOP,
             "id=%p: CreateIoCompletionPort() failed with error %d",

--- a/source/windows/iocp/iocp_event_loop.c
+++ b/source/windows/iocp/iocp_event_loop.c
@@ -490,17 +490,21 @@ static int s_connect_to_io_completion_port(struct aws_event_loop *event_loop, st
         "id=%p: subscribing to events on handle %p",
         (void *)event_loop,
         (void *)handle->data.handle);
-    /* iocp_handle should be the event loop's handle if this succeeds */
+
     const HANDLE iocp_handle = CreateIoCompletionPort(
         handle->data.handle, /* FileHandle */
         impl->iocp_handle,   /* ExistingCompletionPort */
         0,                   /* CompletionKey */
         1);                  /* NumberOfConcurrentThreads */
 
+    /* iocp_handle should be the event loop's handle if this succeeded */
+    bool iocp_associated = iocp_handle == impl->iocp_handle
+
+#if defined(AWS_SUPPORT_WIN7)
     /*
      * When associating named pipes, it is possible to open the same pipe in the same
      * process for read and write, causing multiple attempts to associate. This will
-     * return ERROR_INVALID_PARAMETER from GetLastError on the second association,
+     * return ERROR_INVALID_PARAMETER from GetLastError on the second association on Win7,
      * but the prior association will continue. Detecting this before attempting to
      * associate requires the DDK API.
      */
@@ -509,7 +513,10 @@ static int s_connect_to_io_completion_port(struct aws_event_loop *event_loop, st
         /* Both handles should be valid prior to the above call. If they are,
          * and we got ERROR_INVALID_PARAMETER, the file handle already has an IOCP association */
         handle->data.handle != INVALID_HANDLE_VALUE && impl->iocp_handle != INVALID_HANDLE_VALUE;
-    if (!already_associated && iocp_handle != impl->iocp_handle) {
+    iocp_associated |= already_associated;
+#endif
+
+    if (!iocp_associated) {
         AWS_LOGF_ERROR(
             AWS_LS_IO_EVENT_LOOP,
             "id=%p: CreateIoCompletionPort() failed with error %d",

--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -417,7 +417,7 @@ static int s_do_server_side_negotiation_step_1(struct aws_channel_handler *handl
         .pBuffers = input_bufs,
     };
 
-#ifdef SECBUFFER_APPLICATION_PROTOCOLS
+#if !defined(AWS_SUPPORT_WIN7) && defined(SECBUFFER_APPLICATION_PROTOCOLS)
     if (sc_handler->alpn_list && aws_tls_is_alpn_available()) {
         AWS_LOGF_DEBUG(AWS_LS_IO_TLS, "id=%p: Setting ALPN to %s", handler, aws_string_c_str(sc_handler->alpn_list));
         size_t extension_length = 0;

--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -417,7 +417,7 @@ static int s_do_server_side_negotiation_step_1(struct aws_channel_handler *handl
         .pBuffers = input_bufs,
     };
 
-#if !defined(AWS_SUPPORT_WIN7) && defined(SECBUFFER_APPLICATION_PROTOCOLS)
+#ifdef SECBUFFER_APPLICATION_PROTOCOLS
     if (sc_handler->alpn_list && aws_tls_is_alpn_available()) {
         AWS_LOGF_DEBUG(AWS_LS_IO_TLS, "id=%p: Setting ALPN to %s", handler, aws_string_c_str(sc_handler->alpn_list));
         size_t extension_length = 0;
@@ -634,7 +634,7 @@ static int s_do_server_side_negotiation_step_2(struct aws_channel_handler *handl
            grab the negotiated protocol out of the session.
         */
 #ifdef SECBUFFER_APPLICATION_PROTOCOLS
-        if (sc_handler->alpn_list) {
+        if (sc_handler->alpn_list && aws_tls_is_alpn_available()) {
             SecPkgContext_ApplicationProtocol alpn_result;
             status = QueryContextAttributes(&sc_handler->sec_handle, SECPKG_ATTR_APPLICATION_PROTOCOL, &alpn_result);
             AWS_LOGF_TRACE(AWS_LS_IO_TLS, "id=%p: ALPN is configured. Checking for negotiated protocol", handler);
@@ -919,7 +919,7 @@ static int s_do_client_side_negotiation_step_2(struct aws_channel_handler *handl
         s_message_overhead(handler);
 
 #ifdef SECBUFFER_APPLICATION_PROTOCOLS
-        if (sc_handler->alpn_list) {
+        if (sc_handler->alpn_list && aws_tls_is_alpn_available()) {
             AWS_LOGF_TRACE(AWS_LS_IO_TLS, "id=%p: Retrieving negotiated protocol.", handler);
             SecPkgContext_ApplicationProtocol alpn_result;
             status = QueryContextAttributes(&sc_handler->sec_handle, SECPKG_ATTR_APPLICATION_PROTOCOL, &alpn_result);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -178,4 +178,4 @@ generate_test_driver(${TEST_BINARY_NAME})
 #SSL certificates to use for testing.
 add_custom_command(TARGET ${TEST_BINARY_NAME} PRE_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_CURRENT_SOURCE_DIR}/resources ${CMAKE_CURRENT_BINARY_DIR})
+        ${CMAKE_CURRENT_SOURCE_DIR}/resources $<TARGET_FILE_DIR:${TEST_BINARY_NAME}>)

--- a/tests/pki_utils_test.c
+++ b/tests/pki_utils_test.c
@@ -486,7 +486,7 @@ static int s_test_pem_cert_parse_from_file(struct aws_allocator *allocator, void
     struct aws_array_list output_list;
 
     ASSERT_SUCCESS(aws_array_list_init_dynamic(&output_list, allocator, 1, sizeof(struct aws_byte_buf)));
-    ASSERT_SUCCESS(aws_read_and_decode_pem_file_to_buffer_list(allocator, "./unittests.crt", &output_list));
+    ASSERT_SUCCESS(aws_read_and_decode_pem_file_to_buffer_list(allocator, "unittests.crt", &output_list));
     ASSERT_UINT_EQUALS(1, aws_array_list_length(&output_list));
 
     struct aws_byte_buf *cert_data = NULL;
@@ -577,7 +577,7 @@ static int s_test_pem_private_key_parse_from_file(struct aws_allocator *allocato
     struct aws_array_list output_list;
 
     ASSERT_SUCCESS(aws_array_list_init_dynamic(&output_list, allocator, 1, sizeof(struct aws_byte_buf)));
-    ASSERT_SUCCESS(aws_read_and_decode_pem_file_to_buffer_list(allocator, "./unittests.key", &output_list));
+    ASSERT_SUCCESS(aws_read_and_decode_pem_file_to_buffer_list(allocator, "unittests.key", &output_list));
     ASSERT_UINT_EQUALS(1, aws_array_list_length(&output_list));
 
     struct aws_byte_buf *cert_data = NULL;

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -60,10 +60,10 @@ static int s_tls_server_opt_tester_init(struct aws_allocator *allocator, struct 
 
 #ifdef __APPLE__
     struct aws_byte_cursor pwd_cur = aws_byte_cursor_from_c_str("1234");
-    aws_tls_ctx_options_init_server_pkcs12_from_path(&tester->ctx_options, allocator, "./unittests.p12", &pwd_cur);
+    aws_tls_ctx_options_init_server_pkcs12_from_path(&tester->ctx_options, allocator, "unittests.p12", &pwd_cur);
 #else
     aws_tls_ctx_options_init_default_server_from_path(
-        &tester->ctx_options, allocator, "./unittests.crt", "./unittests.key");
+        &tester->ctx_options, allocator, "unittests.crt", "unittests.key");
 #endif /* __APPLE__ */
     aws_tls_ctx_options_set_alpn_list(&tester->ctx_options, "h2;http/1.1");
     tester->ctx = aws_tls_server_ctx_new(allocator, &tester->ctx_options);
@@ -81,7 +81,7 @@ static int s_tls_client_opt_tester_init(
     aws_io_library_init(allocator);
 
     aws_tls_ctx_options_init_default_client(&tester->ctx_options, allocator);
-    aws_tls_ctx_options_override_default_trust_store_from_path(&tester->ctx_options, NULL, "./unittests.crt");
+    aws_tls_ctx_options_override_default_trust_store_from_path(&tester->ctx_options, NULL, "unittests.crt");
 
     tester->ctx = aws_tls_client_ctx_new(allocator, &tester->ctx_options);
     aws_tls_connection_options_init_from_ctx(&tester->opt, tester->ctx);
@@ -1603,7 +1603,7 @@ static int s_test_concurrent_cert_import(struct aws_allocator *allocator, void *
     /* setup, note that all I/O should be before the threads are launched */
     for (size_t idx = 0; idx < NUM_PAIRS; ++idx) {
         char filename[1024];
-        sprintf(filename, "./key_pair%u.pem", (uint32_t)idx);
+        sprintf(filename, "key_pair%u.pem", (uint32_t)idx);
 
         struct import_info *import = &imports[idx];
         import->allocator = allocator;


### PR DESCRIPTION
*Issue #, if available:* https://github.com/awslabs/aws-crt-cpp/issues/144

*Description of changes:*
* Force checks for ALPN availability in every case where ALPN might be attempted, should allow Win7 and Win8 < Win8.1 to use TLS 1.2 if enabled.
* Fixed spurious failure due to duplicate registration of IOCP on named pipes
* Fixes to unit tests resource installation on windows, should now be robust regardless of build configuration


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
