### PR TITLE
2 new aws_uri helpers

### DIFF
--- a/.github/workflows/proof-alarm.yml
+++ b/.github/workflows/proof-alarm.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Check
       run: |
-        git diff --quiet 9276b7251 source/linux/epoll_event_loop.c
+        git diff --quiet aaabab98c source/linux/epoll_event_loop.c
 
     # No further steps if successful
 

--- a/.github/workflows/proof-alarm.yml
+++ b/.github/workflows/proof-alarm.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Check
       run: |
-        git diff --quiet aaabab98c source/linux/epoll_event_loop.c
+        git diff --quiet 84bfb96d0 source/linux/epoll_event_loop.c
 
     # No further steps if successful
 

--- a/NOTICE
+++ b/NOTICE
@@ -1,2 +1,3 @@
 AWS C Io
-Copyright 2018 Amazon.com, Inc. or its affiliates. All Rights Reserved. 
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0.

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ cd libcrypto-build
 curl -LO https://www.openssl.org/source/openssl-1.1.1-latest.tar.gz
 tar -xzvf openssl-1.1.1-latest.tar.gz
 
-# Build openssl libcrypto
+# Build openssl libcrypto.  Note that the install path specified here must be absolute.
 cd `tar ztf openssl-1.1.1-latest.tar.gz | head -n1 | cut -f1 -d/`
 ./config -fPIC no-shared              \
          no-md2 no-rc5 no-rfc3779 no-sctp no-ssl-trace no-zlib     \
          no-hw no-mdc2 no-seed no-idea enable-ec_nistp_64_gcc_128 no-camellia\
          no-bf no-ripemd no-dsa no-ssl2 no-ssl3 no-capieng                  \
          -DSSL_FORBID_ENULL -DOPENSSL_NO_DTLS1 -DOPENSSL_NO_HEARTBEATS      \
-         --prefix=`pwd`/../../libcrypto-root/
+         --prefix=<absolute-install-path>
 make
 make install
 

--- a/docs/epoll_event_loop_proof.md
+++ b/docs/epoll_event_loop_proof.md
@@ -1,8 +1,11 @@
 # VCC Proof Signoff
 
 Verification tool: VCC (code-level proof)
-Proofs: https://github.com/nchong-at-aws/vcc-proofs-of-cio/
+
+Proofs: tests/vcc/
+
 Implementation: Linux event loop (`source/linux/epoll_event_loop.c`)
+
 Specification / Properties (`preamble.h`):
   - *Memory safety*: the implementation only accesses valid memory.
   - *Thread safety*: threads only update objects that they own.

--- a/include/aws/io/channel.h
+++ b/include/aws/io/channel.h
@@ -1,18 +1,8 @@
 #ifndef AWS_IO_CHANNEL_H
 #define AWS_IO_CHANNEL_H
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/io.h>

--- a/include/aws/io/channel_bootstrap.h
+++ b/include/aws/io/channel_bootstrap.h
@@ -1,19 +1,9 @@
 #ifndef AWS_IO_CHANNEL_BOOTSTRAP_H
 #define AWS_IO_CHANNEL_BOOTSTRAP_H
 
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/common/atomics.h>
 #include <aws/io/channel.h>

--- a/include/aws/io/event_loop.h
+++ b/include/aws/io/event_loop.h
@@ -1,19 +1,9 @@
 #ifndef AWS_IO_EVENT_LOOP_H
 #define AWS_IO_EVENT_LOOP_H
 
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/common/atomics.h>

--- a/include/aws/io/exports.h
+++ b/include/aws/io/exports.h
@@ -1,19 +1,9 @@
 #ifndef AWS_IO_EXPORTS_H
 #define AWS_IO_EXPORTS_H
 
-/*
- *Copyright 2010-2017 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- *icensed under the Apache License, Version 2.0 (the "License").
- *You may not use this file except in compliance with the License.
- *A copy of the License is located at
- *
- * http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #if defined(USE_WINDOWS_DLL_SEMANTICS) || defined(WIN32)

--- a/include/aws/io/file_utils.h
+++ b/include/aws/io/file_utils.h
@@ -1,19 +1,9 @@
 #ifndef AWS_IO_FILE_UTILS_H
 #define AWS_IO_FILE_UTILS_H
 
-/*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/io.h>

--- a/include/aws/io/host_resolver.h
+++ b/include/aws/io/host_resolver.h
@@ -1,18 +1,8 @@
 #ifndef AWS_IO_HOST_RESOLVER_H
 #define AWS_IO_HOST_RESOLVER_H
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/io.h>

--- a/include/aws/io/io.h
+++ b/include/aws/io/io.h
@@ -1,19 +1,9 @@
 #ifndef AWS_IO_IO_H
 #define AWS_IO_IO_H
 
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/common/byte_buf.h>
 #include <aws/common/common.h>

--- a/include/aws/io/logging.h
+++ b/include/aws/io/logging.h
@@ -1,19 +1,9 @@
 #ifndef AWS_IO_LOGGING_H
 #define AWS_IO_LOGGING_H
 
-/*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/io.h>

--- a/include/aws/io/message_pool.h
+++ b/include/aws/io/message_pool.h
@@ -1,18 +1,8 @@
 #ifndef AWS_IO_MESSAGE_POOL_H
 #define AWS_IO_MESSAGE_POOL_H
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/common/array_list.h>
 #include <aws/io/io.h>

--- a/include/aws/io/pipe.h
+++ b/include/aws/io/pipe.h
@@ -1,19 +1,9 @@
 #ifndef AWS_IO_PIPE_H
 #define AWS_IO_PIPE_H
 
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/common/byte_buf.h>

--- a/include/aws/io/pki_utils.h
+++ b/include/aws/io/pki_utils.h
@@ -1,18 +1,8 @@
 #ifndef AWS_IO_PKI_UTILS_H
 #define AWS_IO_PKI_UTILS_H
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/io/io.h>
 

--- a/include/aws/io/private/tls_channel_handler_shared.h
+++ b/include/aws/io/private/tls_channel_handler_shared.h
@@ -1,18 +1,8 @@
 #ifndef AWS_IO_TLS_CHANNEL_HANDLER_SHARED_H
 #define AWS_IO_TLS_CHANNEL_HANDLER_SHARED_H
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/io.h>

--- a/include/aws/io/retry_strategy.h
+++ b/include/aws/io/retry_strategy.h
@@ -1,18 +1,8 @@
 #ifndef AWS_IO_CLIENT_RETRY_STRATEGY_H
 #define AWS_IO_CLIENT_RETRY_STRATEGY_H
-/*
- * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/io/exports.h>
 

--- a/include/aws/io/shared_library.h
+++ b/include/aws/io/shared_library.h
@@ -1,19 +1,9 @@
 #ifndef AWS_COMMON_SHARED_LIBRARY_H
 #define AWS_COMMON_SHARED_LIBRARY_H
 
-/*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/io.h>

--- a/include/aws/io/socket.h
+++ b/include/aws/io/socket.h
@@ -1,18 +1,8 @@
 #ifndef AWS_IO_SOCKET_H
 #define AWS_IO_SOCKET_H
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/channel.h>

--- a/include/aws/io/socket_channel_handler.h
+++ b/include/aws/io/socket_channel_handler.h
@@ -1,18 +1,8 @@
 #ifndef AWS_IO_SOCKET_CHANNEL_HANDLER_H
 #define AWS_IO_SOCKET_CHANNEL_HANDLER_H
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/io.h>

--- a/include/aws/io/statistics.h
+++ b/include/aws/io/statistics.h
@@ -1,19 +1,9 @@
 #ifndef AWS_IO_STATISTICS_H
 #define AWS_IO_STATISTICS_H
 
-/*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/io.h>

--- a/include/aws/io/stream.h
+++ b/include/aws/io/stream.h
@@ -1,19 +1,9 @@
 #ifndef AWS_IO_STREAM_H
 #define AWS_IO_STREAM_H
 
-/*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/io.h>

--- a/include/aws/io/tls_channel_handler.h
+++ b/include/aws/io/tls_channel_handler.h
@@ -1,18 +1,8 @@
 #ifndef AWS_IO_TLS_CHANNEL_HANDLER_H
 #define AWS_IO_TLS_CHANNEL_HANDLER_H
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/common/byte_buf.h>
 

--- a/include/aws/io/uri.h
+++ b/include/aws/io/uri.h
@@ -121,6 +121,21 @@ AWS_IO_API uint16_t aws_uri_port(const struct aws_uri *uri);
 AWS_IO_API const struct aws_byte_cursor *aws_uri_path_and_query(const struct aws_uri *uri);
 
 /**
+ * For iterating over the params in the uri query string.
+ * `param` is an in/out argument used to track progress, it MUST be zeroed out to start.
+ * If true is returned, `param` contains the value of the next param.
+ * If false is returned, there are no further params.
+ *
+ * Edge cases:
+ * 1) Entries without '=' sign are treated as having a key and no value.
+ *    Example: First param in query string "a&b=c" has key="a" value=""
+ *
+ * 2) Blank entries are skipped.
+ *    Example: The only param in query string "&&a=b" is key="a" value="b"
+ */
+AWS_IO_API bool aws_uri_query_string_next_param(const struct aws_uri *uri, struct aws_uri_param *param);
+
+/**
  * Parses query string and stores the parameters in 'out_params'. Returns AWS_OP_SUCCESS on success and
  * AWS_OP_ERR on failure. The user is responsible for initializing out_params with item size of struct aws_query_param.
  * The user is also responsible for cleaning up out_params when finished.
@@ -134,9 +149,19 @@ AWS_IO_API int aws_uri_query_string_params(const struct aws_uri *uri, struct aws
 AWS_IO_API int aws_byte_buf_append_encoding_uri_path(struct aws_byte_buf *buffer, const struct aws_byte_cursor *cursor);
 
 /**
- * Writes the uri query param encoding (passthrough alnum + '-' '_' '~' '.') of a cursor to a buffer
+ * Writes the uri query param encoding (passthrough alnum + '-' '_' '~' '.') of a UTF-8 cursor to a buffer
+ * For example, reading "a b_c" would write "a%20b_c".
  */
 AWS_IO_API int aws_byte_buf_append_encoding_uri_param(
+    struct aws_byte_buf *buffer,
+    const struct aws_byte_cursor *cursor);
+
+/**
+ * Writes the uri decoding of a UTF-8 cursor to a buffer,
+ * replacing %xx escapes by their single byte equivalent.
+ * For example, reading "a%20b_c" would write "a b_c".
+ */
+AWS_IO_API int aws_byte_buf_append_decoding_uri(
     struct aws_byte_buf *buffer,
     const struct aws_byte_cursor *cursor);
 

--- a/include/aws/io/uri.h
+++ b/include/aws/io/uri.h
@@ -1,18 +1,8 @@
 #ifndef AWS_IO_URI_H
 #define AWS_IO_URI_H
-/*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/io/io.h>
 

--- a/include/aws/testing/io_testing_channel.h
+++ b/include/aws/testing/io_testing_channel.h
@@ -1,18 +1,8 @@
 #ifndef AWS_TESTING_IO_TESTING_CHANNEL_H
 #define AWS_TESTING_IO_TESTING_CHANNEL_H
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/common/clock.h>
 #include <aws/common/task_scheduler.h>

--- a/source/alpn_handler.c
+++ b/source/alpn_handler.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/channel.h>

--- a/source/bsd/kqueue_event_loop.c
+++ b/source/bsd/kqueue_event_loop.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/event_loop.h>

--- a/source/channel.c
+++ b/source/channel.c
@@ -132,11 +132,11 @@ static void s_on_channel_setup_complete(struct aws_task *task, void *arg, enum a
             AWS_LOGF_DEBUG(
                 AWS_LS_IO_CHANNEL,
                 "id=%p: no message pool is currently stored in the event-loop "
-                "local storage, adding %p with max message size %llu, "
+                "local storage, adding %p with max message size %zu, "
                 "message count 4, with 4 small blocks of 128 bytes.",
                 (void *)setup_args->channel,
                 (void *)message_pool,
-                (unsigned long long)g_aws_channel_max_fragment_size);
+                g_aws_channel_max_fragment_size);
 
             struct aws_message_pool_creation_args creation_args = {
                 .application_data_msg_data_size = g_aws_channel_max_fragment_size,
@@ -427,12 +427,12 @@ struct aws_io_message *aws_channel_acquire_message_from_pool(
         message->owning_channel = channel;
         AWS_LOGF_TRACE(
             AWS_LS_IO_CHANNEL,
-            "id=%p: acquired message %p of length %llu from pool %p. Requested size was %llu",
+            "id=%p: acquired message %p of capacity %zu from pool %p. Requested size was %zu",
             (void *)channel,
             (void *)message,
-            (unsigned long long)message->message_data.len,
+            message->message_data.capacity,
             (void *)channel->msg_pool,
-            (unsigned long long)size_hint);
+            size_hint);
     }
 
     return message;
@@ -749,10 +749,10 @@ int aws_channel_slot_send_message(
         if (!slot->channel->read_back_pressure_enabled || slot->adj_right->window_size >= message->message_data.len) {
             AWS_LOGF_TRACE(
                 AWS_LS_IO_CHANNEL,
-                "id=%p: sending read message of size %llu, "
+                "id=%p: sending read message of size %zu, "
                 "from slot %p to slot %p with handler %p.",
                 (void *)slot->channel,
-                (unsigned long long)message->message_data.len,
+                message->message_data.len,
                 (void *)slot,
                 (void *)slot->adj_right,
                 (void *)slot->adj_right->handler);
@@ -761,11 +761,11 @@ int aws_channel_slot_send_message(
         }
         AWS_LOGF_ERROR(
             AWS_LS_IO_CHANNEL,
-            "id=%p: sending message of size %llu, "
+            "id=%p: sending message of size %zu, "
             "from slot %p to slot %p with handler %p, but this would exceed the channel's "
             "read window, this is always a programming error.",
             (void *)slot->channel,
-            (unsigned long long)message->message_data.len,
+            message->message_data.len,
             (void *)slot,
             (void *)slot->adj_right,
             (void *)slot->adj_right->handler);
@@ -776,10 +776,10 @@ int aws_channel_slot_send_message(
     AWS_ASSERT(slot->adj_left->handler);
     AWS_LOGF_TRACE(
         AWS_LS_IO_CHANNEL,
-        "id=%p: sending write message of size %llu, "
+        "id=%p: sending write message of size %zu, "
         "from slot %p to slot %p with handler %p.",
         (void *)slot->channel,
-        (unsigned long long)message->message_data.len,
+        message->message_data.len,
         (void *)slot,
         (void *)slot->adj_left,
         (void *)slot->adj_left->handler);

--- a/source/channel.c
+++ b/source/channel.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/channel.h>

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/io/channel_bootstrap.h>
 

--- a/source/darwin/darwin_pki_utils.c
+++ b/source/darwin/darwin_pki_utils.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/io/pki_utils.h>
 

--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/io/tls_channel_handler.h>
 

--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -610,8 +610,8 @@ static int s_process_read_message(
     OSStatus status = noErr;
     while (processed < downstream_window && status == noErr) {
 
-        struct aws_io_message *outgoing_read_message =
-            aws_channel_acquire_message_from_pool(slot->channel, AWS_IO_MESSAGE_APPLICATION_DATA, downstream_window);
+        struct aws_io_message *outgoing_read_message = aws_channel_acquire_message_from_pool(
+            slot->channel, AWS_IO_MESSAGE_APPLICATION_DATA, downstream_window - processed);
         if (!outgoing_read_message) {
             return AWS_OP_ERR;
         }

--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/event_loop.h>

--- a/source/exponential_backoff_retry_strategy.c
+++ b/source/exponential_backoff_retry_strategy.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/io/retry_strategy.h>
 

--- a/source/file_utils_shared.c
+++ b/source/file_utils_shared.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/file_utils.h>

--- a/source/host_resolver.c
+++ b/source/host_resolver.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/io/host_resolver.h>
 

--- a/source/io.c
+++ b/source/io.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/io/io.h>
 

--- a/source/linux/epoll_event_loop.c
+++ b/source/linux/epoll_event_loop.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/event_loop.h>

--- a/source/message_pool.c
+++ b/source/message_pool.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/message_pool.h>

--- a/source/pki_utils.c
+++ b/source/pki_utils.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/io/pki_utils.h>
 

--- a/source/posix/file_utils.c
+++ b/source/posix/file_utils.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/file_utils.h>

--- a/source/posix/host_resolver.c
+++ b/source/posix/host_resolver.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/host_resolver.h>

--- a/source/posix/pipe.c
+++ b/source/posix/pipe.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/pipe.h>

--- a/source/posix/shared_library.c
+++ b/source/posix/shared_library.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/shared_library.h>

--- a/source/posix/socket.c
+++ b/source/posix/socket.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/socket.h>

--- a/source/retry_strategy.c
+++ b/source/retry_strategy.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/io/retry_strategy.h>
 

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/io/tls_channel_handler.h>
 

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -486,8 +486,8 @@ static int s_s2n_handler_process_read_message(
 
     while (processed < downstream_window && blocked == S2N_NOT_BLOCKED) {
 
-        struct aws_io_message *outgoing_read_message =
-            aws_channel_acquire_message_from_pool(slot->channel, AWS_IO_MESSAGE_APPLICATION_DATA, downstream_window);
+        struct aws_io_message *outgoing_read_message = aws_channel_acquire_message_from_pool(
+            slot->channel, AWS_IO_MESSAGE_APPLICATION_DATA, downstream_window - processed);
         if (!outgoing_read_message) {
             return AWS_OP_ERR;
         }

--- a/source/socket_channel_handler.c
+++ b/source/socket_channel_handler.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/io/socket_channel_handler.h>
 

--- a/source/statistics.c
+++ b/source/statistics.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/statistics.h>

--- a/source/stream.c
+++ b/source/stream.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/stream.h>

--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/channel.h>

--- a/source/tls_channel_handler_shared.c
+++ b/source/tls_channel_handler_shared.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/private/tls_channel_handler_shared.h>

--- a/source/uri.c
+++ b/source/uri.c
@@ -222,65 +222,56 @@ uint16_t aws_uri_port(const struct aws_uri *uri) {
     return uri->port;
 }
 
+bool aws_uri_query_string_next_param(const struct aws_uri *uri, struct aws_uri_param *param) {
+    /* If param is zeroed, then this is the first run. */
+    bool first_run = param->value.ptr == NULL;
+
+    /* aws_byte_cursor_next_split() is used to iterate over params in the query string.
+     * It takes an in/out substring arg similar to how this function works */
+    struct aws_byte_cursor substr;
+    if (first_run) {
+        /* substring must be zeroed to start */
+        AWS_ZERO_STRUCT(substr);
+    } else {
+        /* re-assemble substring which contained key and value */
+        substr.ptr = param->key.ptr;
+        substr.len = (param->value.ptr - param->key.ptr) + param->value.len;
+    }
+
+    /* The do-while is to skip over any empty substrings */
+    do {
+        if (!aws_byte_cursor_next_split(&uri->query_string, '&', &substr)) {
+            /* no more splits, done iterating */
+            return false;
+        }
+    } while (substr.len == 0);
+
+    uint8_t *delim = memchr(substr.ptr, '=', substr.len);
+    if (delim) {
+        param->key.ptr = substr.ptr;
+        param->key.len = delim - substr.ptr;
+        param->value.ptr = delim + 1;
+        param->value.len = substr.len - param->key.len - 1;
+    } else {
+        /* no '=', key gets substring, value is blank */
+        param->key = substr;
+        param->value.ptr = substr.ptr + substr.len;
+        param->value.len = 0;
+    }
+
+    return true;
+}
+
 int aws_uri_query_string_params(const struct aws_uri *uri, struct aws_array_list *out_params) {
-    if (uri->query_string.len == 0) {
-        return AWS_OP_SUCCESS;
-    }
-
-    struct aws_array_list key_val_array;
-    if (aws_array_list_init_dynamic(&key_val_array, uri->allocator, 8, sizeof(struct aws_byte_cursor))) {
-        return AWS_OP_ERR;
-    }
-
-    if (aws_byte_cursor_split_on_char(&uri->query_string, '&', &key_val_array)) {
-        goto error;
-    }
-
-    for (size_t i = 0; i < aws_array_list_length(&key_val_array); ++i) {
-        struct aws_byte_cursor *key_val = NULL;
-        aws_array_list_get_at_ptr(&key_val_array, (void *)&key_val, i);
-
-        uint8_t *delim = memchr(key_val->ptr, '=', key_val->len);
-
-        if (delim) {
-            struct aws_uri_param param_value = {
-                .key =
-                    {
-                        .ptr = key_val->ptr,
-                        .len = delim - key_val->ptr,
-                    },
-                .value =
-                    {
-                        .ptr = delim + 1,
-                        .len = key_val->len - (delim - key_val->ptr) - 1,
-                    },
-            };
-
-            if (aws_array_list_push_back(out_params, &param_value)) {
-                goto error;
-            }
-        } else {
-            struct aws_uri_param param_value = {
-                .key =
-                    {
-                        .ptr = key_val->ptr,
-                        .len = key_val->len,
-                    },
-            };
-            AWS_ZERO_STRUCT(param_value.value);
-
-            if (aws_array_list_push_back(out_params, &param_value)) {
-                goto error;
-            }
+    struct aws_uri_param param;
+    AWS_ZERO_STRUCT(param);
+    while (aws_uri_query_string_next_param(uri, &param)) {
+        if (aws_array_list_push_back(out_params, &param)) {
+            return AWS_OP_ERR;
         }
     }
 
-    aws_array_list_clean_up(&key_val_array);
     return AWS_OP_SUCCESS;
-error:
-    aws_array_list_clean_up(&key_val_array);
-    aws_array_list_clear(out_params);
-    return AWS_OP_ERR;
 }
 
 static void s_parse_scheme(struct uri_parser *parser, struct aws_byte_cursor *str) {
@@ -554,4 +545,28 @@ int aws_byte_buf_append_encoding_uri_path(struct aws_byte_buf *buffer, const str
 
 int aws_byte_buf_append_encoding_uri_param(struct aws_byte_buf *buffer, const struct aws_byte_cursor *cursor) {
     return s_encode_cursor_to_buffer(buffer, cursor, s_raw_append_canonicalized_param_character);
+}
+
+int aws_byte_buf_append_decoding_uri(struct aws_byte_buf *buffer, const struct aws_byte_cursor *cursor) {
+    /* reserve room up front for worst possible case: no % and everything copies over 1:1 */
+    if (aws_byte_buf_reserve_relative(buffer, cursor->len)) {
+        return AWS_OP_ERR;
+    }
+
+    /* advance over cursor */
+    struct aws_byte_cursor advancing = *cursor;
+    uint8_t c;
+    while (aws_byte_cursor_read_u8(&advancing, &c)) {
+
+        if (c == '%') {
+            /* two hex characters following '%' are the byte's value */
+            if (AWS_UNLIKELY(aws_byte_cursor_read_hex_u8(&advancing, &c) == false)) {
+                return aws_raise_error(AWS_ERROR_MALFORMED_INPUT_STRING);
+            }
+        }
+
+        buffer->buffer[buffer->len++] = c;
+    }
+
+    return AWS_OP_SUCCESS;
 }

--- a/source/uri.c
+++ b/source/uri.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/io/uri.h>
 

--- a/source/windows/file_utils.c
+++ b/source/windows/file_utils.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/file_utils.h>

--- a/source/windows/host_resolver.c
+++ b/source/windows/host_resolver.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 /* don't move this below the Windows.h include!!!!*/

--- a/source/windows/iocp/iocp_event_loop.c
+++ b/source/windows/iocp/iocp_event_loop.c
@@ -490,13 +490,35 @@ static int s_connect_to_io_completion_port(struct aws_event_loop *event_loop, st
         "id=%p: subscribing to events on handle %p",
         (void *)event_loop,
         (void *)handle->data.handle);
-    bool success = CreateIoCompletionPort(
+
+    const HANDLE iocp_handle = CreateIoCompletionPort(
         handle->data.handle, /* FileHandle */
         impl->iocp_handle,   /* ExistingCompletionPort */
         0,                   /* CompletionKey */
         1);                  /* NumberOfConcurrentThreads */
 
-    if (!success) {
+    /* iocp_handle should be the event loop's handle if this succeeded */
+    bool iocp_associated = iocp_handle == impl->iocp_handle;
+
+/* clang-format off */
+#if defined(AWS_SUPPORT_WIN7)
+    /*
+     * When associating named pipes, it is possible to open the same pipe in the same
+     * process for read and write, causing multiple attempts to associate. This will
+     * return ERROR_INVALID_PARAMETER from GetLastError on the second association on Win7,
+     * but the prior association will continue. Detecting this before attempting to
+     * associate requires the DDK API.
+     */
+    const bool already_associated =
+        GetLastError() == ERROR_INVALID_PARAMETER &&
+        /* Both handles should be valid prior to the above call. If they are,
+         * and we got ERROR_INVALID_PARAMETER, the file handle already has an IOCP association */
+        handle->data.handle != INVALID_HANDLE_VALUE && impl->iocp_handle != INVALID_HANDLE_VALUE;
+    iocp_associated |= already_associated;
+#endif
+    /* clang-format on */
+
+    if (!iocp_associated) {
         AWS_LOGF_ERROR(
             AWS_LS_IO_EVENT_LOOP,
             "id=%p: CreateIoCompletionPort() failed with error %d",

--- a/source/windows/iocp/iocp_event_loop.c
+++ b/source/windows/iocp/iocp_event_loop.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/io/event_loop.h>
 

--- a/source/windows/iocp/pipe.c
+++ b/source/windows/iocp/pipe.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/pipe.h>

--- a/source/windows/iocp/socket.c
+++ b/source/windows/iocp/socket.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 /* clang is just a naive little idealist and doesn't understand that it can't just

--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -1105,7 +1105,9 @@ static int s_process_pending_output_messages(struct aws_channel_handler *handler
                 return AWS_OP_ERR;
             }
 
-            downstream_window = aws_channel_slot_downstream_read_window(sc_handler->slot);
+            if (sc_handler->slot->adj_right) {
+                downstream_window = aws_channel_slot_downstream_read_window(sc_handler->slot);
+            }
             AWS_LOGF_TRACE(AWS_LS_IO_TLS, "id=%p: Downstream window is %zu", (void *)handler, downstream_window);
         } else {
             if (sc_handler->on_data_read) {

--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -828,7 +828,7 @@ static int s_do_client_side_negotiation_step_2(struct aws_channel_handler *handl
 
     char server_name_cstr[256];
     AWS_ZERO_ARRAY(server_name_cstr);
-    AWS_ASSERT(sc_handler->server_name.len < 256);
+    AWS_FATAL_ASSERT(sc_handler->server_name.len < sizeof(server_name_cstr));
     memcpy(server_name_cstr, sc_handler->server_name.buffer, sc_handler->server_name.len);
 
     status = InitializeSecurityContextA(
@@ -1462,11 +1462,15 @@ static int s_handler_shutdown(
             };
 
             struct aws_byte_buf server_name = aws_tls_handler_server_name(handler);
+            char server_name_cstr[256];
+            AWS_ZERO_ARRAY(server_name_cstr);
+            AWS_FATAL_ASSERT(server_name.len < sizeof(server_name_cstr));
+            memcpy(server_name_cstr, server_name.buffer, server_name.len);
             /* this acutally gives us an Alert record to send. */
             status = InitializeSecurityContextA(
                 &sc_handler->creds,
                 &sc_handler->sec_handle,
-                (SEC_CHAR *)server_name.buffer,
+                (SEC_CHAR *)server_name_cstr,
                 sc_handler->ctx_req,
                 0,
                 0,

--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -634,7 +634,7 @@ static int s_do_server_side_negotiation_step_2(struct aws_channel_handler *handl
            grab the negotiated protocol out of the session.
         */
 #ifdef SECBUFFER_APPLICATION_PROTOCOLS
-        if (sc_handler->alpn_list) {
+        if (sc_handler->alpn_list && aws_tls_is_alpn_available()) {
             SecPkgContext_ApplicationProtocol alpn_result;
             status = QueryContextAttributes(&sc_handler->sec_handle, SECPKG_ATTR_APPLICATION_PROTOCOL, &alpn_result);
             AWS_LOGF_TRACE(AWS_LS_IO_TLS, "id=%p: ALPN is configured. Checking for negotiated protocol", handler);
@@ -919,7 +919,7 @@ static int s_do_client_side_negotiation_step_2(struct aws_channel_handler *handl
         s_message_overhead(handler);
 
 #ifdef SECBUFFER_APPLICATION_PROTOCOLS
-        if (sc_handler->alpn_list) {
+        if (sc_handler->alpn_list && aws_tls_is_alpn_available()) {
             AWS_LOGF_TRACE(AWS_LS_IO_TLS, "id=%p: Retrieving negotiated protocol.", handler);
             SecPkgContext_ApplicationProtocol alpn_result;
             status = QueryContextAttributes(&sc_handler->sec_handle, SECPKG_ATTR_APPLICATION_PROTOCOL, &alpn_result);

--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #define SECURITY_WIN32
 

--- a/source/windows/shared_library.c
+++ b/source/windows/shared_library.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 // clang-format off

--- a/source/windows/windows_pki_utils.c
+++ b/source/windows/windows_pki_utils.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/pki_utils.h>

--- a/source/windows/winsock_init.c
+++ b/source/windows/winsock_init.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 /* clang is just a naive little idealist and doesn't understand that it can't just

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -137,6 +137,7 @@ add_test_case(uri_builder)
 add_test_case(uri_builder_from_string)
 add_test_case(test_uri_encode_path_rfc3986)
 add_test_case(test_uri_encode_query)
+add_test_case(test_uri_decode)
 
 add_test_case(test_home_directory_not_null)
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -179,4 +179,4 @@ generate_test_driver(${TEST_BINARY_NAME})
 #SSL certificates to use for testing.
 add_custom_command(TARGET ${TEST_BINARY_NAME} PRE_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_CURRENT_SOURCE_DIR}/resources ${CMAKE_CURRENT_BINARY_DIR})
+        ${CMAKE_CURRENT_SOURCE_DIR}/resources $<TARGET_FILE_DIR:${TEST_BINARY_NAME}>)

--- a/tests/alpn_handler_test.c
+++ b/tests/alpn_handler_test.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/channel.h>

--- a/tests/channel_test.c
+++ b/tests/channel_test.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/common/atomics.h>

--- a/tests/default_host_resolver_test.c
+++ b/tests/default_host_resolver_test.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/common/condition_variable.h>

--- a/tests/error_test.c
+++ b/tests/error_test.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/testing/aws_test_harness.h>

--- a/tests/event_loop_test.c
+++ b/tests/event_loop_test.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/common/atomics.h>

--- a/tests/exponential_backoff_retry_test.c
+++ b/tests/exponential_backoff_retry_test.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2020 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/io/retry_strategy.h>
 

--- a/tests/file_utils_test.c
+++ b/tests/file_utils_test.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/file_utils.h>

--- a/tests/io_testing_channel_test.c
+++ b/tests/io_testing_channel_test.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/testing/io_testing_channel.h>
 

--- a/tests/mock_dns_resolver.c
+++ b/tests/mock_dns_resolver.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include "mock_dns_resolver.h"
 

--- a/tests/mock_dns_resolver.h
+++ b/tests/mock_dns_resolver.h
@@ -1,18 +1,8 @@
 #ifndef AWS_MOCK_DNS_RESOLVER_H
 #define AWS_MOCK_DNS_RESOLVER_H
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/common/array_list.h>
 #include <aws/io/io.h>

--- a/tests/pipe_test.c
+++ b/tests/pipe_test.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/common/clock.h>
 #include <aws/common/condition_variable.h>

--- a/tests/pki_utils_test.c
+++ b/tests/pki_utils_test.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/testing/aws_test_harness.h>

--- a/tests/pki_utils_test.c
+++ b/tests/pki_utils_test.c
@@ -486,7 +486,7 @@ static int s_test_pem_cert_parse_from_file(struct aws_allocator *allocator, void
     struct aws_array_list output_list;
 
     ASSERT_SUCCESS(aws_array_list_init_dynamic(&output_list, allocator, 1, sizeof(struct aws_byte_buf)));
-    ASSERT_SUCCESS(aws_read_and_decode_pem_file_to_buffer_list(allocator, "./unittests.crt", &output_list));
+    ASSERT_SUCCESS(aws_read_and_decode_pem_file_to_buffer_list(allocator, "unittests.crt", &output_list));
     ASSERT_UINT_EQUALS(1, aws_array_list_length(&output_list));
 
     struct aws_byte_buf *cert_data = NULL;
@@ -577,7 +577,7 @@ static int s_test_pem_private_key_parse_from_file(struct aws_allocator *allocato
     struct aws_array_list output_list;
 
     ASSERT_SUCCESS(aws_array_list_init_dynamic(&output_list, allocator, 1, sizeof(struct aws_byte_buf)));
-    ASSERT_SUCCESS(aws_read_and_decode_pem_file_to_buffer_list(allocator, "./unittests.key", &output_list));
+    ASSERT_SUCCESS(aws_read_and_decode_pem_file_to_buffer_list(allocator, "unittests.key", &output_list));
     ASSERT_UINT_EQUALS(1, aws_array_list_length(&output_list));
 
     struct aws_byte_buf *cert_data = NULL;

--- a/tests/read_write_test_handler.c
+++ b/tests/read_write_test_handler.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include "read_write_test_handler.h"

--- a/tests/read_write_test_handler.h
+++ b/tests/read_write_test_handler.h
@@ -1,18 +1,8 @@
 #ifndef AWS_READ_WRITE_TEST_HANDLER
 #define AWS_READ_WRITE_TEST_HANDLER
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/io.h>

--- a/tests/shared_library_test.c
+++ b/tests/shared_library_test.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/shared_library.h>

--- a/tests/socket_handler_test.c
+++ b/tests/socket_handler_test.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/io/channel_bootstrap.h>
 #include <aws/io/event_loop.h>

--- a/tests/socket_test.c
+++ b/tests/socket_test.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/testing/aws_test_harness.h>

--- a/tests/statistics_handler_test.c
+++ b/tests/statistics_handler_test.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include "statistics_handler_test.h"

--- a/tests/statistics_handler_test.h
+++ b/tests/statistics_handler_test.h
@@ -1,19 +1,9 @@
 #ifndef STATISTICS_HANDLER_TEST_H
 #define STATISTICS_HANDLER_TEST_H
 
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/common/condition_variable.h>

--- a/tests/stream_test.c
+++ b/tests/stream_test.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/testing/aws_test_harness.h>

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -60,10 +60,10 @@ static int s_tls_server_opt_tester_init(struct aws_allocator *allocator, struct 
 
 #ifdef __APPLE__
     struct aws_byte_cursor pwd_cur = aws_byte_cursor_from_c_str("1234");
-    aws_tls_ctx_options_init_server_pkcs12_from_path(&tester->ctx_options, allocator, "./unittests.p12", &pwd_cur);
+    aws_tls_ctx_options_init_server_pkcs12_from_path(&tester->ctx_options, allocator, "unittests.p12", &pwd_cur);
 #else
     aws_tls_ctx_options_init_default_server_from_path(
-        &tester->ctx_options, allocator, "./unittests.crt", "./unittests.key");
+        &tester->ctx_options, allocator, "unittests.crt", "unittests.key");
 #endif /* __APPLE__ */
     aws_tls_ctx_options_set_alpn_list(&tester->ctx_options, "h2;http/1.1");
     tester->ctx = aws_tls_server_ctx_new(allocator, &tester->ctx_options);
@@ -81,7 +81,7 @@ static int s_tls_client_opt_tester_init(
     aws_io_library_init(allocator);
 
     aws_tls_ctx_options_init_default_client(&tester->ctx_options, allocator);
-    aws_tls_ctx_options_override_default_trust_store_from_path(&tester->ctx_options, NULL, "./unittests.crt");
+    aws_tls_ctx_options_override_default_trust_store_from_path(&tester->ctx_options, NULL, "unittests.crt");
 
     tester->ctx = aws_tls_client_ctx_new(allocator, &tester->ctx_options);
     aws_tls_connection_options_init_from_ctx(&tester->opt, tester->ctx);
@@ -1603,7 +1603,7 @@ static int s_test_concurrent_cert_import(struct aws_allocator *allocator, void *
     /* setup, note that all I/O should be before the threads are launched */
     for (size_t idx = 0; idx < NUM_PAIRS; ++idx) {
         char filename[1024];
-        sprintf(filename, "./key_pair%u.pem", (uint32_t)idx);
+        sprintf(filename, "key_pair%u.pem", (uint32_t)idx);
 
         struct import_info *import = &imports[idx];
         import->allocator = allocator;

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2018 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 
 #include <aws/io/channel_bootstrap.h>

--- a/tests/uri_test.c
+++ b/tests/uri_test.c
@@ -1,16 +1,6 @@
-/*
- * Copyright 2010-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
- *
- * Licensed under the Apache License, Version 2.0 (the "License").
- * You may not use this file except in compliance with the License.
- * A copy of the License is located at
- *
- *  http://aws.amazon.com/apache2.0
- *
- * or in the "license" file accompanying this file. This file is distributed
- * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
- * express or implied. See the License for the specific language governing
- * permissions and limitations under the License.
+/**
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ * SPDX-License-Identifier: Apache-2.0.
  */
 #include <aws/io/uri.h>
 #include <aws/testing/aws_test_harness.h>

--- a/tests/vcc/Makefile
+++ b/tests/vcc/Makefile
@@ -1,0 +1,30 @@
+VCC?=vcc
+VCC_ARGS+=/sm
+GIT?=git
+NO_CHANGE_EXPECTED_HASH=84bfb96d0
+NO_CHANGE_FILE=source/linux/epoll_event_loop.c
+
+# The VCC proofs in this directory are based on a snapshot of
+# epoll_event_loop.c. This target fails if the source file has changed, in
+# which case the proof results may no longer be valid.
+.phony: .no_change
+.no_change:
+	cd ../.. && $(GIT) diff --quiet $(NO_CHANGE_EXPECTED_HASH) $(NO_CHANGE_FILE)
+
+.phony: .proofs
+.proofs:
+	$(VCC) $(VCC_ARGS) preamble.h
+	$(VCC) $(VCC_ARGS) subscribe.c /f:s_subscribe_to_io_events
+	$(VCC) $(VCC_ARGS) unsubscribe.c /f:s_unsubscribe_from_io_events
+	$(VCC) $(VCC_ARGS) schedule.c /f:s_schedule_task_common /f:s_schedule_task_now /f:s_schedule_task_future
+	$(VCC) $(VCC_ARGS) cancel_task.c /f:s_cancel_task
+	$(VCC) $(VCC_ARGS) is_on_callers_thread.c /f:s_is_on_callers_thread
+	$(VCC) $(VCC_ARGS) process_task_pre_queue.c /f:s_process_task_pre_queue
+	$(VCC) $(VCC_ARGS) lifecycle.c /f:s_stop_task /f:s_stop /f:s_wait_for_stop_completion /f:s_run
+	$(VCC) $(VCC_ARGS) main_loop.c /f:s_on_tasks_to_schedule /f:s_main_loop
+	$(VCC) $(VCC_ARGS) new_destroy.c /f:aws_event_loop_new_default /f:s_destroy /p:"-DUSE_EFD=0"
+	$(VCC) $(VCC_ARGS) new_destroy.c /f:aws_event_loop_new_default /f:s_destroy /p:"-DUSE_EFD=1"
+	$(VCC) $(VCC_ARGS) client.c /f:test_new_destroy /f:test_subscribe_unsubscribe
+
+.phony: all
+all: .no_change .proofs

--- a/tests/vcc/README.md
+++ b/tests/vcc/README.md
@@ -1,0 +1,65 @@
+# VCC Proofs of the Linux epoll event loop
+
+This directory gives the specification and annotated source-code implementation
+of the Linux epoll event loop implementation of C-IO. See
+`docs/epoll_event_loop_proof.md` for an overview of the properties proven,
+assumptions and simplifications.
+
+## Reading the proofs
+
+The majority of the specification is given in the header file `preamble.h`,
+which specifies a contract (preconditions and postconditions) for each
+implementation function.
+
+The proofs themselves are the source code of the Linux epoll event loop
+implementation with VCC annotations embedded alongside to guide VCC.
+We split the event loop functions over the following files:
+
+  - `cancel_task.c`
+  - `is_on_callers_thread.c`
+  - `lifecycle.c`
+  - `main_loop.c`
+  - `new_destroy.c`
+  - `process_task_pre_queue.c`
+  - `schedule.c`
+  - `subscribe.c`
+  - `unsubscribe.c`
+
+Additionally, the file `client.c` shows some simple uses of the event loop API,
+demonstrating that the specifications can be used together in a meaningful way.
+
+## Running proof regression
+
+The following will check all proofs assuming VCC and make are on your path.
+For obtaining VCC, see the next section on building VCC in a Windows docker
+container.
+
+        $ make
+
+## VCC docker container
+
+I've tested the following on Windows 10 1809 with Docker Desktop 2.2.03.
+
+1. Make sure that docker is running with Windows containers. Another good
+sanity check is to ensure `docker run hello-world` works as expected.
+
+2. Build the image (this takes about 30 minutes)
+
+        docker build -t vcc docker-images/win10-vs2012/
+
+3. Run an interactive powershell in a container
+
+        docker run -it vcc powershell
+
+4. Inside the container check VCC works
+
+        vcc "C:\vcc\vcc\Test\testsuite\examples3\ArrayList.c"
+        Verification of ArrayList#adm succeeded.[1.36]
+        Verification of Length succeeded. [0.01]
+        Verification of CreateArrayList succeeded. [0.05]
+        Verification of MakeEmpty succeeded. [0.03]
+        Verification of Select succeeded. [0.02]
+        Verification of Update succeeded. [0.05]
+        Verification of DisposeArrayList succeeded. [0.03]
+        Verification of Add succeeded. [0.44]
+        Verification of main_test succeeded. [0.67]

--- a/tests/vcc/cancel_task.c
+++ b/tests/vcc/cancel_task.c
@@ -1,0 +1,24 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/* clang-format off */
+#include "preamble.h"
+
+static void s_cancel_task(struct aws_event_loop *event_loop, struct aws_task *task) {
+    AWS_LOGF_TRACE(AWS_LS_IO_EVENT_LOOP, "id=%p: cancelling task %p", (void *)event_loop, (void *)task);
+    struct epoll_loop *epoll_loop = event_loop->impl_data;
+    aws_task_scheduler_cancel_task(&epoll_loop->scheduler, task);
+}
+/* clang-format on */

--- a/tests/vcc/client.c
+++ b/tests/vcc/client.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/* clang-format off */
+#include "preamble.h"
+
+struct aws_allocator *aws_default_allocator()
+    _(ensures \wrapped(\result))
+;
+
+uint64_t next_timestamp();
+
+int clock(uint64_t *timestamp)
+    _(writes timestamp)
+{
+    *timestamp = next_timestamp();
+    return AWS_OP_SUCCESS;
+}
+
+void test_new_destroy()
+{
+    struct aws_allocator *alloc = aws_default_allocator();
+    _(ghost \claim c_mutex)
+    struct aws_event_loop *event_loop = aws_event_loop_new_default(alloc, clock, _(out c_mutex));
+    if (!event_loop) return;
+    _(ghost \claim c_event_loop;)
+    _(ghost c_event_loop = \make_claim({event_loop}, event_loop->\closed);)
+    s_destroy(event_loop _(ghost c_event_loop) _(ghost c_mutex));
+}
+
+void on_event(
+    struct aws_event_loop *event_loop,
+    struct aws_io_handle *handle,
+    int events,
+    void *user_data _(ghost \claim(c))
+);
+
+void test_subscribe_unsubscribe(struct aws_event_loop *event_loop
+    _(ghost \claim(c_event_loop))
+    _(ghost \claim(c_mutex))
+)
+    _(always c_event_loop, event_loop->\closed)
+    _(requires \wrapped(c_mutex) && \claims_object(c_mutex, &(epoll_loop_of(event_loop)->task_pre_queue_mutex)))
+    _(writes event_loop)
+    _(updates &epoll_loop_of(event_loop)->scheduler)
+{
+    struct aws_io_handle *handle = malloc(sizeof(struct aws_io_handle));
+    if (!handle) return;
+    handle->data.fd = 1; /* model successful open() */
+    _(wrap handle)
+    int err = s_subscribe_to_io_events(event_loop, handle, 0, on_event, NULL, _(ghost c_event_loop));
+    if (err) {
+      return;
+    }
+    _(assert wf_cio_handle(handle))
+    _(assert \wrapped((struct epoll_event_data *)handle->additional_data))
+    _(assert ((struct epoll_event_data *)handle->additional_data)->\owner == \me)
+    s_unsubscribe_from_io_events(event_loop, handle _(ghost c_event_loop) _(ghost c_mutex));
+}
+
+void task_fn(struct aws_task *task, void *arg, enum aws_task_status) {
+    (void)task;
+    (void)arg;
+}
+
+void test_schedule_cancel(struct aws_event_loop *event_loop
+    _(ghost \claim(c_event_loop))
+    _(ghost \claim(c_mutex))
+)
+    _(requires \wrapped(event_loop))
+    _(always c_event_loop, event_loop->\closed)
+    _(requires \wrapped(c_mutex) && \claims_object(c_mutex, &(epoll_loop_of(event_loop)->task_pre_queue_mutex)))
+    _(updates &epoll_loop_of(event_loop)->scheduler)
+{
+    struct aws_task *task = malloc(sizeof(struct aws_task));
+    if (!task) return;
+    aws_task_init(task, task_fn, NULL, "test_task");
+    s_schedule_task_now(event_loop, task _(ghost c_event_loop) _(ghost c_mutex));
+    s_cancel_task(event_loop, task);
+}
+/* clang-format on */

--- a/tests/vcc/docker-images/win10-vs2012/Dockerfile
+++ b/tests/vcc/docker-images/win10-vs2012/Dockerfile
@@ -1,0 +1,32 @@
+# escape=`
+
+FROM mcr.microsoft.com/windows:1809
+
+CMD [ "cmd.exe" ]
+
+RUN powershell -NoProfile -InputFormat None -ExecutionPolicy Bypass -Command "[System.Net.ServicePointManager]::SecurityProtocol = 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://chocolatey.org/install.ps1'))" && SET "PATH=%PATH%;%ALLUSERSPROFILE%\chocolatey\bin" && `
+    choco install -y --timeout 0 git make python2 visualstudio2012professional && `
+    refreshenv && `
+    git --version
+
+RUN git clone https://github.com/nchong-at-aws/vcc.git && `
+    git clone https://github.com/z3prover/z3.git
+
+RUN cd "C:\Program Files (x86)\Microsoft Visual Studio 11.0\Common7\Tools" && `
+    .\vsvars32.bat && `
+    cd "C:\z3" && `
+    git checkout z3-4.3.0 && `
+    python scripts\mk_make.py && `
+    cd "build" && `
+    nmake && `
+    cd "C:\vcc" && `
+    # some vcc build failures are acceptable
+    (msbuild || exit 0)
+
+RUN copy /Y "C:\z3\build\z3.exe" "C:\vcc\vcc\Host\bin\Debug\z3.exe"
+
+# Add vcc to path
+RUN powershell -Command "$path = $env:path + ';C:\vcc\vcc\Host\bin\Debug'; Set-ItemProperty -Path 'HKLM:\SYSTEM\CurrentControlSet\Control\Session Manager\Environment\' -Name Path -Value $path"
+
+# sanity check
+RUN vcc "C:\vcc\vcc\Test\testsuite\examples3\ArrayList.c"

--- a/tests/vcc/is_on_callers_thread.c
+++ b/tests/vcc/is_on_callers_thread.c
@@ -1,0 +1,33 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/* clang-format off */
+#include "preamble.h"
+
+static bool s_is_on_callers_thread(struct aws_event_loop *event_loop
+    _(ghost \claim(c_event_loop))
+) {
+    _(assert \always_by_claim(c_event_loop, event_loop))
+    struct epoll_loop *epoll_loop = event_loop->impl_data;
+    _(assert \always_by_claim(c_event_loop, epoll_loop))
+    _(assert \inv(epoll_loop))
+
+    aws_thread_id_t *thread_id = aws_atomic_load_ptr(&epoll_loop->running_thread_id);
+    _(assume \thread_local(thread_id))
+    _(assume thread_id == NULL || *thread_id == \addr(event_loop->\owner))
+
+    return thread_id && aws_thread_thread_id_equal(*thread_id, aws_thread_current_thread_id());
+}
+/* clang-format on */

--- a/tests/vcc/lifecycle.c
+++ b/tests/vcc/lifecycle.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/* clang-format off */
+#define STOP_TASK_FN_PTR
+#include "preamble.h"
+
+static void s_stop_task(struct aws_task *task, void *args, enum aws_task_status status) {
+
+    (void)task;
+    struct aws_event_loop *event_loop = args;
+    struct epoll_loop *epoll_loop = event_loop->impl_data;
+
+    _(unwrap &epoll_loop->stop_task_ptr)
+    aws_atomic_store_ptr(&epoll_loop->stop_task_ptr, NULL);
+    _(wrap &epoll_loop->stop_task_ptr)
+    if (status == AWS_TASK_STATUS_RUN_READY) {
+        /*
+         * this allows the event loop to invoke the callback once the event loop has completed.
+         */
+        _(unwrap epoll_loop::status)
+        epoll_loop->should_continue = false;
+        _(wrap epoll_loop::status)
+    }
+}
+
+static int s_stop(struct aws_event_loop *event_loop
+    _(ghost \claim(c_event_loop))
+    _(ghost \claim(c_mutex))
+) {
+    _(assert \always_by_claim(c_event_loop, event_loop))
+    struct epoll_loop *epoll_loop = event_loop->impl_data;
+
+    void *expected_ptr = NULL;
+    _(unwrap &epoll_loop->stop_task_ptr)
+    bool update_succeeded =
+        aws_atomic_compare_exchange_ptr(&epoll_loop->stop_task_ptr, &expected_ptr, &epoll_loop->stop_task);
+    _(wrap &epoll_loop->stop_task_ptr)
+    if (!update_succeeded) {
+        /* the stop task is already scheduled. */
+        return AWS_OP_SUCCESS;
+    }
+    AWS_LOGF_INFO(AWS_LS_IO_EVENT_LOOP, "id=%p: Stopping event-loop thread.", (void *)event_loop);
+    aws_task_init(&epoll_loop->stop_task, s_stop_task, event_loop, "epoll_event_loop_stop");
+    s_schedule_task_now(event_loop, &epoll_loop->stop_task _(ghost c_event_loop) _(ghost c_mutex));
+
+    return AWS_OP_SUCCESS;
+}
+
+int aws_thread_join(struct aws_thread *thread
+    _(ghost struct aws_event_loop *event_loop) _(ghost \claim(c_event_loop)) _(ghost \claim(c_mutex))
+)
+    _(requires c_event_loop != c_mutex)
+    _(requires \wrapped0(c_event_loop) && \claims(c_event_loop, event_loop->\closed) && \claims_object(c_event_loop, event_loop))
+    _(writes c_event_loop, event_loop)
+    _(ensures !c_event_loop->\closed)
+    _(ensures \wrapped0(event_loop) && \nested(epoll_loop_of(event_loop)))
+    _(ensures ownership_of_epoll_loop_objects(epoll_loop_of(event_loop)))
+    _(ensures epoll_loop_of(event_loop)->task_pre_queue_mutex.locked == 0)
+    _(maintains \malloc_root(epoll_loop_of(event_loop)))
+    _(maintains \wrapped0(c_mutex) && \claims_object(c_mutex, &epoll_loop_of(event_loop)->task_pre_queue_mutex))
+;
+
+static int s_wait_for_stop_completion(struct aws_event_loop *event_loop
+    _(ghost \claim(c_event_loop)) _(ghost \claim(c_mutex))
+) {
+    struct epoll_loop *epoll_loop = _(by_claim c_event_loop) event_loop->impl_data;
+    return aws_thread_join(&epoll_loop->thread_created_on _(ghost event_loop) _(ghost c_event_loop) _(ghost c_mutex));
+}
+
+int aws_thread_launch(
+    struct aws_thread *thread,
+    void (*func)(void *arg),
+    void *arg,
+    const struct aws_thread_options *options)
+    _(requires \wrapped0(event_loop_of(arg)))
+    _(requires func->\valid)
+;
+
+/* Not modeled: thread launch ownership change semantics */
+void dummy_main_loop(void *arg); /*< VCC change */
+
+static int s_run(struct aws_event_loop *event_loop _(ghost \claim(c_mutex))) {
+    struct epoll_loop *epoll_loop = event_loop->impl_data;
+
+    AWS_LOGF_INFO(AWS_LS_IO_EVENT_LOOP, "id=%p: Starting event-loop thread.", (void *)event_loop);
+
+    epoll_loop->should_continue = true;
+    if (aws_thread_launch(&epoll_loop->thread_created_on, /*&s_main_loop*/&dummy_main_loop, event_loop, NULL)) {
+        AWS_LOGF_FATAL(AWS_LS_IO_EVENT_LOOP, "id=%p: thread creation failed.", (void *)event_loop);
+        epoll_loop->should_continue = false;
+        return AWS_OP_ERR;
+    }
+
+    return AWS_OP_SUCCESS;
+}
+/* clang-format on */

--- a/tests/vcc/main_loop.c
+++ b/tests/vcc/main_loop.c
@@ -1,0 +1,176 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/* clang-format off */
+#include "preamble.h"
+
+#define DEFAULT_TIMEOUT 100000
+#define MAX_EVENTS 100
+
+static void s_on_tasks_to_schedule(
+    struct aws_event_loop *event_loop,
+    struct aws_io_handle *handle,
+    int events,
+    void *user_data _(ghost \claim(c_event_loop))
+) {
+    (void)handle;
+    (void)user_data;
+
+    AWS_LOGF_TRACE(AWS_LS_IO_EVENT_LOOP, "id=%p: notified of cross-thread tasks to schedule", (void *)event_loop);
+    struct epoll_loop *epoll_loop = event_loop->impl_data;
+    if (events & AWS_IO_EVENT_TYPE_READABLE) {
+        epoll_loop->should_process_task_pre_queue = true;
+    }
+}
+
+static void s_main_loop(void *args _(ghost \claim(c_mutex))) {
+    struct aws_event_loop *event_loop = args;
+    AWS_LOGF_INFO(AWS_LS_IO_EVENT_LOOP, "id=%p: main loop started", (void *)event_loop);
+    struct epoll_loop *epoll_loop = event_loop->impl_data;
+    _(ghost \claim c_event_loop;)
+    _(ghost c_event_loop = \make_claim({event_loop}, event_loop->\closed);)
+
+    /* set thread id to the thread of the event loop */
+    _(unwrap &epoll_loop->running_thread_id)
+    aws_atomic_store_ptr(&epoll_loop->running_thread_id, &epoll_loop->thread_created_on.thread_id);
+    _(wrap &epoll_loop->running_thread_id)
+
+    int err = s_subscribe_to_io_events(
+        event_loop, &epoll_loop->read_task_handle, AWS_IO_EVENT_TYPE_READABLE, s_on_tasks_to_schedule, NULL _(ghost c_event_loop));
+    if (err) {
+        return;
+    }
+
+    int timeout = DEFAULT_TIMEOUT;
+
+    struct epoll_event events[MAX_EVENTS];
+
+    AWS_LOGF_INFO(
+        AWS_LS_IO_EVENT_LOOP,
+        "id=%p: default timeout %d, and max events to process per tick %d",
+        (void *)event_loop,
+        timeout,
+        MAX_EVENTS);
+
+    /*
+     * until stop is called,
+     * call epoll_wait, if a task is scheduled, or a file descriptor has activity, it will
+     * return.
+     *
+     * process all events,
+     *
+     * run all scheduled tasks.
+     *
+     * process queued subscription cleanups.
+     */
+    while (epoll_loop->should_continue)
+      _(invariant \extent_mutable((struct epoll_event[MAX_EVENTS]) events))
+      _(invariant (&epoll_loop->read_task_handle)->\closed)
+      _(invariant \wrapped(&epoll_loop->scheduler))
+      _(writes &epoll_loop->scheduler)
+      _(writes &epoll_loop->should_process_task_pre_queue)
+      _(writes \extent((struct epoll_event[MAX_EVENTS]) events))
+    {
+        AWS_LOGF_TRACE(AWS_LS_IO_EVENT_LOOP, "id=%p: waiting for a maximum of %d ms", (void *)event_loop, timeout);
+        int event_count = epoll_wait(epoll_loop->epoll_fd, events, MAX_EVENTS, timeout);
+        AWS_LOGF_TRACE(
+            AWS_LS_IO_EVENT_LOOP, "id=%p: wake up with %d events to process.", (void *)event_loop, event_count);
+        for (int i = 0; i < event_count; ++i)
+            _(writes &epoll_loop->should_process_task_pre_queue)
+        {
+            struct epoll_event_data *event_data = (struct epoll_event_data *)events[i].data.ptr;
+            _(assert \wrapped(event_data))
+            _(assert \inv(event_data))
+
+            int event_mask = 0;
+            if (events[i].events & EPOLLIN) {
+                event_mask |= AWS_IO_EVENT_TYPE_READABLE;
+            }
+
+            if (events[i].events & EPOLLOUT) {
+                event_mask |= AWS_IO_EVENT_TYPE_WRITABLE;
+            }
+
+            if (events[i].events & EPOLLRDHUP) {
+                event_mask |= AWS_IO_EVENT_TYPE_REMOTE_HANG_UP;
+            }
+
+            if (events[i].events & EPOLLHUP) {
+                event_mask |= AWS_IO_EVENT_TYPE_CLOSED;
+            }
+
+            if (events[i].events & EPOLLERR) {
+                event_mask |= AWS_IO_EVENT_TYPE_ERROR;
+            }
+
+            if (event_data->is_subscribed) {
+                AWS_LOGF_TRACE(
+                    AWS_LS_IO_EVENT_LOOP,
+                    "id=%p: activity on fd %d, invoking handler.",
+                    (void *)event_loop,
+                    event_data->handle->data.fd);
+                event_data->on_event(event_loop, event_data->handle, event_mask, event_data->user_data _(ghost c_event_loop));
+            }
+        }
+
+        /* run scheduled tasks */
+        s_process_task_pre_queue(event_loop _(ghost c_event_loop) _(ghost c_mutex));
+
+        uint64_t now_ns = 0;
+        event_loop->clock(&now_ns); /* if clock fails, now_ns will be 0 and tasks scheduled for a specific time
+                                       will not be run. That's ok, we'll handle them next time around. */
+        AWS_LOGF_TRACE(AWS_LS_IO_EVENT_LOOP, "id=%p: running scheduled tasks.", (void *)event_loop);
+        aws_task_scheduler_run_all(&epoll_loop->scheduler, now_ns);
+
+        /* set timeout for next epoll_wait() call.
+         * if clock fails, or scheduler has no tasks, use default timeout */
+        bool use_default_timeout = false;
+
+        if (event_loop->clock(&now_ns)) {
+            use_default_timeout = true;
+        }
+
+        uint64_t next_run_time_ns;
+        if (!aws_task_scheduler_has_tasks(&epoll_loop->scheduler, &next_run_time_ns)) {
+            use_default_timeout = true;
+        }
+
+        if (use_default_timeout) {
+            AWS_LOGF_TRACE(
+                AWS_LS_IO_EVENT_LOOP, "id=%p: no more scheduled tasks using default timeout.", (void *)event_loop);
+            timeout = DEFAULT_TIMEOUT;
+        } else {
+            /* Translate timestamp (in nanoseconds) to timeout (in milliseconds) */
+            uint64_t timeout_ns = (next_run_time_ns > now_ns) ? (next_run_time_ns - now_ns) : 0;
+            uint64_t timeout_ms64 = aws_timestamp_convert(timeout_ns, AWS_TIMESTAMP_NANOS, AWS_TIMESTAMP_MILLIS, NULL);
+            timeout = timeout_ms64 > INT_MAX ? INT_MAX : (int)timeout_ms64;
+            AWS_LOGF_TRACE(
+                AWS_LS_IO_EVENT_LOOP,
+                "id=%p: detected more scheduled tasks with the next occurring at "
+                "%llu, using timeout of %d.",
+                (void *)event_loop,
+                (unsigned long long)timeout_ns,
+                timeout);
+        }
+    }
+
+    AWS_LOGF_DEBUG(AWS_LS_IO_EVENT_LOOP, "id=%p: exiting main loop", (void *)event_loop);
+    s_unsubscribe_from_io_events(event_loop, &epoll_loop->read_task_handle _(ghost c_event_loop) _(ghost c_mutex));
+    /* set thread id back to NULL. This should be updated again in destroy, before tasks are canceled. */
+    _(unwrap &epoll_loop->running_thread_id)
+    aws_atomic_store_ptr(&epoll_loop->running_thread_id, NULL);
+    _(wrap &epoll_loop->running_thread_id)
+}
+/* clang-format on */

--- a/tests/vcc/new_destroy.c
+++ b/tests/vcc/new_destroy.c
@@ -1,0 +1,290 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/* clang-format off */
+#include "preamble.h"
+
+/* VCC change: clock fnptr */
+int aws_event_loop_init_base(struct aws_event_loop *loop, struct aws_allocator *allocator, aws_io_clock_fn_ptr clock)
+    _(writes &loop->alloc)
+    _(writes &loop->clock)
+    _(maintains \wrapped(allocator))
+    _(ensures \result == 0 <==> loop->alloc == allocator && loop->clock->\valid)
+;
+
+/* Cleans up hash-table (but not modeled) */
+void aws_event_loop_clean_up_base(struct aws_event_loop *loop)
+    _(writes \extent(loop))
+    _(ensures \mutable(loop))
+;
+
+void close(int fd)
+    _(requires valid_fd(fd))
+;
+
+struct aws_event_loop_vtable s_vtable;
+
+#if USE_EFD
+enum
+  {
+    EFD_SEMAPHORE = 1,
+#define EFD_SEMAPHORE EFD_SEMAPHORE
+    EFD_CLOEXEC = 02000000,
+#define EFD_CLOEXEC EFD_CLOEXEC
+    EFD_NONBLOCK = 04000
+#define EFD_NONBLOCK EFD_NONBLOCK
+  };
+int eventfd(unsigned int initval, int flags);
+#else
+int aws_open_nonblocking_posix_pipe(/*int pipe_fds[2]*/int *pipe_fds)
+    _(writes \extent((int[2]) pipe_fds))
+    _(ensures \extent_mutable((int[2]) pipe_fds))
+    _(ensures \result == AWS_OP_SUCCESS <==>
+              valid_fd(pipe_fds[0]) && valid_fd(pipe_fds[1]))
+;
+#endif
+
+struct aws_event_loop *aws_event_loop_new_default(struct aws_allocator *alloc, aws_io_clock_fn_ptr clock
+    _(out \claim(c_mutex))
+) {
+    struct aws_event_loop *loop = aws_mem_calloc(alloc, 1, sizeof(struct aws_event_loop));
+    if (!loop) {
+        return NULL;
+    }
+
+    AWS_LOGF_INFO(AWS_LS_IO_EVENT_LOOP, "id=%p: Initializing edge-triggered epoll", (void *)loop);
+    if (aws_event_loop_init_base(loop, alloc, clock)) {
+        goto clean_up_loop;
+    }
+
+    struct epoll_loop *epoll_loop = aws_mem_calloc(alloc, 1, sizeof(struct epoll_loop));
+    if (!epoll_loop) {
+        goto cleanup_base_loop;
+    }
+
+    /* initialize thread id to NULL, it should be updated when the event loop thread starts. */
+    aws_atomic_init_ptr(&epoll_loop->running_thread_id, NULL);
+
+    aws_linked_list_init(&epoll_loop->task_pre_queue);
+    epoll_loop->task_pre_queue_mutex = (struct aws_mutex)AWS_MUTEX_INIT;
+    aws_atomic_init_ptr(&epoll_loop->stop_task_ptr, NULL);
+
+    epoll_loop->epoll_fd = epoll_create(100);
+    if (epoll_loop->epoll_fd < 0) {
+        AWS_LOGF_FATAL(AWS_LS_IO_EVENT_LOOP, "id=%p: Failed to open epoll handle.", (void *)loop);
+        aws_raise_error(AWS_ERROR_SYS_CALL_FAILURE);
+        goto clean_up_epoll;
+    }
+
+    if (aws_thread_init(&epoll_loop->thread_created_on, alloc)) {
+        goto clean_up_epoll;
+    }
+
+#if USE_EFD
+    AWS_LOGF_INFO(AWS_LS_IO_EVENT_LOOP, "id=%p: Using eventfd for cross-thread notifications.", (void *)loop);
+    int fd = eventfd(0, EFD_CLOEXEC | EFD_NONBLOCK);
+
+    if (fd < 0) {
+        AWS_LOGF_FATAL(AWS_LS_IO_EVENT_LOOP, "id=%p: Failed to open eventfd handle.", (void *)loop);
+        aws_raise_error(AWS_ERROR_SYS_CALL_FAILURE);
+        goto clean_up_thread;
+    }
+
+    AWS_LOGF_TRACE(AWS_LS_IO_EVENT_LOOP, "id=%p: eventfd descriptor %d.", (void *)loop, fd);
+    epoll_loop->write_task_handle = (struct aws_io_handle){.data.fd = fd, .additional_data = NULL};
+    epoll_loop->read_task_handle = (struct aws_io_handle){.data.fd = fd, .additional_data = NULL};
+#else
+    /* VCC change: array init using {0} */
+#if 0
+    int pipe_fds[2] = {0};
+#else
+    int pipe_fds[2];
+    pipe_fds[0] = 0; pipe_fds[1] = 0;
+#endif
+    /* this pipe is for task scheduling. */
+    if (aws_open_nonblocking_posix_pipe(pipe_fds)) {
+        AWS_LOGF_FATAL(AWS_LS_IO_EVENT_LOOP, "id=%p: failed to open pipe handle.", (void *)loop);
+        goto clean_up_thread;
+    }
+
+    AWS_LOGF_TRACE(
+        AWS_LS_IO_EVENT_LOOP, "id=%p: pipe descriptors read %d, write %d.", (void *)loop, pipe_fds[0], pipe_fds[1]);
+    epoll_loop->write_task_handle.data.fd = pipe_fds[1];
+    epoll_loop->read_task_handle.data.fd = pipe_fds[0];
+#endif
+
+    if (aws_task_scheduler_init(&epoll_loop->scheduler, alloc)) {
+        goto clean_up_pipe;
+    }
+
+    epoll_loop->should_continue = false;
+
+    loop->impl_data = epoll_loop;
+    loop->vtable = &s_vtable;
+
+    _(wrap(&epoll_loop->task_pre_queue.head))
+    _(wrap(&epoll_loop->task_pre_queue.tail))
+    _(wrap(&epoll_loop->task_pre_queue))
+    epoll_loop->task_pre_queue_mutex.locked = 0;
+    _(ghost {
+        epoll_loop->task_pre_queue_mutex.protected_obj = &epoll_loop->task_pre_queue;
+        epoll_loop->task_pre_queue_mutex.\owns = {&epoll_loop->task_pre_queue};
+        _(wrap(&epoll_loop->task_pre_queue_mutex))
+        c_mutex = \make_claim({&epoll_loop->task_pre_queue_mutex}, epoll_loop->task_pre_queue_mutex.\closed);
+    })
+    _(wrap(&epoll_loop->write_task_handle))
+    _(wrap(&epoll_loop->scheduler.timed_queue))
+    _(wrap(&epoll_loop->scheduler.timed_list.head))
+    _(wrap(&epoll_loop->scheduler.timed_list.tail))
+    _(wrap(&epoll_loop->scheduler.timed_list))
+    _(wrap(&epoll_loop->scheduler.asap_list.head))
+    _(wrap(&epoll_loop->scheduler.asap_list.tail))
+    _(wrap(&epoll_loop->scheduler.asap_list))
+    _(wrap(&epoll_loop->scheduler))
+    _(wrap(&epoll_loop->thread_created_on))
+    _(wrap(&epoll_loop->running_thread_id))
+    _(wrap(&epoll_loop->read_task_handle))
+    _(wrap(&epoll_loop->stop_task.node))
+    _(wrap(&epoll_loop->stop_task.priority_queue_node))
+    _(wrap(&epoll_loop->stop_task))
+    _(wrap(&epoll_loop->stop_task_ptr))
+    _(wrap(epoll_loop::scheduler))
+    _(wrap(epoll_loop::read_handle))
+    _(wrap(epoll_loop::stop_task))
+    _(wrap(epoll_loop::queue))
+    _(wrap(epoll_loop::status))
+    _(wrap(epoll_loop))
+    _(wrap(loop))
+    return loop;
+
+clean_up_pipe:
+#if USE_EFD
+    close(epoll_loop->write_task_handle.data.fd);
+    epoll_loop->write_task_handle.data.fd = -1;
+    epoll_loop->read_task_handle.data.fd = -1;
+#else
+    close(epoll_loop->read_task_handle.data.fd);
+    close(epoll_loop->write_task_handle.data.fd);
+#endif
+
+clean_up_thread:
+    aws_thread_clean_up(&epoll_loop->thread_created_on);
+
+clean_up_epoll:
+    if (epoll_loop->epoll_fd >= 0) {
+        close(epoll_loop->epoll_fd);
+    }
+
+    aws_mem_release(alloc, epoll_loop);
+
+cleanup_base_loop:
+    aws_event_loop_clean_up_base(loop);
+
+clean_up_loop:
+    aws_mem_release(alloc, loop);
+
+    return NULL;
+}
+
+/* Fake-up call to s_stop since this is just a vtable lookup */
+#define aws_event_loop_stop(event_loop) \
+    s_stop(event_loop _(ghost c_event_loop) _(ghost c_mutex));
+
+static void s_destroy(struct aws_event_loop *event_loop
+    _(ghost \claim(c_event_loop)) _(ghost \claim(c_mutex))
+) {
+    AWS_LOGF_INFO(AWS_LS_IO_EVENT_LOOP, "id=%p: Destroying event_loop", (void *)event_loop);
+
+    struct epoll_loop *epoll_loop = event_loop->impl_data;
+
+    /* we don't know if stop() has been called by someone else,
+     * just call stop() again and wait for event-loop to finish. */
+    aws_event_loop_stop(event_loop);
+    s_wait_for_stop_completion(event_loop _(ghost c_event_loop) _(ghost c_mutex));
+    epoll_loop = event_loop->impl_data; /*< VCC change: refresh epoll_loop reference */
+    _(unwrap(event_loop))
+    _(unwrap(epoll_loop))
+    _(assert epoll_loop->task_pre_queue_mutex.\claim_count == 1)
+    _(ghost \destroy_claim(c_mutex, {&epoll_loop->task_pre_queue_mutex}))
+    _(assert epoll_loop->task_pre_queue_mutex.\claim_count == 0)
+    _(assert \wrapped0(&epoll_loop->task_pre_queue_mutex))
+    _(assert epoll_loop->task_pre_queue_mutex.locked == 0)
+    _(assert \inv(&epoll_loop->task_pre_queue_mutex))
+    _(unwrap(&epoll_loop->task_pre_queue_mutex))
+    _(assert \wrapped(&epoll_loop->task_pre_queue))
+
+    /* setting this so that canceled tasks don't blow up when asking if they're on the event-loop thread. */
+    epoll_loop->thread_joined_to = aws_thread_current_thread_id();
+    _(unwrap &epoll_loop->running_thread_id)
+    aws_atomic_store_ptr(&epoll_loop->running_thread_id, &epoll_loop->thread_joined_to);
+    _(wrap &epoll_loop->running_thread_id)
+    aws_task_scheduler_clean_up(&epoll_loop->scheduler);
+
+    while (!aws_linked_list_empty(&epoll_loop->task_pre_queue))
+        _(invariant 0 <= epoll_loop->task_pre_queue.length)
+        _(invariant \wrapped(&epoll_loop->task_pre_queue))
+        _(writes &epoll_loop->task_pre_queue)
+    {
+        _(ghost struct aws_task *t)
+        struct aws_linked_list_node *node = aws_linked_list_pop_front(&epoll_loop->task_pre_queue _(out t));
+        struct aws_task *task = AWS_CONTAINER_OF(node, struct aws_task, node);
+        task->fn(task, task->arg, AWS_TASK_STATUS_CANCELED);
+    }
+
+    _(unwrap(&epoll_loop->thread_created_on))
+    aws_thread_clean_up(&epoll_loop->thread_created_on);
+
+    _(unwrap(&epoll_loop->read_task_handle))
+    _(unwrap(&epoll_loop->write_task_handle))
+#if USE_EFD
+    close(epoll_loop->write_task_handle.data.fd);
+    epoll_loop->write_task_handle.data.fd = -1;
+    epoll_loop->read_task_handle.data.fd = -1;
+#else
+    close(epoll_loop->read_task_handle.data.fd);
+    close(epoll_loop->write_task_handle.data.fd);
+#endif
+
+    close(epoll_loop->epoll_fd);
+    /* successively unwrap epoll for imminent free() */
+    _(unwrap
+        epoll_loop::scheduler,
+        &epoll_loop->scheduler,
+        &epoll_loop->running_thread_id,
+        epoll_loop::read_handle,
+        epoll_loop::stop_task,
+        &epoll_loop->stop_task,
+        epoll_loop::queue,
+        &epoll_loop->task_pre_queue,
+        epoll_loop::status)
+    _(unwrap
+        &epoll_loop->scheduler.timed_queue,
+        &epoll_loop->scheduler.timed_list,
+        &epoll_loop->scheduler.asap_list,
+        &epoll_loop->stop_task.node,
+        &epoll_loop->stop_task.priority_queue_node,
+        &epoll_loop->stop_task_ptr,
+        &epoll_loop->task_pre_queue.head,
+        &epoll_loop->task_pre_queue.tail)
+    _(unwrap
+        &epoll_loop->scheduler.timed_list.head,
+        &epoll_loop->scheduler.timed_list.tail,
+        &epoll_loop->scheduler.asap_list.head,
+        &epoll_loop->scheduler.asap_list.tail)
+    aws_mem_release(event_loop->alloc, epoll_loop);
+    aws_event_loop_clean_up_base(event_loop);
+    aws_mem_release(event_loop->alloc, event_loop);
+}
+/* clang-format on */

--- a/tests/vcc/preamble.h
+++ b/tests/vcc/preamble.h
@@ -1,0 +1,818 @@
+#ifndef PREAMBLE_H
+#define PREAMBLE_H
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/* clang-format off */
+#include <vcc.h>
+#include <stdlib.h>
+#include <stddef.h>
+#include <stdint.h>
+
+/* Fake-up sys/types.h */
+typedef signed int ssize_t;
+
+/* Fake-up stdbool.h */
+typedef int bool;
+const int true = 1;
+const int false = 0;
+
+/* Definitions from epoll.h */
+typedef union epoll_data
+{
+  _(backing_member) void *ptr;
+  int fd; 
+  uint32_t u32;
+  uint64_t u64;
+} epoll_data_t;
+
+struct epoll_event
+{
+  uint32_t events;        /* Epoll events */
+  _(inline) epoll_data_t data;        /* User data variable */
+};
+
+enum EPOLL_EVENTS
+  {
+    EPOLLIN = 0x001,
+#define EPOLLIN EPOLLIN
+    EPOLLPRI = 0x002,
+#define EPOLLPRI EPOLLPRI
+    EPOLLOUT = 0x004,
+#define EPOLLOUT EPOLLOUT
+    EPOLLRDNORM = 0x040,
+#define EPOLLRDNORM EPOLLRDNORM
+    EPOLLRDBAND = 0x080,
+#define EPOLLRDBAND EPOLLRDBAND
+    EPOLLWRNORM = 0x100,
+#define EPOLLWRNORM EPOLLWRNORM
+    EPOLLWRBAND = 0x200,
+#define EPOLLWRBAND EPOLLWRBAND
+    EPOLLMSG = 0x400,
+#define EPOLLMSG EPOLLMSG
+    EPOLLERR = 0x008,
+#define EPOLLERR EPOLLERR
+    EPOLLHUP = 0x010,
+#define EPOLLHUP EPOLLHUP
+    EPOLLRDHUP = 0x2000,
+#define EPOLLRDHUP EPOLLRDHUP
+    EPOLLONESHOT = (1 << 30),
+#define EPOLLONESHOT EPOLLONESHOT
+    EPOLLET = (1 << 31)
+#define EPOLLET EPOLLET
+  };
+
+#define EPOLL_CTL_ADD 1        /* Add a file decriptor to the interface.  */
+#define EPOLL_CTL_DEL 2        /* Remove a file decriptor from the interface.  */
+#define EPOLL_CTL_MOD 3        /* Change file decriptor epoll_event structure.  */
+
+struct abstract_os_t {
+  int unused;
+  _(ghost \bool watched[int])
+} abstract_os_data;
+struct abstract_os_t *abstract_os = &abstract_os_data;
+
+int epoll_ctl (int __epfd, int __op, int __fd, struct epoll_event *__event)
+  _(ensures \result == 0 && __op == EPOLL_CTL_ADD ==>  abstract_os->watched[__fd])
+  _(ensures \result == 0 && __op == EPOLL_CTL_DEL ==> !abstract_os->watched[__fd])
+;
+
+struct epoll_event_data;
+int epoll_wait(int __epfd, struct epoll_event *__events, int maxevents, int timeout)
+  _(ensures \result <= maxevents)
+  /*TODO: use explicit triggers for quantifier instantiation*/
+  _(ensures \forall int i; {:level 2} 0 <= i && i < \result ==> \wrapped((struct epoll_event_data *)__events[i].data.ptr))
+  _(writes \extent((struct epoll_event[(unsigned)maxevents]) __events))
+  _(ensures \extent_mutable((struct epoll_event[(unsigned)maxevents]) __events))
+;
+
+int epoll_create(int size)
+  _(requires 0 < size)
+;
+
+/* Definitions from aws/common/macros.h */
+#define AWS_CONTAINER_OF(ptr, type, member) ((type *)((uint8_t *)(ptr)-offsetof(type, member)))
+#define AWS_UNLIKELY(x) x
+
+/* Definitions from aws/common/assert.h */
+/* Convert into VCC assertions */
+#define AWS_ASSERT(x) _(assert x)
+
+/* Definitions from aws/common/logging.h (no-ops for proof) */
+#define AWS_LOGF_INFO(...)
+#define AWS_LOGF_TRACE(...)
+#define AWS_LOGF_DEBUG(...)
+#define AWS_LOGF_ERROR(...)
+#define AWS_LOGF_FATAL(...)
+
+/* Definitions from aws/common/clock.h */
+enum aws_timestamp_unit {
+    AWS_TIMESTAMP_SECS = 1,
+    AWS_TIMESTAMP_MILLIS = 1000,
+    AWS_TIMESTAMP_MICROS = 1000000,
+    AWS_TIMESTAMP_NANOS = 1000000000,
+};
+
+uint64_t aws_timestamp_convert(
+    uint64_t timestamp,
+    enum aws_timestamp_unit convert_from,
+    enum aws_timestamp_unit convert_to,
+    uint64_t *remainder);
+
+/* Definitions from aws/common/error.h */
+#define AWS_OP_SUCCESS (0)
+#define AWS_OP_ERR (-1)
+
+enum aws_common_error {
+    AWS_ERROR_SUCCESS = 0,
+    AWS_ERROR_OOM,
+    AWS_ERROR_UNKNOWN,
+    AWS_ERROR_SHORT_BUFFER,
+    AWS_ERROR_OVERFLOW_DETECTED,
+    AWS_ERROR_UNSUPPORTED_OPERATION,
+    AWS_ERROR_INVALID_BUFFER_SIZE,
+    AWS_ERROR_INVALID_HEX_STR,
+    AWS_ERROR_INVALID_BASE64_STR,
+    AWS_ERROR_INVALID_INDEX,
+    AWS_ERROR_THREAD_INVALID_SETTINGS,
+    AWS_ERROR_THREAD_INSUFFICIENT_RESOURCE,
+    AWS_ERROR_THREAD_NO_PERMISSIONS,
+    AWS_ERROR_THREAD_NOT_JOINABLE,
+    AWS_ERROR_THREAD_NO_SUCH_THREAD_ID,
+    AWS_ERROR_THREAD_DEADLOCK_DETECTED,
+    AWS_ERROR_MUTEX_NOT_INIT,
+    AWS_ERROR_MUTEX_TIMEOUT,
+    AWS_ERROR_MUTEX_CALLER_NOT_OWNER,
+    AWS_ERROR_MUTEX_FAILED,
+    AWS_ERROR_COND_VARIABLE_INIT_FAILED,
+    AWS_ERROR_COND_VARIABLE_TIMED_OUT,
+    AWS_ERROR_COND_VARIABLE_ERROR_UNKNOWN,
+    AWS_ERROR_CLOCK_FAILURE,
+    AWS_ERROR_LIST_EMPTY,
+    AWS_ERROR_DEST_COPY_TOO_SMALL,
+    AWS_ERROR_LIST_EXCEEDS_MAX_SIZE,
+    AWS_ERROR_LIST_STATIC_MODE_CANT_SHRINK,
+    AWS_ERROR_PRIORITY_QUEUE_FULL,
+    AWS_ERROR_PRIORITY_QUEUE_EMPTY,
+    AWS_ERROR_PRIORITY_QUEUE_BAD_NODE,
+    AWS_ERROR_HASHTBL_ITEM_NOT_FOUND,
+    AWS_ERROR_INVALID_DATE_STR,
+    AWS_ERROR_INVALID_ARGUMENT,
+    AWS_ERROR_RANDOM_GEN_FAILED,
+    AWS_ERROR_MALFORMED_INPUT_STRING,
+    AWS_ERROR_UNIMPLEMENTED,
+    AWS_ERROR_INVALID_STATE,
+    AWS_ERROR_ENVIRONMENT_GET,
+    AWS_ERROR_ENVIRONMENT_SET,
+    AWS_ERROR_ENVIRONMENT_UNSET,
+    AWS_ERROR_STREAM_UNSEEKABLE,
+    AWS_ERROR_NO_PERMISSION,
+    AWS_ERROR_FILE_INVALID_PATH,
+    AWS_ERROR_MAX_FDS_EXCEEDED,
+    AWS_ERROR_SYS_CALL_FAILURE,
+    AWS_ERROR_C_STRING_BUFFER_NOT_NULL_TERMINATED,
+    AWS_ERROR_STRING_MATCH_NOT_FOUND,
+
+    AWS_ERROR_END_COMMON_RANGE = 0x03FF
+};
+
+int aws_raise_error(int err)
+    _(ensures \result == AWS_OP_ERR)
+;
+
+/* Forward declarations */
+struct epoll_loop;
+struct aws_allocator;
+struct aws_linked_list_node;
+struct aws_mutex;
+struct aws_io_handle;
+
+/* Definitions from aws/common/allocator.h */
+struct aws_allocator {
+    void *(*mem_acquire)(struct aws_allocator *allocator, size_t size);
+    void (*mem_release)(struct aws_allocator *allocator, void *ptr);
+    /* Optional method; if not supported, this pointer must be NULL */
+    void *(*mem_realloc)(struct aws_allocator *allocator, void *oldptr, size_t oldsize, size_t newsize);
+    /* Optional method; if not supported, this pointer must be NULL */
+    void *(*mem_calloc)(struct aws_allocator *allocator, size_t num, size_t size);
+    void *impl;
+    _(invariant mem_acquire->\valid)
+    _(invariant mem_release->\valid)
+    _(invariant mem_realloc == NULL || mem_release->\valid)
+    _(invariant mem_calloc == NULL || mem_calloc->\valid)
+};
+
+#define aws_mem_calloc(a,n,s) malloc(n*s)
+#define aws_mem_release(a,o) free(o)
+
+/* Definitions from aws/common/array_list.h */
+struct aws_array_list {
+    struct aws_allocator *alloc;
+    size_t current_size;
+    size_t length;
+    size_t item_size;
+    void *data;
+};
+
+/* Definitions from aws/common/priority_queue.h */
+struct aws_priority_queue_node {
+    size_t current_index;
+};
+
+/* VCC change: fnptr declaration
+cio function pointer declaration can't be parsed
+typedef int(aws_priority_queue_compare_fn)(const void *a, const void *b);
+replaced with */
+typedef int(* aws_priority_queue_compare_fn_ptr)(const void *a, const void *b);
+
+struct aws_priority_queue {
+    aws_priority_queue_compare_fn_ptr pred; /*< VCC change: fnptr */
+    _(inline) struct aws_array_list container;
+    _(inline) struct aws_array_list backpointers;
+    _(invariant pred->\valid)
+};
+
+/* Definitions from aws/common/task_scheduler.h */
+struct aws_task;
+
+typedef enum aws_task_status {
+    AWS_TASK_STATUS_RUN_READY,
+    AWS_TASK_STATUS_CANCELED,
+} aws_task_status;
+
+/* VCC change: fnptr declaration */
+typedef void(* aws_task_fn_ptr)(struct aws_task *task, void *arg, enum aws_task_status)
+#ifdef UNSUB_TASK_FN_PTR
+  _(requires \malloc_root((struct epoll_event_data *)arg))
+  _(writes \extent((struct epoll_event_data *)arg))
+#elif defined(STOP_TASK_FN_PTR)
+  _(updates epoll_loop_of(event_loop_of(arg))::status)
+  _(updates &epoll_loop_of(event_loop_of(arg))->stop_task_ptr)
+  _(requires \thread_local(event_loop_of(arg)))
+#endif
+;
+
+struct aws_task {
+    aws_task_fn_ptr fn; /*< VCC change: fnptr */
+    void *arg;
+    uint64_t timestamp;
+    struct aws_linked_list_node node;
+    struct aws_priority_queue_node priority_queue_node;
+    const char *type_tag;
+    size_t reserved;
+    _(invariant \mine(&node))
+    _(invariant \mine(&priority_queue_node))
+};
+
+void aws_task_init(struct aws_task *task, aws_task_fn_ptr aws_task_fn, void *arg, const char *type_tag)
+  _(requires \thread_local(task))
+  _(writes task)
+  _(ensures \wrapped(task))
+  _(ensures task->fn == aws_task_fn)
+  _(ensures task->arg == arg)
+  _(ensures task->type_tag == type_tag)
+;
+
+struct aws_task_scheduler {
+    struct aws_allocator *alloc;
+    struct aws_priority_queue timed_queue; /* Tasks scheduled to run at specific times */
+    struct aws_linked_list timed_list;     /* If timed_queue runs out of memory, further timed tests are stored here */
+    struct aws_linked_list asap_list;      /* Tasks scheduled to run as soon as possible */
+    _(invariant \mine(&timed_queue))
+    _(invariant \mine(&timed_list))
+    _(invariant \mine(&asap_list))
+};
+
+int aws_task_scheduler_init(struct aws_task_scheduler *scheduler, struct aws_allocator *allocator)
+    _(writes \extent(&scheduler->timed_list))
+    _(writes \extent(&scheduler->asap_list))
+    _(ensures \extent_mutable(&scheduler->timed_list))
+    _(ensures \extent_mutable(&scheduler->asap_list))
+    _(ensures \result == AWS_OP_SUCCESS <==>
+        scheduler->timed_queue.pred.\valid &&
+        (scheduler->timed_list.head.next == &scheduler->timed_list.tail && scheduler->timed_list.length == 0) &&
+        (scheduler->asap_list.head.next == &scheduler->asap_list.tail && scheduler->asap_list.length == 0)
+     )
+;
+
+void aws_task_scheduler_schedule_now(struct aws_task_scheduler *scheduler, struct aws_task *task)
+    _(updates scheduler)
+;
+
+void aws_task_scheduler_schedule_future(struct aws_task_scheduler *scheduler, struct aws_task *task, uint64_t time_to_run)
+    _(updates scheduler)
+;
+
+void aws_task_scheduler_run_all(struct aws_task_scheduler *scheduler, uint64_t current_time)
+    _(updates scheduler)
+;
+
+void aws_task_scheduler_clean_up(struct aws_task_scheduler *scheduler)
+    _(updates scheduler)
+;
+
+void aws_task_scheduler_cancel_task(struct aws_task_scheduler *scheduler, struct aws_task *task)
+    _(updates scheduler)
+;
+
+bool aws_task_scheduler_has_tasks(const struct aws_task_scheduler *scheduler, uint64_t *next_task_time);
+
+/* Definitions from aws/common/atomics.h */
+struct aws_atomic_var {
+  void *value;
+};
+
+/* VCC change: remove volatile annotation */
+void aws_atomic_init_int(/*volatile*/ struct aws_atomic_var *var, size_t n)
+  _(writes &(var->value))
+;
+
+void aws_atomic_init_ptr(/*volatile*/ struct aws_atomic_var *var, void *p)
+  _(writes &(var->value))
+;
+
+void *aws_atomic_load_ptr(/*volatile*/ struct aws_atomic_var *var)
+;
+
+uint64_t aws_atomic_load_int(/*volatile const*/ struct aws_atomic_var *var)
+;
+
+void aws_atomic_store_int(/*volatile*/ struct aws_atomic_var *var, size_t n)
+  _(writes &(var->value))
+;
+
+bool aws_atomic_compare_exchange_ptr(/*volatile*/ struct aws_atomic_var *var, void **expected, void *desired)
+  _(writes &(var->value))
+;
+
+void aws_atomic_store_ptr(/*volatile*/ struct aws_atomic_var *var, void *val)
+  _(writes &(var->value))
+;
+
+/* Fake-up pthread.h */
+typedef uint64_t pthread_t;
+
+/* Definitions from aws/common.thread.h */
+enum aws_thread_detach_state {
+    AWS_THREAD_NOT_CREATED = 1,
+    AWS_THREAD_JOINABLE,
+    AWS_THREAD_JOIN_COMPLETED,
+};
+
+typedef pthread_t aws_thread_id_t;
+
+struct aws_thread {
+    struct aws_allocator *allocator;
+    enum aws_thread_detach_state detach_state;
+    aws_thread_id_t thread_id;
+};
+
+struct aws_thread_options {
+    size_t stack_size;
+};
+
+_(pure) aws_thread_id_t aws_thread_current_thread_id(void)
+    _(ensures \result == \addr(\me))
+;
+
+int aws_thread_init(struct aws_thread *thread, struct aws_allocator *allocator)
+  _(requires allocator->\valid)
+  _(writes \span(thread))
+  _(ensures \extent_mutable(thread))
+;
+
+void aws_thread_clean_up(struct aws_thread *thread)
+  _(writes \span(thread))
+  _(ensures \extent_mutable(thread))
+;
+
+_(pure) bool aws_thread_thread_id_equal(aws_thread_id_t t1, aws_thread_id_t t2)
+  _(ensures \result == (t1 == t2))
+;
+
+/* Definitions from aws/io/io.h */
+enum aws_io_event_type {
+    AWS_IO_EVENT_TYPE_READABLE = 1,
+    AWS_IO_EVENT_TYPE_WRITABLE = 2,
+    AWS_IO_EVENT_TYPE_REMOTE_HANG_UP = 4,
+    AWS_IO_EVENT_TYPE_CLOSED = 8,
+    AWS_IO_EVENT_TYPE_ERROR = 16,
+};
+
+struct aws_io_handle {
+    _(inline) struct {
+        int fd;
+        void *handle;
+    } data;
+    void *additional_data;
+    _(invariant valid_fd(data.fd))
+};
+
+/* VCC change: fnptr declaration */
+typedef int(* aws_io_clock_fn_ptr)(uint64_t *timestamp)
+  _(writes timestamp)
+;
+
+/* Definitions from aws/io/event_loop.h */
+struct aws_event_loop_vtable;
+
+_(claimable) struct aws_event_loop {
+    struct aws_event_loop_vtable *vtable;
+    struct aws_allocator *alloc;
+    aws_io_clock_fn_ptr clock;           /*< VCC change: fnptr */
+/*  struct aws_hash_table local_data; */ /*< VCC change: not modeled */
+    void *impl_data;
+    /*TODO: allocator is shared and closed*/
+    _(invariant clock->\valid)
+    _(invariant \mine((struct epoll_loop *)impl_data))
+};
+
+/* VCC change: fnptr declaration */
+typedef void(* aws_event_loop_on_event_fn_ptr)(
+    struct aws_event_loop *event_loop,
+    struct aws_io_handle *handle,
+    int events,
+    void *user_data _(ghost \claim(c)))
+    _(requires \wrapped(c) && \claims(c, event_loop->\closed))
+    _(requires \nested(handle))
+    _(writes &epoll_loop_of(event_loop)->should_process_task_pre_queue)
+;
+
+/* Definitions from aws/common/linked_list.h */
+struct aws_linked_list_node {
+    struct aws_linked_list_node *next;
+    struct aws_linked_list_node *prev;
+};
+
+struct aws_linked_list {
+    struct aws_linked_list_node head;
+    struct aws_linked_list_node tail;
+    _(ghost \natural length)
+    _(invariant \mine(&head))
+    _(invariant \mine(&tail))
+    _(invariant (0 == length) <==> (head.next == &tail))
+};
+
+void aws_linked_list_init(struct aws_linked_list *list)
+  _(requires \thread_local(list))
+  _(writes \extent(list))
+  _(ensures \extent_mutable(list))
+  _(ensures list->head.next == &list->tail)
+  _(ensures list->tail.next == NULL)
+  _(ensures list->tail.prev == &list->head)
+  _(ensures list->head.prev == NULL)
+  _(ensures list->length == 0)
+;
+
+_(pure) bool aws_linked_list_empty(const struct aws_linked_list *list)
+    _(requires \wrapped(list))
+    _(reads &list->length)
+    _(ensures \result == (list->length == 0))
+    _(decreases 0)
+{
+    return list->head.next == &list->tail;
+}
+
+/* Specialized for linked lists containing tasks */
+struct aws_linked_list_node *aws_linked_list_pop_front(struct aws_linked_list *list _(out struct aws_task * task))
+    /* general: */
+    _(maintains \wrapped(list))
+    _(requires 0 < list->length)
+    _(ensures (\old(list->length) - 1) == list->length)
+    _(writes list)
+    _(decreases 0)
+    /* specialized: */
+    _(ensures task == AWS_CONTAINER_OF(\result, struct aws_task, node))
+    _(ensures \thread_local(task))
+    _(ensures task->fn->\valid)
+;
+
+/* We omit `task == AWS_CONTAINER_OF(node, struct aws_task, node)`
+because VCC's memory model can't prove this when this occurs in
+`s_schedule_task_common` */
+void aws_linked_list_push_back(struct aws_linked_list *list, struct aws_linked_list_node *node _(ghost struct aws_task *task))
+    /* general: */
+    _(updates list)
+    /* specialized: */
+    _(requires task->fn->\valid)
+;
+
+void aws_linked_list_swap_contents(struct aws_linked_list *a, struct aws_linked_list *b)
+    _(updates a)
+    _(updates b)
+;
+
+/* Definitions from source/linux/epoll_event_loop.c */
+struct epoll_loop {
+    _(group scheduler)
+    _(:scheduler) struct aws_task_scheduler scheduler;
+    struct aws_thread thread_created_on;
+    aws_thread_id_t thread_joined_to;
+    struct aws_atomic_var running_thread_id;
+    _(group read_handle)
+    _(:read_handle) struct aws_io_handle read_task_handle;
+    struct aws_io_handle write_task_handle;
+    struct aws_mutex task_pre_queue_mutex;
+    _(group queue)
+    _(:queue) struct aws_linked_list task_pre_queue;
+    _(group stop_task)
+    _(:stop_task) struct aws_task stop_task;
+    _(:stop_task) struct aws_atomic_var stop_task_ptr;
+    int epoll_fd;
+    _(group status)
+    _(:status) bool should_process_task_pre_queue;
+    _(:status) bool should_continue;
+    _(invariant valid_fd(epoll_fd))
+    /* scheduler */
+    _(invariant \mine(&thread_created_on))
+    _(invariant \mine(&running_thread_id))
+    /* read_handle */
+    _(invariant \mine(&write_task_handle))
+    _(invariant \mine(&task_pre_queue_mutex))
+    /* task_pre_queue */
+    /* stop_task */
+    /* stop_task_ptr */
+    _(invariant task_pre_queue_mutex.protected_obj == &task_pre_queue)
+    _(invariant task_pre_queue_mutex.\claim_count == 1)
+};
+
+struct epoll_event_data {
+    struct aws_allocator *alloc;
+    struct aws_io_handle *handle;
+    aws_event_loop_on_event_fn_ptr on_event; /*< VCC change: fnptr */
+    void *user_data;
+    struct aws_task cleanup_task;
+    bool is_subscribed; /* false when handle is unsubscribed, but this struct hasn't beeen cleaned up yet */
+    _(invariant \mine(handle))
+    _(invariant ((struct epoll_event_data *)handle->additional_data) == \this)
+    _(invariant on_event->\valid)
+    _(invariant \mine(&cleanup_task))
+};
+
+/* VCC mutex contract */
+/* VCC change: replace mutex implementation with VCC contract */
+#define AWS_MUTEX_INIT { .locked = 0 }
+
+_(claimable) _(volatile_owns) struct aws_mutex {
+    volatile int locked; /* 0=>unlocked / 1=>locked */
+    _(ghost \object protected_obj)
+    _(invariant locked == 0 ==> \mine(protected_obj))
+};
+
+void aws_mutex_lock(struct aws_mutex *l _(ghost \claim c))
+    _(always c, l->\closed)
+    _(ensures \wrapped(l->protected_obj) && \fresh(l->protected_obj))
+    _(ensures l->locked == 1)
+;
+
+void aws_mutex_unlock(struct aws_mutex *l _(ghost \claim c))
+    _(always c, l->\closed)
+    _(requires l->protected_obj != c)
+    _(writes l->protected_obj)
+    _(requires \wrapped(l->protected_obj))
+    _(ensures l->locked == 0)
+;
+
+/* Useful definitions */
+_(def bool valid_fd(int fd) {
+  return 0 <= fd;
+})
+
+_(def struct aws_event_loop *event_loop_of(void *arg) {
+  return (struct aws_event_loop *)arg;
+})
+
+_(def struct epoll_loop *epoll_loop_of(struct aws_event_loop *event_loop) {
+  return (struct epoll_loop *)event_loop->impl_data;
+})
+
+/*
+ * This predicate (which implies the object invariant properties of
+ * epoll_event_data) means the heap looks like this:
+ *
+ * handle --.additional_data--> epoll_event_data --.on_event--> valid fn
+ *     ^                         /            \
+ *      `--------------.handle--'              '--.user_data--> (can be NULL)
+ */
+_(def \bool wf_cio_handle(struct aws_io_handle *handle) {
+  return \nested(handle) && handle->\closed &&
+         \malloc_root((struct epoll_event_data *)handle->additional_data) &&
+         \wrapped((struct epoll_event_data *)handle->additional_data) &&
+         (handle->\owner == (struct epoll_event_data *)handle->additional_data);
+})
+
+#define current_thread_owns_event_loop(event_loop) \
+  \addr(\me) == \addr(event_loop->\owner)
+
+#define ownership_of_epoll_loop_objects(loop) \
+    (\wrapped(loop::scheduler)                       \
+        && \wrapped(&loop->scheduler)                \
+        && \wrapped(loop::read_handle)               \
+        && \wrapped(&loop->read_task_handle)         \
+        && \wrapped(loop::stop_task)                 \
+        && \wrapped(&loop->stop_task)                \
+        && \wrapped(&loop->stop_task_ptr)            \
+        && \wrapped(loop::queue)                     \
+        && \wrapped(loop::status)                    \
+        && \fresh(loop::scheduler)                   \
+        && \fresh(&loop->scheduler)                  \
+        && \fresh(loop::read_handle)                 \
+        && \fresh(&loop->read_task_handle)           \
+        && \fresh(loop::stop_task)                   \
+        && \fresh(&loop->stop_task)                  \
+        && \fresh(&loop->stop_task_ptr)              \
+        && \fresh(loop::queue)                       \
+        && \fresh(&loop->task_pre_queue)             \
+        && \fresh(loop::status))
+
+/* Specifications for epoll_loop functions */
+static int s_subscribe_to_io_events(
+    struct aws_event_loop *event_loop,
+    struct aws_io_handle *handle,
+    int events,
+    aws_event_loop_on_event_fn_ptr on_event, /*< VCC change: fnptr */
+    void *user_data
+    _(ghost \claim(c_event_loop))
+)
+    _(always c_event_loop, event_loop->\closed) /*< the event_loop won't be changed or destroyed underneath us */
+    _(requires \wrapped(handle))                /*< wrapped means closed (the handle is valid) and owned by the current thread */
+    _(requires on_event->\valid)                /*< valid function pointer */
+    /* user_data may be NULL */
+    _(ensures \result == AWS_OP_SUCCESS <==> wf_cio_handle(handle))
+    _(ensures \result == AWS_OP_SUCCESS  ==> \fresh((struct epoll_event_data *)handle->additional_data))
+    _(writes handle)
+;
+
+static int s_unsubscribe_from_io_events(struct aws_event_loop *event_loop, struct aws_io_handle *handle
+    _(ghost \claim(c_event_loop))
+    _(ghost \claim(c_mutex))
+)
+    _(maintains \wrapped(event_loop))           /*< current thread owns event loop (i.e., current thread is the event loop thread) */
+    _(always c_event_loop, event_loop->\closed) /*< required for schedule call */
+    _(requires \wrapped(c_mutex) && \claims_object(c_mutex, &(epoll_loop_of(event_loop)->task_pre_queue_mutex)))
+    _(requires wf_cio_handle(handle))
+    _(ensures \result == AWS_OP_SUCCESS <==> !\nested(handle))
+    _(ensures \result != AWS_OP_SUCCESS <==> wf_cio_handle(handle))
+    _(writes ((struct epoll_event_data *)handle->additional_data))
+    _(updates &epoll_loop_of(event_loop)->scheduler)
+;
+
+static void s_schedule_task_now(struct aws_event_loop *event_loop, struct aws_task *task
+    _(ghost \claim(c_event_loop))
+    _(ghost \claim(c_mutex))
+)
+    _(always c_event_loop, event_loop->\closed)
+    _(requires \wrapped(c_mutex) && \claims_object(c_mutex, &(epoll_loop_of(event_loop)->task_pre_queue_mutex)))
+    _(requires \thread_local(task))
+    _(requires \wrapped(task))
+    _(requires task->fn->\valid)
+    _(writes task)
+    _(updates &epoll_loop_of(event_loop)->scheduler)
+;
+
+static void s_schedule_task_future(struct aws_event_loop *event_loop, struct aws_task *task, uint64_t run_at_nanos
+    _(ghost \claim(c_event_loop))
+    _(ghost \claim(c_mutex))
+)
+    _(always c_event_loop, event_loop->\closed)
+    _(requires \wrapped(c_mutex) && \claims_object(c_mutex, &(epoll_loop_of(event_loop)->task_pre_queue_mutex)))
+    _(requires \thread_local(task))
+    _(requires \wrapped(task))
+    _(requires task->fn->\valid)
+    _(writes task)
+    _(updates &epoll_loop_of(event_loop)->scheduler)
+;
+
+static bool s_is_on_callers_thread(struct aws_event_loop *event_loop
+    _(ghost \claim(c_event_loop))
+)
+    _(always c_event_loop, event_loop->\closed)
+    _(ensures \result ==> current_thread_owns_event_loop(event_loop))
+;
+
+static void s_cancel_task(struct aws_event_loop *event_loop, struct aws_task *task)
+    _(requires \wrapped(event_loop))
+    _(updates &epoll_loop_of(event_loop)->scheduler)
+;
+
+static void s_process_task_pre_queue(struct aws_event_loop *event_loop _(ghost \claim(c_event_loop)) _(ghost \claim(c_mutex)))
+    _(always c_event_loop, event_loop->\closed)
+    _(requires \wrapped(c_mutex) && \claims_object(c_mutex, &(epoll_loop_of(event_loop)->task_pre_queue_mutex)))
+    _(requires \thread_local(&epoll_loop_of(event_loop)->read_task_handle))
+    _(requires (&epoll_loop_of(event_loop)->read_task_handle)->\closed)
+    _(writes &epoll_loop_of(event_loop)->should_process_task_pre_queue)
+    _(updates &epoll_loop_of(event_loop)->scheduler)
+;
+
+static void s_stop_task(struct aws_task *task, void *args, enum aws_task_status status)
+    _(requires \thread_local(event_loop_of(args)))
+    _(updates epoll_loop_of(event_loop_of(args))::status)
+    _(updates &epoll_loop_of(event_loop_of(args))->stop_task_ptr)
+;
+
+static int s_stop(struct aws_event_loop *event_loop
+    _(ghost \claim(c_event_loop))
+    _(ghost \claim(c_mutex))
+)
+    /* wrapped0 means the claim_count of c_event_loop is 0 (i.e., notionally,
+    all of the claims handed to client threads have been destroyed), so
+    client threads may no longer call any further event loop API calls. */
+    _(maintains \wrapped0(c_event_loop) && \claims(c_event_loop, event_loop->\closed))
+    _(maintains \wrapped0(c_mutex) && \claims_object(c_mutex, &(epoll_loop_of(event_loop)->task_pre_queue_mutex)))
+    _(requires \wrapped(&epoll_loop_of(event_loop)->stop_task))
+    _(writes (&epoll_loop_of(event_loop)->stop_task))
+    _(updates epoll_loop_of(event_loop)::status)
+    _(updates &epoll_loop_of(event_loop)->scheduler)
+    _(updates &epoll_loop_of(event_loop)->stop_task_ptr)
+;
+
+static int s_wait_for_stop_completion(struct aws_event_loop *event_loop
+    _(ghost \claim(c_event_loop)) _(ghost \claim(c_mutex))
+)
+    _(requires c_event_loop != c_mutex)
+    _(requires \wrapped0(c_event_loop) && \claims(c_event_loop, event_loop->\closed) && \claims_object(c_event_loop, event_loop))
+    _(writes c_event_loop, event_loop)
+    _(ensures !c_event_loop->\closed)
+    _(ensures \wrapped0(event_loop) && \nested(epoll_loop_of(event_loop)))
+    _(ensures ownership_of_epoll_loop_objects(epoll_loop_of(event_loop)))
+    _(ensures epoll_loop_of(event_loop)->task_pre_queue_mutex.locked == 0)
+    _(maintains \malloc_root(epoll_loop_of(event_loop)))
+    _(maintains \wrapped0(c_mutex) && \claims_object(c_mutex, &epoll_loop_of(event_loop)->task_pre_queue_mutex))
+;
+
+static int s_run(struct aws_event_loop *event_loop _(ghost \claim(c_mutex)))
+    _(requires
+        \wrapped0(event_loop) &&
+        \wrapped(c_mutex) && \claims_object(c_mutex, &(epoll_loop_of(event_loop)->task_pre_queue_mutex)))
+    _(writes &epoll_loop_of(event_loop)->should_continue)
+;
+
+static void s_on_tasks_to_schedule(
+    struct aws_event_loop *event_loop,
+    struct aws_io_handle *handle,
+    int events,
+    void *user_data _(ghost \claim(c_event_loop))
+)
+    _(always c_event_loop, event_loop->\closed)
+    _(requires \nested(handle))
+    _(writes &epoll_loop_of(event_loop)->should_process_task_pre_queue)
+;
+
+static void s_main_loop(void *args _(ghost \claim(c_mutex)))
+    _(requires \wrapped(event_loop_of(args)))
+    _(requires \not_shared(event_loop_of(args)))
+    _(requires \wrapped(c_mutex) && \claims_object(c_mutex, &(epoll_loop_of(event_loop_of(args))->task_pre_queue_mutex)))
+    _(requires \wrapped(&epoll_loop_of(event_loop_of(args))->read_task_handle))
+    _(updates &epoll_loop_of(event_loop_of(args))->scheduler)
+    _(updates &epoll_loop_of(event_loop_of(args))->running_thread_id)
+    _(writes event_loop_of(args))
+    _(writes &epoll_loop_of(event_loop_of(args))->read_task_handle)
+    _(writes (struct epoll_event_data *)(epoll_loop_of(event_loop_of(args))->read_task_handle.additional_data))
+    _(writes &epoll_loop_of(event_loop_of(args))->should_process_task_pre_queue)
+;
+
+struct aws_event_loop *aws_event_loop_new_default(struct aws_allocator *alloc, aws_io_clock_fn_ptr clock
+    _(out \claim(c_mutex))
+)
+    _(requires \wrapped(alloc))
+    _(requires clock->\valid)
+    _(ensures \result == NULL ||
+       (\wrapped0(\result) &&
+        \fresh(\result) && \malloc_root(\result) &&
+        \fresh(epoll_loop_of(\result)) && \malloc_root(epoll_loop_of(\result)) &&
+        ownership_of_epoll_loop_objects(epoll_loop_of(\result)) &&
+        \fresh(c_mutex) && \wrapped0(c_mutex) && \claims_object(c_mutex, &(epoll_loop_of(\result)->task_pre_queue_mutex))))
+;
+
+static void s_destroy(struct aws_event_loop *event_loop
+    _(ghost \claim(c_event_loop)) _(ghost \claim(c_mutex))
+)
+    _(requires \malloc_root(event_loop))
+    _(requires \malloc_root(epoll_loop_of(event_loop)))
+    _(requires c_event_loop != c_mutex)
+    _(requires \wrapped0(c_event_loop) && \claims_object(c_event_loop, event_loop))
+    _(requires \wrapped0(c_mutex) && \claims_object(c_mutex, &epoll_loop_of(event_loop)->task_pre_queue_mutex))
+    _(requires \wrapped(&epoll_loop_of(event_loop)->scheduler))
+    _(requires \wrapped(epoll_loop_of(event_loop)::status))
+    _(requires \wrapped(&epoll_loop_of(event_loop)->stop_task))
+    _(writes &epoll_loop_of(event_loop)->scheduler)
+    _(writes epoll_loop_of(event_loop)::status)
+    _(writes &epoll_loop_of(event_loop)->stop_task)
+    _(writes event_loop, c_event_loop, c_mutex)
+    _(updates &epoll_loop_of(event_loop)->stop_task_ptr)
+;
+
+/* clang-format on */
+#endif PREAMBLE_H

--- a/tests/vcc/process_task_pre_queue.c
+++ b/tests/vcc/process_task_pre_queue.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/* clang-format off */
+#include "preamble.h"
+
+/* `read` not in preamble because we specialize for reading-into a uint64_t
+var (as used by `s_process_task_pre_queue`) */
+ssize_t read(int fd, void *buf, uint64_t count)
+    _(requires valid_fd(fd))
+    _(requires count == sizeof(uint64_t))
+    _(writes (uint64_t *)buf)
+;
+
+static void s_process_task_pre_queue(struct aws_event_loop *event_loop _(ghost \claim(c_event_loop)) _(ghost \claim(c_mutex))) {
+    _(assert \always_by_claim(c_event_loop, event_loop))
+    struct epoll_loop *epoll_loop = event_loop->impl_data;
+    _(assert \inv(epoll_loop))
+
+    if (!epoll_loop->should_process_task_pre_queue) {
+        return;
+    }
+
+    AWS_LOGF_TRACE(AWS_LS_IO_EVENT_LOOP, "id=%p: processing cross-thread tasks", (void *)event_loop);
+    epoll_loop->should_process_task_pre_queue = false;
+
+    struct aws_linked_list task_pre_queue;
+    aws_linked_list_init(&task_pre_queue);
+    _(wrap(&task_pre_queue.head))
+    _(wrap(&task_pre_queue.tail))
+    _(wrap(&task_pre_queue))
+
+    uint64_t count_ignore = 0;
+
+    aws_mutex_lock(&epoll_loop->task_pre_queue_mutex _(ghost c_mutex));
+
+    /* several tasks could theoretically have been written (though this should never happen), make sure we drain the
+     * eventfd/pipe. */
+    while (read(epoll_loop->read_task_handle.data.fd, &count_ignore, sizeof(count_ignore)) > -1)
+        _(invariant \thread_local(&epoll_loop->read_task_handle))
+        _(invariant (&epoll_loop->read_task_handle)->\closed)
+        _(invariant \inv(&epoll_loop->read_task_handle))
+        _(invariant \wrapped(&epoll_loop->scheduler))
+        _(writes &count_ignore)
+    {
+    }
+
+    aws_linked_list_swap_contents(&epoll_loop->task_pre_queue, &task_pre_queue);
+
+    aws_mutex_unlock(&epoll_loop->task_pre_queue_mutex _(ghost c_mutex));
+
+    while (!aws_linked_list_empty(&task_pre_queue))
+        _(invariant 0 <= task_pre_queue.length)
+        _(invariant \wrapped(&task_pre_queue))
+        _(invariant \wrapped(&epoll_loop->scheduler))
+        _(writes &task_pre_queue, &epoll_loop->scheduler)
+    {
+        _(ghost struct aws_task *t)
+        struct aws_linked_list_node *node = aws_linked_list_pop_front(&task_pre_queue _(out t));
+        struct aws_task *task = AWS_CONTAINER_OF(node, struct aws_task, node);
+        AWS_LOGF_TRACE(
+            AWS_LS_IO_EVENT_LOOP,
+            "id=%p: task %p pulled to event-loop, scheduling now.",
+            (void *)event_loop,
+            (void *)task);
+        /* Timestamp 0 is used to denote "now" tasks */
+        if (task->timestamp == 0) {
+            aws_task_scheduler_schedule_now(&epoll_loop->scheduler, task);
+        } else {
+            aws_task_scheduler_schedule_future(&epoll_loop->scheduler, task, task->timestamp);
+        }
+    }
+    _(unwrap(&task_pre_queue))
+    _(unwrap(&task_pre_queue.head))
+    _(unwrap(&task_pre_queue.tail))
+}
+/* clang-format on */

--- a/tests/vcc/schedule.c
+++ b/tests/vcc/schedule.c
@@ -1,0 +1,113 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/* clang-format off */
+#include "preamble.h"
+
+/* not in preamble because we specialize for reading-from a uint64_t var (as
+used by `s_schedule_task_common`) */
+ssize_t write(int fd, void *bytes, size_t nbytes)
+    _(requires valid_fd(fd))
+    _(requires nbytes == sizeof(uint64_t))
+    _(requires \thread_local((uint64_t *)bytes))
+;
+
+static void s_schedule_task_common(struct aws_event_loop *event_loop, struct aws_task *task, uint64_t run_at_nanos
+    _(ghost \claim(c_event_loop))
+    _(ghost \claim(c_mutex))
+)
+    _(always c_event_loop, event_loop->\closed)
+    _(requires \wrapped(c_mutex) && \claims_object(c_mutex, &(epoll_loop_of(event_loop)->task_pre_queue_mutex)))
+    _(requires \thread_local(task))
+    _(requires \wrapped(task))
+    _(requires task->fn->\valid)
+    _(writes task)
+    _(updates &epoll_loop_of(event_loop)->scheduler)
+{
+    _(assert \always_by_claim(c_event_loop, event_loop))
+    _(assert \active_claim(c_event_loop))
+    struct epoll_loop *epoll_loop = event_loop->impl_data;
+    _(assert \inv(epoll_loop))
+    _(assert epoll_loop->\closed)
+    _(assert epoll_loop->write_task_handle.\closed)
+    _(assert \inv(&epoll_loop->write_task_handle))
+    _(assert valid_fd(epoll_loop->write_task_handle.data.fd))
+
+    /* if event loop and the caller are the same thread, just schedule and be done with it. */
+    if (s_is_on_callers_thread(event_loop _(ghost c_event_loop))) {
+        AWS_LOGF_TRACE(
+            AWS_LS_IO_EVENT_LOOP,
+            "id=%p: scheduling task %p in-thread for timestamp %llu",
+            (void *)event_loop,
+            (void *)task,
+            (unsigned long long)run_at_nanos);
+        if (run_at_nanos == 0) {
+            /* zero denotes "now" task */
+            aws_task_scheduler_schedule_now(&epoll_loop->scheduler, task);
+        } else {
+            aws_task_scheduler_schedule_future(&epoll_loop->scheduler, task, run_at_nanos);
+        }
+        return;
+    }
+
+    AWS_LOGF_TRACE(
+        AWS_LS_IO_EVENT_LOOP,
+        "id=%p: Scheduling task %p cross-thread for timestamp %llu",
+        (void *)event_loop,
+        (void *)task,
+        (unsigned long long)run_at_nanos);
+    _(unwrap task)
+    task->timestamp = run_at_nanos;
+    _(wrap task)
+    aws_mutex_lock(&epoll_loop->task_pre_queue_mutex _(ghost c_mutex));
+    _(assert epoll_loop->task_pre_queue.\owner == \me)
+
+    uint64_t counter = 1;
+
+    bool is_first_task = aws_linked_list_empty(&epoll_loop->task_pre_queue);
+
+    aws_linked_list_push_back(&epoll_loop->task_pre_queue, &task->node _(ghost task));
+
+    /* if the list was not empty, we already have a pending read on the pipe/eventfd, no need to write again. */
+    if (is_first_task) {
+        AWS_LOGF_TRACE(AWS_LS_IO_EVENT_LOOP, "id=%p: Waking up event-loop thread", (void *)event_loop);
+
+        /* If the write fails because the buffer is full, we don't actually care because that means there's a pending
+         * read on the pipe/eventfd and thus the event loop will end up checking to see if something has been queued.*/
+        _(assert \active_claim(c_event_loop)) /*< implies write_task_handle.data.fd is a valid fd
+                                                 ==> event_loop->\closed
+                                                 ==> epoll_loop->\closed ==> \inv(epoll_loop)
+                                                 ==> epoll_loop->write_task_handle.\closed ==> \inv(&epoll_loop->write_task_handle) */
+        ssize_t do_not_care = write(_(by_claim c_event_loop) epoll_loop->write_task_handle.data.fd, (void *)&counter, sizeof(counter));
+        (void)do_not_care;
+    }
+
+    aws_mutex_unlock(&epoll_loop->task_pre_queue_mutex _(ghost c_mutex));
+}
+
+static void s_schedule_task_now(struct aws_event_loop *event_loop, struct aws_task *task
+    _(ghost \claim(c_event_loop))
+    _(ghost \claim(c_mutex))
+) {
+    s_schedule_task_common(event_loop, task, 0 /* zero denotes "now" task */ _(ghost c_event_loop) _(ghost c_mutex));
+}
+
+static void s_schedule_task_future(struct aws_event_loop *event_loop, struct aws_task *task, uint64_t run_at_nanos
+    _(ghost \claim(c_event_loop))
+    _(ghost \claim(c_mutex))
+) {
+    s_schedule_task_common(event_loop, task, run_at_nanos _(ghost c_event_loop) _(ghost c_mutex));
+}
+/* clang-format on */

--- a/tests/vcc/subscribe.c
+++ b/tests/vcc/subscribe.c
@@ -1,0 +1,83 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/* clang-format off */
+#include "preamble.h"
+
+static int s_subscribe_to_io_events(
+    struct aws_event_loop *event_loop,
+    struct aws_io_handle *handle,
+    int events,
+    aws_event_loop_on_event_fn_ptr on_event, /*< VCC change: fnptr */
+    void *user_data
+    _(ghost \claim(c_event_loop))
+) {
+    _(assert \always_by_claim(c_event_loop, event_loop))
+
+    struct epoll_event_data *epoll_event_data = aws_mem_calloc(event_loop->alloc, 1, sizeof(struct epoll_event_data));
+    _(unwrap handle)
+    handle->additional_data = epoll_event_data;
+
+    if (!epoll_event_data) {
+        return AWS_OP_ERR;
+    }
+
+    struct epoll_loop *epoll_loop = (struct epoll_loop *)event_loop->impl_data;
+    epoll_event_data->alloc = event_loop->alloc;
+    epoll_event_data->user_data = user_data;
+    epoll_event_data->handle = handle;
+    epoll_event_data->on_event = on_event;
+    epoll_event_data->is_subscribed = true;
+
+    /*everyone is always registered for edge-triggered, hang up, remote hang up, errors. */
+    uint32_t event_mask = EPOLLET | EPOLLHUP | EPOLLRDHUP | EPOLLERR;
+
+    if (events & AWS_IO_EVENT_TYPE_READABLE) {
+        event_mask |= EPOLLIN;
+    }
+
+    if (events & AWS_IO_EVENT_TYPE_WRITABLE) {
+        event_mask |= EPOLLOUT;
+    }
+
+    /* this guy is copied by epoll_ctl */
+    /* VCC change: rewrite struct initialization */
+#if 0
+    struct epoll_event epoll_event = {
+        .data = {.ptr = epoll_event_data},
+        .events = event_mask,
+    };
+#else
+    struct epoll_event epoll_event;
+    epoll_event.data.ptr = epoll_event_data;
+    epoll_event.events = event_mask;
+#endif
+ 
+    if (epoll_ctl(_(by_claim c_event_loop) epoll_loop->epoll_fd, EPOLL_CTL_ADD, handle->data.fd, &epoll_event)) {
+        AWS_LOGF_ERROR(
+            AWS_LS_IO_EVENT_LOOP, "id=%p: failed to subscribe to events on fd %d", (void *)event_loop, handle->data.fd);
+        handle->additional_data = NULL;
+        aws_mem_release(event_loop->alloc, epoll_event_data);
+        return aws_raise_error(AWS_ERROR_SYS_CALL_FAILURE);
+    }
+    _(wrap(handle))
+    _(wrap(&epoll_event_data->cleanup_task.node))
+    _(wrap(&epoll_event_data->cleanup_task.priority_queue_node))
+    _(wrap(&epoll_event_data->cleanup_task))
+    _(wrap(epoll_event_data))
+
+    return AWS_OP_SUCCESS;
+}
+/* clang-format on */

--- a/tests/vcc/unsubscribe.c
+++ b/tests/vcc/unsubscribe.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+/* clang-format off */
+#define UNSUB_TASK_FN_PTR
+#include "preamble.h"
+
+void s_unsubscribe_cleanup_task(struct aws_task *task, void *arg, enum aws_task_status status)
+    _(requires \malloc_root((struct epoll_event_data *)arg))
+    _(writes \extent((struct epoll_event_data *)arg))
+{
+    (void)task;
+    (void)status;
+    struct epoll_event_data *event_data = (struct epoll_event_data *)arg;
+    aws_mem_release(event_data->alloc, (void *)event_data);
+}
+
+static int s_unsubscribe_from_io_events(struct aws_event_loop *event_loop, struct aws_io_handle *handle
+    _(ghost \claim(c_event_loop))
+    _(ghost \claim(c_mutex))
+) {
+    AWS_LOGF_TRACE(
+        AWS_LS_IO_EVENT_LOOP, "id=%p: un-subscribing from events on fd %d", (void *)event_loop, handle->data.fd);
+    struct epoll_loop *epoll_loop = event_loop->impl_data;
+
+    AWS_ASSERT(handle->additional_data);
+    struct epoll_event_data *additional_handle_data = handle->additional_data;
+    _(assert \wrapped(additional_handle_data))
+    _(assert \inv(additional_handle_data))
+
+    struct epoll_event dummy_event;
+
+    if (AWS_UNLIKELY(epoll_ctl(epoll_loop->epoll_fd, EPOLL_CTL_DEL, handle->data.fd, &dummy_event /*ignored*/))) {
+        AWS_LOGF_ERROR(
+            AWS_LS_IO_EVENT_LOOP,
+            "id=%p: failed to un-subscribe from events on fd %d",
+            (void *)event_loop,
+            handle->data.fd);
+        return aws_raise_error(AWS_ERROR_SYS_CALL_FAILURE);
+    }
+
+    /* We can't clean up yet, because we have schedule tasks and more events to process,
+     * mark it as unsubscribed and schedule a cleanup task. */
+
+    _(unwrap(additional_handle_data))
+    _(assert handle->\owner != additional_handle_data)
+    additional_handle_data->is_subscribed = false;
+
+    aws_task_init(
+        &additional_handle_data->cleanup_task,
+        s_unsubscribe_cleanup_task,
+        additional_handle_data,
+        "epoll_event_loop_unsubscribe_cleanup");
+    s_schedule_task_now(event_loop, &additional_handle_data->cleanup_task _(ghost c_event_loop) _(ghost c_mutex));
+
+    _(unwrap(handle))
+    handle->additional_data = NULL;
+    _(assert handle->\owner == \me)
+
+    return AWS_OP_SUCCESS;
+}
+/* clang-format on */


### PR DESCRIPTION
**new** `aws_byte_buf_append_decoding_uri()`: Write the decoded URI to a buffer.

**new** `aws_uri_query_string_next_param()`: For iterating over query params without allocating.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
