### PR TITLE
README says we have a Select-based event-loop

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,8 +166,6 @@ Platform | Implementation
 Linux | Edge-Triggered Epoll
 BSD Variants and Apple Devices | KQueue
 Windows | IOCP (IO Completion Ports)
-Solaris | /dev/poll
-Default Fallback | Select
 
 Also, you can always implement your own as well.
 


### PR DESCRIPTION
We haven't built a Select-based event-loop yet, so remove mention of it from README.
This was confusing a customer


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
