### PR TITLE
Fix sys/errno.h import

### DIFF
--- a/source/posix/socket.c
+++ b/source/posix/socket.c
@@ -15,9 +15,9 @@
 
 #include <arpa/inet.h>
 #include <aws/io/io.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <netinet/tcp.h>
-#include <sys/errno.h>
 #include <sys/socket.h>
 #include <sys/types.h>
 #include <unistd.h>


### PR DESCRIPTION
Fixes builds in Alpine environment.

"[ 34%] Building C object CMakeFiles/aws-c-io.dir/source/posix/socket.c.o
In file included from /build/aws-c-io/source/posix/socket.c:20:
    1 | #warning redirecting incorrect #include <sys/errno.h> to <errno.h>
      |  ^~~~~~~
cc1: all warnings being treated as errors
"

Signed-off-by: Alexandru Ciobotaru <alcioa@amazon.com>

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
