### PR TITLE
Preventing null TLS context crash on aws_tls_ctx_destroy

### DIFF
--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -1058,7 +1058,6 @@ struct aws_tls_ctx *aws_tls_client_ctx_new(struct aws_allocator *alloc, const st
 void aws_tls_ctx_destroy(struct aws_tls_ctx *ctx) {
 
     if (ctx == NULL) {
-        AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: trying to destroy a NULL TLS Context.");
         return;
     }
 

--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -1056,6 +1056,12 @@ struct aws_tls_ctx *aws_tls_client_ctx_new(struct aws_allocator *alloc, const st
 }
 
 void aws_tls_ctx_destroy(struct aws_tls_ctx *ctx) {
+
+    if (ctx == NULL) {
+        AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: trying to destroy a NULL TLS Context.");
+        return;
+    }
+
     struct secure_transport_ctx *secure_transport_ctx = ctx->impl;
 
     if (secure_transport_ctx->certs) {

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -908,6 +908,12 @@ struct aws_channel_handler *aws_tls_server_handler_new(
 }
 
 void aws_tls_ctx_destroy(struct aws_tls_ctx *ctx) {
+
+    if (ctx == NULL) {
+        AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: trying to destroy a NULL TLS Context.");
+        return;
+    }
+
     struct s2n_ctx *s2n_ctx = ctx->impl;
 
     if (s2n_ctx) {

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -910,7 +910,6 @@ struct aws_channel_handler *aws_tls_server_handler_new(
 void aws_tls_ctx_destroy(struct aws_tls_ctx *ctx) {
 
     if (ctx == NULL) {
-        AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: trying to destroy a NULL TLS Context.");
         return;
     }
 

--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -1730,6 +1730,12 @@ struct aws_channel_handler *aws_tls_server_handler_new(
 }
 
 void aws_tls_ctx_destroy(struct aws_tls_ctx *ctx) {
+
+    if (ctx == NULL) {
+        AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: trying to destroy a NULL TLS Context.");
+        return;
+    }
+
     struct secure_channel_ctx *secure_channel_ctx = ctx->impl;
 
     if (secure_channel_ctx->custom_trust_store) {

--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -1732,7 +1732,6 @@ struct aws_channel_handler *aws_tls_server_handler_new(
 void aws_tls_ctx_destroy(struct aws_tls_ctx *ctx) {
 
     if (ctx == NULL) {
-        AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: trying to destroy a NULL TLS Context.");
         return;
     }
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -119,6 +119,7 @@ add_net_test_case(tls_server_multiple_connections)
 add_net_test_case(tls_server_hangup_during_negotiation)
 add_net_test_case(tls_client_channel_no_verify)
 add_net_test_case(test_tls_negotiation_timeout)
+add_test_case(tls_destroy_null_context)
 
 add_net_test_case(alpn_successfully_negotiates)
 add_net_test_case(alpn_no_protocol_message)

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -1670,7 +1670,7 @@ static int s_tls_destroy_null_context(struct aws_allocator *allocator, void *ctx
 
     struct aws_tls_ctx *null_context = NULL;
 
-    /* Validate that we don't crash. */
+    /* Verify that we don't crash. */
     aws_tls_ctx_destroy(null_context);
 
     return AWS_OP_SUCCESS;

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -1664,3 +1664,15 @@ static int s_test_concurrent_cert_import(struct aws_allocator *allocator, void *
 }
 
 AWS_TEST_CASE(test_concurrent_cert_import, s_test_concurrent_cert_import)
+
+static int s_tls_destroy_null_context(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    struct aws_tls_ctx *null_context = NULL;
+
+    /* Validate that we don't crash. */
+    aws_tls_ctx_destroy(null_context);
+
+    return AWS_OP_SUCCESS;
+}
+AWS_TEST_CASE(tls_destroy_null_context, s_tls_destroy_null_context);

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -1666,6 +1666,7 @@ static int s_test_concurrent_cert_import(struct aws_allocator *allocator, void *
 AWS_TEST_CASE(test_concurrent_cert_import, s_test_concurrent_cert_import)
 
 static int s_tls_destroy_null_context(struct aws_allocator *allocator, void *ctx) {
+    (void)allocator;
     (void)ctx;
 
     struct aws_tls_ctx *null_context = NULL;


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/145

*Description of changes:*
Null checking TLS contexts in aws_tls_ctx_destroy to prevent possible crashes.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
