### PR TITLE
Removed PKI utils that iOS doesn't support

### DIFF
--- a/include/aws/io/pki_utils.h
+++ b/include/aws/io/pki_utils.h
@@ -39,6 +39,7 @@ AWS_IO_API int aws_read_and_decode_pem_file_to_buffer_list(
 #ifdef __MACH__
 struct __CFArray;
 typedef const struct __CFArray *CFArrayRef;
+#    if !defined(AWS_OS_IOS)
 /**
  * Imports a PEM armored PKCS#7 public/private key pair
  * into identity for use with SecurityFramework.
@@ -49,6 +50,7 @@ int aws_import_public_and_private_keys_to_identity(
     const struct aws_byte_cursor *public_cert_chain,
     const struct aws_byte_cursor *private_key,
     CFArrayRef *identity);
+#    endif /* AWS_OS_IOS */
 
 /**
  * Imports a PKCS#12 file into identity for use with

--- a/include/aws/io/pki_utils.h
+++ b/include/aws/io/pki_utils.h
@@ -36,7 +36,7 @@ AWS_IO_API int aws_read_and_decode_pem_file_to_buffer_list(
     const char *filename,
     struct aws_array_list *cert_chain_or_key);
 
-#ifdef __MACH__
+#ifdef AWS_OS_APPLE
 struct __CFArray;
 typedef const struct __CFArray *CFArrayRef;
 #    if !defined(AWS_OS_IOS)
@@ -82,7 +82,7 @@ void aws_release_identity(CFArrayRef identity);
  */
 void aws_release_certificates(CFArrayRef certs);
 
-#endif /* __MACH__ */
+#endif /* AWS_OS_APPLE */
 
 #ifdef _WIN32
 typedef void *HCERTSTORE;

--- a/include/aws/io/tls_channel_handler.h
+++ b/include/aws/io/tls_channel_handler.h
@@ -209,6 +209,8 @@ AWS_IO_API void aws_tls_ctx_options_init_default_client(
  */
 AWS_IO_API void aws_tls_ctx_options_clean_up(struct aws_tls_ctx_options *options);
 
+#if !defined(AWS_OS_IOS)
+
 /**
  * Initializes options for use with mutual tls in client mode.
  * cert_path and pkey_path are paths to files on disk. cert_path
@@ -254,6 +256,8 @@ AWS_IO_API int aws_tls_ctx_options_init_default_server(
     struct aws_allocator *allocator,
     struct aws_byte_cursor *cert,
     struct aws_byte_cursor *pkey);
+
+#endif /* AWS_OS_IOS */
 
 #ifdef _WIN32
 /**

--- a/source/darwin/darwin_pki_utils.c
+++ b/source/darwin/darwin_pki_utils.c
@@ -15,6 +15,8 @@
 /* https://developer.apple.com/documentation/security/certificate_key_and_trust_services/working_with_concurrency */
 static struct aws_mutex s_sec_mutex = AWS_MUTEX_INIT;
 
+#if !defined(AWS_OS_IOS)
+
 int aws_import_public_and_private_keys_to_identity(
     struct aws_allocator *alloc,
     CFAllocatorRef cf_alloc,
@@ -140,6 +142,8 @@ done:
 
     return result;
 }
+
+#endif /* AWS_OS_IOS */
 
 int aws_import_pkcs12_to_identity(
     CFAllocatorRef cf_alloc,

--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -979,6 +979,7 @@ static struct aws_tls_ctx *s_tls_ctx_new(struct aws_allocator *alloc, const stru
     secure_transport_ctx->ctx.impl = secure_transport_ctx;
 
     if (options->certificate.len && options->private_key.len) {
+#if !defined(AWS_OS_IOS)
         AWS_LOGF_DEBUG(AWS_LS_IO_TLS, "static: certificate and key have been set, setting them up now.");
 
         if (!aws_text_is_utf8(options->certificate.buffer, options->certificate.len)) {
@@ -1005,6 +1006,7 @@ static struct aws_tls_ctx *s_tls_ctx_new(struct aws_allocator *alloc, const stru
                 AWS_LS_IO_TLS, "static: failed to import certificate and private key with error %d.", aws_last_error());
             goto cleanup_wrapped_allocator;
         }
+#endif
     } else if (options->pkcs12.len) {
         AWS_LOGF_DEBUG(AWS_LS_IO_TLS, "static: a pkcs$12 certificate and key has been set, setting it up now.");
 

--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -78,6 +78,8 @@ static int s_load_null_terminated_buffer_from_cursor(
     return AWS_OP_SUCCESS;
 }
 
+#if !defined(AWS_OS_IOS)
+
 int aws_tls_ctx_options_init_client_mtls(
     struct aws_tls_ctx_options *options,
     struct aws_allocator *allocator,
@@ -128,6 +130,8 @@ int aws_tls_ctx_options_init_client_mtls_from_path(
 
     return AWS_OP_SUCCESS;
 }
+
+#endif /* AWS_OS_IOS */
 
 #ifdef _WIN32
 void aws_tls_ctx_options_init_client_mtls_from_system_path(
@@ -226,6 +230,8 @@ int aws_tls_ctx_options_init_server_pkcs12(
 
 #endif /* __APPLE__ */
 
+#if !defined(AWS_OS_IOS)
+
 int aws_tls_ctx_options_init_default_server_from_path(
     struct aws_tls_ctx_options *options,
     struct aws_allocator *allocator,
@@ -251,6 +257,8 @@ int aws_tls_ctx_options_init_default_server(
     options->verify_peer = false;
     return AWS_OP_SUCCESS;
 }
+
+#endif /* AWS_OS_IOS */
 
 int aws_tls_ctx_options_set_alpn_list(struct aws_tls_ctx_options *options, const char *alpn_list) {
     options->alpn_list = aws_string_new_from_c_str(options->allocator, alpn_list);

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -1572,8 +1572,9 @@ struct import_info {
 };
 
 static void s_import_cert(void *ctx) {
+    (void)ctx;
+#if !defined(AWS_OS_IOS)
     struct import_info *import = ctx;
-
     struct aws_byte_cursor cert_cur = aws_byte_cursor_from_buf(&import->cert_buf);
     struct aws_byte_cursor key_cur = aws_byte_cursor_from_buf(&import->key_buf);
     struct aws_tls_ctx_options tls_options = {0};
@@ -1585,6 +1586,7 @@ static void s_import_cert(void *ctx) {
     AWS_FATAL_ASSERT(import->tls);
 
     aws_tls_ctx_options_clean_up(&tls_options);
+#endif /* !AWS_OS_IOS */
 }
 
 #define NUM_PAIRS 1


### PR DESCRIPTION
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
