### PR TITLE
Increase default TLS timeout

### DIFF
--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -8,7 +8,7 @@
 #include <aws/io/logging.h>
 #include <aws/io/tls_channel_handler.h>
 
-#define AWS_DEFAULT_TLS_TIMEOUT_MS 4000
+#define AWS_DEFAULT_TLS_TIMEOUT_MS 10000
 
 #include <aws/common/string.h>
 


### PR DESCRIPTION
We've had decent number of customer issues and CI failures since this was introduced in Feb.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
