### PR TITLE
Fixing SOVERSION

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -188,7 +188,6 @@ aws_check_headers(${PROJECT_NAME} ${IO_HEADERS})
 
 aws_add_sanitizers(${PROJECT_NAME})
 
-# We are not ABI stable yet
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION 1.0.0)
 set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 1)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -190,6 +190,7 @@ aws_add_sanitizers(${PROJECT_NAME})
 
 # We are not ABI stable yet
 set_target_properties(${PROJECT_NAME} PROPERTIES VERSION 1.0.0)
+set_target_properties(${PROJECT_NAME} PROPERTIES SOVERSION 1)
 
 target_compile_definitions(${PROJECT_NAME} PUBLIC "-DAWS_USE_${EVENT_LOOP_DEFINE}")
 


### PR DESCRIPTION
*Issue #, if available:*
https://github.com/awslabs/aws-c-common/issues/698

*Description of changes:*
Fixing SOVERSION so that resulting SONAME is libaws-c-common.so.1 and not libaws-c-common.so.1.0.0.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
