### PR TITLE
FindLibCrypto.cmake is easier to consume

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -206,7 +206,8 @@ target_include_directories(${PROJECT_NAME} PUBLIC
         $<INSTALL_INTERFACE:include>)
 
 aws_use_package(aws-c-common)
-target_link_libraries(${PROJECT_NAME} PUBLIC ${DEP_AWS_LIBS} ${PLATFORM_LIBS})
+target_link_libraries(${PROJECT_NAME} PUBLIC ${DEP_AWS_LIBS})
+target_link_libraries(${PROJECT_NAME} PRIVATE ${PLATFORM_LIBS})
 
 aws_prepare_shared_lib_exports(${PROJECT_NAME})
 
@@ -230,6 +231,10 @@ configure_file("cmake/${PROJECT_NAME}-config.cmake"
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
         DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/"
+        COMPONENT Development)
+
+install(FILES "cmake/modules/FindLibCrypto.cmake"
+        DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/modules/"
         COMPONENT Development)
 
 if (NOT CMAKE_CROSSCOMPILING)

--- a/cmake/aws-c-io-config.cmake
+++ b/cmake/aws-c-io-config.cmake
@@ -1,7 +1,7 @@
 include(CMakeFindDependencyMacro)
 
 if (UNIX AND NOT APPLE)
-    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/modules")
+    list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_LIST_DIR}/modules")
     find_dependency(s2n)
     find_dependency(LibCrypto)
 endif()

--- a/cmake/aws-c-io-config.cmake
+++ b/cmake/aws-c-io-config.cmake
@@ -1,6 +1,7 @@
 include(CMakeFindDependencyMacro)
 
 if (UNIX AND NOT APPLE)
+    set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_LIST_DIR}/modules")
     find_dependency(s2n)
     find_dependency(LibCrypto)
 endif()
@@ -12,4 +13,3 @@ if (BUILD_SHARED_LIBS)
 else()
     include(${CMAKE_CURRENT_LIST_DIR}/static/@PROJECT_NAME@-targets.cmake)
 endif()
-

--- a/cmake/modules/FindLibCrypto.cmake
+++ b/cmake/modules/FindLibCrypto.cmake
@@ -18,17 +18,17 @@
 find_path(LibCrypto_INCLUDE_DIR
     NAMES openssl/crypto.h
     HINTS
-        ${CMAKE_PREFIX_PATH}/include 
+        ${CMAKE_PREFIX_PATH}/include
         ${CMAKE_INSTALL_PREFIX}/include
     )
 find_library(LibCrypto_SHARED_LIBRARY
-    NAMES libcrypto.so
+    NAMES libcrypto.so libcrypto.dylib
     HINTS
     ${CMAKE_PREFIX_PATH}/build/crypto
     ${CMAKE_PREFIX_PATH}/build
     ${CMAKE_PREFIX_PATH}
     ${CMAKE_PREFIX_PATH}/lib64
-    ${CMAKE_PREFIX_PATH}/lib 
+    ${CMAKE_PREFIX_PATH}/lib
     ${CMAKE_INSTALL_PREFIX}/build/crypto
     ${CMAKE_INSTALL_PREFIX}/build
     ${CMAKE_INSTALL_PREFIX}
@@ -37,12 +37,12 @@ find_library(LibCrypto_SHARED_LIBRARY
     )
 find_library(LibCrypto_STATIC_LIBRARY
     NAMES libcrypto.a
-    HINTS 
+    HINTS
     ${CMAKE_PREFIX_PATH}/build/crypto
     ${CMAKE_PREFIX_PATH}/build
     ${CMAKE_PREFIX_PATH}
     ${CMAKE_PREFIX_PATH}/lib64
-    ${CMAKE_PREFIX_PATH}/lib   
+    ${CMAKE_PREFIX_PATH}/lib
     ${CMAKE_INSTALL_PREFIX}/build/crypto
     ${CMAKE_INSTALL_PREFIX}/build
     ${CMAKE_INSTALL_PREFIX}


### PR DESCRIPTION
I'm trying to write a simple CMakeLists.txt file for a standalone app using the aws-crt-cpp libraries, and it was ending up with this same copy/paste voodoo that we put in every CMakeLists.txt file we write:

```
# This is required in order to append /lib/cmake to each element in CMAKE_PREFIX_PATH
set(AWS_MODULE_DIR "/${CMAKE_INSTALL_LIBDIR}/cmake")
string(REPLACE ";" "${AWS_MODULE_DIR};" AWS_MODULE_PATH "${CMAKE_PREFIX_PATH}${AWS_MODULE_DIR}")
# Append that generated list to the module search path
list(APPEND CMAKE_MODULE_PATH ${AWS_MODULE_PATH})
```
I was searching for a better way and found this [stackoverflow post](https://stackoverflow.com/questions/44920389/installing-a-cmake-library-also-ship-find-modules-for-the-dependencies).

This change makes it so that any consumer of `aws-c-io-config.cmake` gets their CMAKE_MODULE_PATH automatically modified so that FindLibCrypto.cmake will be found. . It feels a little hacky, but overall a better solution than what we had before.

If this is successful, we should do the same thing in s2n, and possibly get rid of aws-c-io's duplicate FindLibCrypto.cmake.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
