### PR TITLE
Safely Destroy EventLoopGroup

### DIFF
--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -64,7 +64,7 @@ static void s_aws_event_loop_group_shutdown_async(struct aws_event_loop_group *e
         aws_thread_launch(&cleanup_thread, s_event_loop_destroy_async_thread_fn, el_group, &thread_options) ==
         AWS_OP_SUCCESS);
 
-    aws_thread_clean_up(&cleanup_thread);
+    aws_thread_join(&cleanup_thread);
 }
 
 struct aws_event_loop_group *aws_event_loop_group_new(


### PR DESCRIPTION
Wait spawned thread to finish cleanning up event loop threads, then return from shutdown.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
