### PR TITLE
Mirror client bootstrap options into server bootstrap options

### DIFF
--- a/tests/socket_handler_test.c
+++ b/tests/socket_handler_test.c
@@ -293,7 +293,11 @@ static int s_local_server_tester_init(
         sizeof(tester->endpoint.address),
         LOCAL_SOCK_TEST_PATTERN,
         (long long unsigned)tester->timestamp);
-    tester->server_bootstrap = aws_server_bootstrap_new(allocator, s_c_tester->el_group);
+
+    struct aws_server_bootstrap_options server_bootstrap_options = {
+        .event_loop_group = s_c_tester->el_group,
+    };
+    tester->server_bootstrap = aws_server_bootstrap_new(allocator, &server_bootstrap_options);
     ASSERT_NOT_NULL(tester->server_bootstrap);
 
     struct aws_server_socket_channel_bootstrap_options bootstrap_options = {

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -317,7 +317,11 @@ static int s_tls_local_server_tester_init(
     tester->socket_options.domain = AWS_SOCKET_LOCAL;
     ASSERT_SUCCESS(aws_sys_clock_get_ticks(&tester->timestamp));
     sprintf(tester->endpoint.address, LOCAL_SOCK_TEST_PATTERN, (long long unsigned)tester->timestamp);
-    tester->server_bootstrap = aws_server_bootstrap_new(allocator, tls_c_tester->el_group);
+
+    struct aws_server_bootstrap_options server_bootstrap_options = {
+        .event_loop_group = tls_c_tester->el_group,
+    };
+    tester->server_bootstrap = aws_server_bootstrap_new(allocator, &server_bootstrap_options);
     ASSERT_NOT_NULL(tester->server_bootstrap);
 
     struct aws_server_socket_channel_bootstrap_options bootstrap_options = {


### PR DESCRIPTION
* Converts server bootstrap constructor to take options struct; requires associated PRs in aws-c-http, aws-c-mqtt, as well as subsequent CRT updates


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
