### PR TITLE
Fix for tls data writes when channel overhead is not zero

### DIFF
--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -162,7 +162,7 @@ static OSStatus s_write_cb(SSLConnectionRef conn, const void *data, size_t *len)
     size_t processed = 0;
     while (processed < buf.len) {
         const size_t overhead = aws_channel_slot_upstream_message_overhead(handler->parent_slot);
-        const size_t message_size_hint = buf.len - processed + overhead;
+        const size_t message_size_hint = (buf.len - processed) + overhead;
         struct aws_io_message *message = aws_channel_acquire_message_from_pool(
             handler->parent_slot->channel, AWS_IO_MESSAGE_APPLICATION_DATA, message_size_hint);
 

--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -161,19 +161,18 @@ static OSStatus s_write_cb(SSLConnectionRef conn, const void *data, size_t *len)
 
     size_t processed = 0;
     while (processed < buf.len) {
+        const size_t overhead = aws_channel_slot_upstream_message_overhead(handler->parent_slot);
+        const size_t message_size_hint = buf.len - processed + overhead;
         struct aws_io_message *message = aws_channel_acquire_message_from_pool(
-            handler->parent_slot->channel, AWS_IO_MESSAGE_APPLICATION_DATA, buf.len - processed);
+            handler->parent_slot->channel, AWS_IO_MESSAGE_APPLICATION_DATA, message_size_hint);
 
-        if (!message) {
+        if (!message || message->message_data.capacity <= overhead) {
             return errSecMemoryError;
         }
 
-        const size_t overhead = aws_channel_slot_upstream_message_overhead(handler->parent_slot);
-        const size_t available_msg_write_capacity = buffer_cursor.len - overhead;
-
-        const size_t to_write = message->message_data.capacity > available_msg_write_capacity
-                                    ? available_msg_write_capacity
-                                    : message->message_data.capacity;
+        const size_t available_msg_write_capacity = message->message_data.capacity - overhead;
+        const size_t to_write =
+            available_msg_write_capacity >= buffer_cursor.len ? buffer_cursor.len : available_msg_write_capacity;
 
         struct aws_byte_cursor chunk = aws_byte_cursor_advance(&buffer_cursor, to_write);
         if (aws_byte_buf_append(&message->message_data, &chunk)) {

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -208,7 +208,7 @@ static int s_generic_send(struct s2n_handler *handler, struct aws_byte_buf *buf)
     size_t processed = 0;
     while (processed < buf->len) {
         const size_t overhead = aws_channel_slot_upstream_message_overhead(handler->slot);
-        const size_t message_size_hint = buf->len - processed + overhead;
+        const size_t message_size_hint = (buf->len - processed) + overhead;
         struct aws_io_message *message = aws_channel_acquire_message_from_pool(
             handler->slot->channel, AWS_IO_MESSAGE_APPLICATION_DATA, message_size_hint);
 

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -130,6 +130,7 @@ add_net_test_case(tls_server_multiple_connections)
 add_net_test_case(tls_server_hangup_during_negotiation)
 add_net_test_case(tls_client_channel_no_verify)
 add_net_test_case(test_tls_negotiation_timeout)
+add_net_test_case(tls_double_channel)
 add_test_case(tls_destroy_null_context)
 
 add_net_test_case(alpn_successfully_negotiates)

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -541,7 +541,7 @@ static struct aws_byte_buf s_client_to_proxy_server_handle_read(
         AWS_FATAL_ASSERT(proxy_context->c2p_server_channel != NULL);
         proxy_context->state = TPTS_CONNECTING;
         aws_client_bootstrap_new_socket_channel(proxy_context->to_endpoint_bootstrap_options);
-    } else if (proxy_context->state == TPTS_CONNECTED) {
+    } else if (proxy_context->state == TPTS_CONNECTED && !proxy_context->endpoint_shutdown_finished) {
         /* schedule a task to send data to the endpoint */
         if (!proxy_context->relay_to_endpoint_scheduled) {
             proxy_context->relay_to_endpoint_scheduled = true;

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -1959,6 +1959,8 @@ static void s_proxy_to_endpoint_client_shutdown_callback(
 }
 
 static void s_c2p_relay_to_client(struct aws_channel_task *channel_task, void *arg, enum aws_task_status status) {
+    (void)channel_task;
+
     if (status != AWS_TASK_STATUS_RUN_READY) {
         return;
     }
@@ -1993,6 +1995,8 @@ static void s_c2p_relay_to_client(struct aws_channel_task *channel_task, void *a
 }
 
 static void s_p2e_relay_to_endpoint(struct aws_channel_task *channel_task, void *arg, enum aws_task_status status) {
+    (void)channel_task;
+
     if (status != AWS_TASK_STATUS_RUN_READY) {
         return;
     }

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -250,16 +250,16 @@ static void s_tls_handler_test_client_setup_callback(
     struct tls_test_args *setup_test_args = user_data;
     aws_mutex_lock(setup_test_args->mutex);
 
+    setup_test_args->setup_callback_invoked = true;
+
     if (!error_code) {
         setup_test_args->channel = channel;
+        s_aws_check_for_user_handler_setup(setup_test_args);
+        s_on_channel_setup_next_tls_handler(setup_test_args);
     } else {
         setup_test_args->error_invoked = true;
         setup_test_args->last_error_code = error_code;
     }
-
-    setup_test_args->setup_callback_invoked = true;
-    s_aws_check_for_user_handler_setup(setup_test_args);
-    s_on_channel_setup_next_tls_handler(setup_test_args);
 
     aws_mutex_unlock(setup_test_args->mutex);
     aws_condition_variable_notify_one(setup_test_args->condition_variable);
@@ -276,6 +276,7 @@ static void s_tls_handler_test_server_setup_callback(
     struct tls_test_args *setup_test_args = (struct tls_test_args *)user_data;
 
     aws_mutex_lock(setup_test_args->mutex);
+    setup_test_args->setup_callback_invoked = true;
     if (!error_code) {
         setup_test_args->channel = channel;
     } else {
@@ -283,7 +284,6 @@ static void s_tls_handler_test_server_setup_callback(
         setup_test_args->last_error_code = error_code;
     }
 
-    setup_test_args->setup_callback_invoked = true;
     s_aws_check_for_user_handler_setup(setup_test_args);
 
     aws_mutex_unlock(setup_test_args->mutex);

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -25,9 +25,9 @@
 #endif
 
 #ifdef _WIN32
-#    define LOCAL_SOCK_TEST_PATTERN "\\\\.\\pipe\\testsock%llu"
+#    define LOCAL_SOCK_TEST_PATTERN "\\\\.\\pipe\\testsock%llu_%d"
 #else
-#    define LOCAL_SOCK_TEST_PATTERN "testsock%llu.sock"
+#    define LOCAL_SOCK_TEST_PATTERN "testsock%llu_%d.sock"
 #endif
 
 struct tls_test_args {
@@ -371,7 +371,8 @@ static int s_tls_local_server_tester_init(
     struct tls_local_server_tester *tester,
     struct tls_test_args *args,
     struct tls_common_tester *tls_c_tester,
-    bool enable_back_pressure) {
+    bool enable_back_pressure,
+    int server_index) {
     AWS_ZERO_STRUCT(*tester);
     ASSERT_SUCCESS(s_tls_server_opt_tester_init(allocator, &tester->server_tls_opt_tester));
     aws_tls_connection_options_set_callbacks(&tester->server_tls_opt_tester.opt, s_tls_on_negotiated, NULL, NULL, args);
@@ -379,7 +380,7 @@ static int s_tls_local_server_tester_init(
     tester->socket_options.type = AWS_SOCKET_STREAM;
     tester->socket_options.domain = AWS_SOCKET_LOCAL;
     ASSERT_SUCCESS(aws_sys_clock_get_ticks(&tester->timestamp));
-    sprintf(tester->endpoint.address, LOCAL_SOCK_TEST_PATTERN, (long long unsigned)tester->timestamp);
+    sprintf(tester->endpoint.address, LOCAL_SOCK_TEST_PATTERN, (long long unsigned)tester->timestamp, server_index);
     tester->server_bootstrap = aws_server_bootstrap_new(allocator, tls_c_tester->el_group);
     ASSERT_NOT_NULL(tester->server_bootstrap);
 
@@ -469,6 +470,137 @@ static struct aws_byte_buf s_tls_test_handle_write(
     return (struct aws_byte_buf){0};
 }
 
+enum tls_proxy_test_state { TPTS_NONE, TPTS_CONNECTING, TPTS_CONNECTED };
+
+struct tls_proxy_test_context {
+    struct aws_mutex *lock;
+    struct aws_condition_variable *signal;
+    struct aws_byte_buf from_client_data;
+    struct aws_byte_buf to_client_data;
+    struct tls_test_args *c2p_server_test_args;
+    struct aws_channel *c2p_server_channel;
+    struct aws_channel *p2e_client_channel;
+    struct aws_channel_handler *c2p_server_rw_handler;
+    struct aws_channel_handler *proxy_server_rw_handler;
+    struct aws_channel_task c2p_relay_to_client_task;
+    struct aws_channel_task pe2_relay_to_endpoint_task;
+    enum tls_proxy_test_state state;
+    bool relay_to_client_scheduled;
+    bool relay_to_endpoint_scheduled;
+    bool endpoint_shutdown_finished;
+    struct aws_socket_channel_bootstrap_options *to_endpoint_bootstrap_options;
+};
+
+static int s_tls_proxy_rw_args_init(
+    struct tls_proxy_test_context *proxy_context,
+    struct aws_allocator *allocator,
+    struct tls_common_tester *tls_c_tester) {
+    AWS_ZERO_STRUCT(*proxy_context);
+
+    proxy_context->state = TPTS_NONE;
+    proxy_context->lock = &tls_c_tester->mutex;
+    proxy_context->signal = &tls_c_tester->condition_variable;
+
+    ASSERT_SUCCESS(aws_byte_buf_init(&proxy_context->from_client_data, allocator, 256));
+    ASSERT_SUCCESS(aws_byte_buf_init(&proxy_context->to_client_data, allocator, 256));
+
+    return AWS_OP_SUCCESS;
+}
+
+static void s_tls_proxy_rw_args_clean_up(struct tls_proxy_test_context *args) {
+
+    aws_byte_buf_clean_up(&args->from_client_data);
+    aws_byte_buf_clean_up(&args->to_client_data);
+}
+
+static bool s_tls_proxy_channel_shutdown_predicate(void *user_data) {
+    struct tls_proxy_test_context *proxy_context = (struct tls_proxy_test_context *)user_data;
+
+    return proxy_context->endpoint_shutdown_finished;
+}
+
+static struct aws_byte_buf s_client_to_proxy_server_handle_read(
+    struct aws_channel_handler *handler,
+    struct aws_channel_slot *slot,
+    struct aws_byte_buf *data_read,
+    void *user_data) {
+
+    (void)handler;
+    (void)slot;
+
+    struct tls_proxy_test_context *proxy_context = (struct tls_proxy_test_context *)user_data;
+    aws_mutex_lock(proxy_context->lock);
+
+    struct aws_byte_cursor data_cursor = aws_byte_cursor_from_buf(data_read);
+    aws_byte_buf_append_dynamic(&proxy_context->from_client_data, &data_cursor);
+
+    if (proxy_context->state == TPTS_NONE) {
+        /* initiate the connection to the endpoint */
+        proxy_context->c2p_server_channel = proxy_context->c2p_server_test_args->channel;
+        AWS_FATAL_ASSERT(proxy_context->c2p_server_channel != NULL);
+        proxy_context->state = TPTS_CONNECTING;
+        aws_client_bootstrap_new_socket_channel(proxy_context->to_endpoint_bootstrap_options);
+    } else if (proxy_context->state == TPTS_CONNECTED) {
+        /* schedule a task to send data to the endpoint */
+        if (!proxy_context->relay_to_endpoint_scheduled) {
+            proxy_context->relay_to_endpoint_scheduled = true;
+            aws_channel_schedule_task_now(
+                proxy_context->p2e_client_channel, &proxy_context->pe2_relay_to_endpoint_task);
+        }
+    }
+
+    aws_mutex_unlock(proxy_context->lock);
+
+    struct aws_byte_buf empty_buf;
+    AWS_ZERO_STRUCT(empty_buf);
+
+    return empty_buf;
+}
+
+static struct aws_byte_buf s_proxy_to_endpoint_client_handle_read(
+    struct aws_channel_handler *handler,
+    struct aws_channel_slot *slot,
+    struct aws_byte_buf *data_read,
+    void *user_data) {
+
+    (void)handler;
+    (void)slot;
+
+    struct tls_proxy_test_context *proxy_context = (struct tls_proxy_test_context *)user_data;
+    aws_mutex_lock(proxy_context->lock);
+
+    struct aws_byte_cursor data_cursor = aws_byte_cursor_from_buf(data_read);
+    aws_byte_buf_append_dynamic(&proxy_context->to_client_data, &data_cursor);
+
+    /* schedule a task to send the data to the client */
+    if (!proxy_context->relay_to_client_scheduled) {
+        proxy_context->relay_to_client_scheduled = true;
+        aws_channel_schedule_task_now(proxy_context->c2p_server_channel, &proxy_context->c2p_relay_to_client_task);
+    }
+
+    aws_mutex_unlock(proxy_context->lock);
+
+    struct aws_byte_buf empty_buf;
+    AWS_ZERO_STRUCT(empty_buf);
+
+    return empty_buf;
+}
+
+static struct aws_byte_buf s_proxy_tls_test_handle_write(
+    struct aws_channel_handler *handler,
+    struct aws_channel_slot *slot,
+    struct aws_byte_buf *data_read,
+    void *user_data) {
+
+    (void)handler;
+    (void)slot;
+    (void)data_read;
+    (void)user_data;
+
+    /*do nothing*/
+    return (struct aws_byte_buf){0};
+}
+
 static int s_tls_channel_echo_and_backpressure_test_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
     aws_io_library_init(allocator);
@@ -499,7 +631,7 @@ static int s_tls_channel_echo_and_backpressure_test_fn(struct aws_allocator *all
     ASSERT_SUCCESS(s_tls_test_arg_init(allocator, &incoming_args, true, &c_tester));
 
     struct tls_local_server_tester local_server_tester;
-    ASSERT_SUCCESS(s_tls_local_server_tester_init(allocator, &local_server_tester, &incoming_args, &c_tester, true));
+    ASSERT_SUCCESS(s_tls_local_server_tester_init(allocator, &local_server_tester, &incoming_args, &c_tester, true, 1));
     /* make the windows small to make sure back pressure is honored. */
     struct aws_channel_handler *outgoing_rw_handler = rw_handler_new(
         allocator, s_tls_test_handle_read, s_tls_test_handle_write, true, write_tag.len / 2, &outgoing_rw_args);
@@ -1056,7 +1188,8 @@ static int s_tls_server_multiple_connections_fn(struct aws_allocator *allocator,
     ASSERT_SUCCESS(s_tls_test_arg_init(allocator, &incoming_args, true, &c_tester));
 
     struct tls_local_server_tester local_server_tester;
-    ASSERT_SUCCESS(s_tls_local_server_tester_init(allocator, &local_server_tester, &incoming_args, &c_tester, false));
+    ASSERT_SUCCESS(
+        s_tls_local_server_tester_init(allocator, &local_server_tester, &incoming_args, &c_tester, false, 1));
 
     struct tls_opt_tester client_tls_opt_tester;
     struct aws_byte_cursor server_name = aws_byte_cursor_from_c_str("localhost");
@@ -1204,7 +1337,8 @@ static int s_tls_server_hangup_during_negotiation_fn(struct aws_allocator *alloc
     ASSERT_SUCCESS(s_tls_test_arg_init(allocator, &incoming_args, true, &c_tester));
 
     struct tls_local_server_tester local_server_tester;
-    ASSERT_SUCCESS(s_tls_local_server_tester_init(allocator, &local_server_tester, &incoming_args, &c_tester, false));
+    ASSERT_SUCCESS(
+        s_tls_local_server_tester_init(allocator, &local_server_tester, &incoming_args, &c_tester, false, 1));
 
     ASSERT_SUCCESS(aws_mutex_lock(&c_tester.mutex));
 
@@ -1348,7 +1482,8 @@ static int s_tls_channel_statistics_test(struct aws_allocator *allocator, void *
     ASSERT_SUCCESS(s_tls_test_arg_init(allocator, &incoming_args, true, &c_tester));
 
     struct tls_local_server_tester local_server_tester;
-    ASSERT_SUCCESS(s_tls_local_server_tester_init(allocator, &local_server_tester, &incoming_args, &c_tester, false));
+    ASSERT_SUCCESS(
+        s_tls_local_server_tester_init(allocator, &local_server_tester, &incoming_args, &c_tester, false, 1));
 
     struct aws_channel_handler *outgoing_rw_handler =
         rw_handler_new(allocator, s_tls_test_handle_read, s_tls_test_handle_write, true, 10000, &outgoing_rw_args);
@@ -1768,13 +1903,152 @@ static int s_tls_destroy_null_context(struct aws_allocator *allocator, void *ctx
 }
 AWS_TEST_CASE(tls_destroy_null_context, s_tls_destroy_null_context);
 
+static void s_proxy_to_endpoint_client_setup_callback(
+    struct aws_client_bootstrap *bootstrap,
+    int error_code,
+    struct aws_channel *channel,
+    void *user_data) {
+
+    (void)bootstrap;
+
+    struct tls_proxy_test_context *proxy_context = user_data;
+    aws_mutex_lock(proxy_context->lock);
+
+    AWS_FATAL_ASSERT(error_code == AWS_ERROR_SUCCESS);
+
+    proxy_context->p2e_client_channel = channel;
+    proxy_context->state = TPTS_CONNECTED;
+
+    proxy_context->proxy_server_rw_handler = rw_handler_new(
+        bootstrap->allocator,
+        s_proxy_to_endpoint_client_handle_read,
+        s_proxy_tls_test_handle_write,
+        true,
+        10000,
+        proxy_context);
+
+    struct aws_channel_slot *rw_slot = aws_channel_slot_new(channel);
+    aws_channel_slot_insert_end(channel, rw_slot);
+    aws_channel_slot_set_handler(rw_slot, proxy_context->proxy_server_rw_handler);
+
+    if (!proxy_context->relay_to_endpoint_scheduled) {
+        proxy_context->relay_to_endpoint_scheduled = true;
+        aws_channel_schedule_task_now(proxy_context->p2e_client_channel, &proxy_context->pe2_relay_to_endpoint_task);
+    }
+
+    aws_mutex_unlock(proxy_context->lock);
+    aws_condition_variable_notify_one(proxy_context->signal);
+}
+
+static void s_proxy_to_endpoint_client_shutdown_callback(
+    struct aws_client_bootstrap *bootstrap,
+    int error_code,
+    struct aws_channel *channel,
+    void *user_data) {
+
+    (void)bootstrap;
+    (void)error_code;
+    (void)channel;
+
+    struct tls_proxy_test_context *proxy_content = user_data;
+
+    aws_mutex_lock(proxy_content->lock);
+    proxy_content->endpoint_shutdown_finished = true;
+    aws_mutex_unlock(proxy_content->lock);
+    aws_condition_variable_notify_one(proxy_content->signal);
+}
+
+static void s_c2p_relay_to_client(struct aws_channel_task *channel_task, void *arg, enum aws_task_status status) {
+    if (status != AWS_TASK_STATUS_RUN_READY) {
+        return;
+    }
+
+    struct aws_io_message *message = NULL;
+    struct aws_channel_slot *slot = NULL;
+    struct tls_proxy_test_context *proxy_context = arg;
+
+    aws_mutex_lock(proxy_context->lock);
+
+    size_t amount_to_send = proxy_context->to_client_data.len;
+    if (amount_to_send > 0) {
+        message = aws_channel_acquire_message_from_pool(
+            proxy_context->c2p_server_channel, AWS_IO_MESSAGE_APPLICATION_DATA, amount_to_send);
+        AWS_FATAL_ASSERT(message);
+
+        AWS_FATAL_ASSERT(
+            aws_byte_buf_write(&message->message_data, proxy_context->to_client_data.buffer, amount_to_send));
+
+        proxy_context->to_client_data.len = 0;
+
+        /* send to tls handler */
+        slot = aws_channel_get_first_slot(proxy_context->c2p_server_channel)->adj_right->adj_right;
+    }
+
+    proxy_context->relay_to_client_scheduled = false;
+    aws_mutex_unlock(proxy_context->lock);
+
+    if (message != NULL && slot != NULL) {
+        AWS_FATAL_ASSERT(AWS_ERROR_SUCCESS == aws_channel_slot_send_message(slot, message, AWS_CHANNEL_DIR_WRITE));
+    }
+}
+
+static void s_p2e_relay_to_endpoint(struct aws_channel_task *channel_task, void *arg, enum aws_task_status status) {
+    if (status != AWS_TASK_STATUS_RUN_READY) {
+        return;
+    }
+
+    struct aws_io_message *message = NULL;
+    struct aws_channel_slot *slot = NULL;
+    struct tls_proxy_test_context *proxy_context = arg;
+
+    aws_mutex_lock(proxy_context->lock);
+
+    size_t amount_to_send = proxy_context->from_client_data.len;
+    if (amount_to_send > 0) {
+        message = aws_channel_acquire_message_from_pool(
+            proxy_context->p2e_client_channel, AWS_IO_MESSAGE_APPLICATION_DATA, amount_to_send);
+        AWS_FATAL_ASSERT(message);
+
+        AWS_FATAL_ASSERT(
+            aws_byte_buf_write(&message->message_data, proxy_context->from_client_data.buffer, amount_to_send));
+
+        proxy_context->from_client_data.len = 0;
+
+        /* socket slot */
+        slot = aws_channel_get_first_slot(proxy_context->p2e_client_channel)->adj_right;
+    }
+
+    proxy_context->relay_to_endpoint_scheduled = false;
+    aws_mutex_unlock(proxy_context->lock);
+
+    if (message != NULL && slot != NULL) {
+        AWS_FATAL_ASSERT(AWS_ERROR_SUCCESS == aws_channel_slot_send_message(slot, message, AWS_CHANNEL_DIR_WRITE));
+    }
+}
+
 /*
  * A variant of the basic tls test, but this time using nested tls handlers on the client.
  *
- * We use two servers, each configured with tls.  The first server, on handshake success, then makes a plain (non-tls)
- * socket connection to the second, and adds a pass-through handler for data coming to and from.  In this way, the
- * client, with its nested tls handlers, will then drive tls negotiation with the second server directly, making for a
- * very simple proxy simulation.
+ * We use two servers, each configured with tls.  The proxy server, on handshake success, then makes a plaintext
+ * (non-tls) socket connection to the endpoint server and adds a pass-through handler for data coming to and from.  In
+ * this way, the client, with its nested tls handlers, will then drive tls negotiation with the endpoint server
+ * directly, making for a simple proxy simulation.
+ *
+ * Visually:
+ *
+ * Client <--------------> proxy server <----------------> endpoint server
+ *
+ * The channel setup is a bit complex:
+ *
+ * c2p = client-to-proxy-server
+ * p2e = proxy-server-to-endpoint-server
+ *
+ * (1) c2p client channel:   socket <---> client tls #1 <---> client tls #2 <---> test rw handler
+ * (2) c2p server channel:   socket <---> server tls <---> to endpoint relay handler
+ * (3) p2e client channel:   socket <---> to client relay handler
+ * (4) p2e server channel:   socket <---> server tls <---> test rw handler
+ *
+ * Where the (read) relay handlers in (2) and (3) blindly forward data between one another.
  */
 static int s_tls_double_channel_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -1788,50 +2062,84 @@ static int s_tls_double_channel_fn(struct aws_allocator *allocator, void *ctx) {
     uint8_t incoming_received_message[128] = {0};
     uint8_t outgoing_received_message[128] = {0};
 
-    struct tls_test_rw_args incoming_rw_args;
+    struct tls_test_rw_args client_channel_context;
     ASSERT_SUCCESS(s_tls_rw_args_init(
-        &incoming_rw_args,
-        &c_tester,
-        aws_byte_buf_from_empty_array(incoming_received_message, sizeof(incoming_received_message))));
-
-    struct tls_test_rw_args outgoing_rw_args;
-    ASSERT_SUCCESS(s_tls_rw_args_init(
-        &outgoing_rw_args,
+        &client_channel_context,
         &c_tester,
         aws_byte_buf_from_empty_array(outgoing_received_message, sizeof(outgoing_received_message))));
 
-    struct tls_test_args outgoing_args;
-    ASSERT_SUCCESS(s_tls_test_arg_init(allocator, &outgoing_args, false, &c_tester));
-    outgoing_args.desired_tls_levels = 2;
+    struct tls_proxy_test_context proxy_channel_context;
+    ASSERT_SUCCESS(s_tls_proxy_rw_args_init(&proxy_channel_context, allocator, &c_tester));
 
-    struct tls_test_args incoming_args;
-    ASSERT_SUCCESS(s_tls_test_arg_init(allocator, &incoming_args, true, &c_tester));
-    incoming_args.desired_tls_levels = 2;
+    /* We use channel tasks to relay data across the c2p/p2e channel divide */
+    aws_channel_task_init(
+        &proxy_channel_context.c2p_relay_to_client_task,
+        s_c2p_relay_to_client,
+        &proxy_channel_context,
+        "c2p_relay_to_client");
+    aws_channel_task_init(
+        &proxy_channel_context.pe2_relay_to_endpoint_task,
+        s_p2e_relay_to_endpoint,
+        &proxy_channel_context,
+        "p2e_relay_to_endpoint");
 
-    struct tls_local_server_tester local_server_tester;
-    ASSERT_SUCCESS(s_tls_local_server_tester_init(allocator, &local_server_tester, &incoming_args, &c_tester, true));
-    /* make the windows small to make sure back pressure is honored. */
-    struct aws_channel_handler *outgoing_rw_handler = rw_handler_new(
-        allocator, s_tls_test_handle_read, s_tls_test_handle_write, true, write_tag.len / 2, &outgoing_rw_args);
-    ASSERT_NOT_NULL(outgoing_rw_handler);
+    struct tls_test_rw_args endpoint_channel_context;
+    ASSERT_SUCCESS(s_tls_rw_args_init(
+        &endpoint_channel_context,
+        &c_tester,
+        aws_byte_buf_from_empty_array(incoming_received_message, sizeof(incoming_received_message))));
 
-    struct aws_channel_handler *incoming_rw_handler = rw_handler_new(
-        allocator, s_tls_test_handle_read, s_tls_test_handle_write, true, read_tag.len / 2, &incoming_rw_args);
-    ASSERT_NOT_NULL(incoming_rw_handler);
+    struct tls_test_args client_test_state;
+    ASSERT_SUCCESS(s_tls_test_arg_init(allocator, &client_test_state, false, &c_tester));
+    client_test_state.desired_tls_levels = 2;
 
-    incoming_args.rw_handler = incoming_rw_handler;
-    outgoing_args.rw_handler = outgoing_rw_handler;
+    /*
+     * Configure the proxy server
+     */
+    struct tls_test_args proxy_server_test_state;
+    ASSERT_SUCCESS(s_tls_test_arg_init(allocator, &proxy_server_test_state, true, &c_tester));
+    proxy_server_test_state.desired_tls_levels = 1;
 
-    g_aws_channel_max_fragment_size = 4096;
+    struct tls_local_server_tester proxy_server_tester;
+    ASSERT_SUCCESS(
+        s_tls_local_server_tester_init(allocator, &proxy_server_tester, &proxy_server_test_state, &c_tester, false, 1));
+
+    /*
+     * Configure the endpoint server
+     */
+    struct tls_test_args endpoint_server_test_state;
+    ASSERT_SUCCESS(s_tls_test_arg_init(allocator, &endpoint_server_test_state, true, &c_tester));
+    endpoint_server_test_state.desired_tls_levels = 1;
+
+    struct tls_local_server_tester endpoint_server_tester;
+    ASSERT_SUCCESS(s_tls_local_server_tester_init(
+        allocator, &endpoint_server_tester, &endpoint_server_test_state, &c_tester, false, 2));
+
+    /* handler setup  */
+    struct aws_channel_handler *client_rw_handler = rw_handler_new(
+        allocator, s_tls_test_handle_read, s_tls_test_handle_write, true, 10000, &client_channel_context);
+    ASSERT_NOT_NULL(client_rw_handler);
+    client_test_state.rw_handler = client_rw_handler;
+
+    struct aws_channel_handler *c2p_server_rw_handler = rw_handler_new(
+        allocator, s_client_to_proxy_server_handle_read, s_tls_test_handle_write, true, 10000, &proxy_channel_context);
+    ASSERT_NOT_NULL(c2p_server_rw_handler);
+    proxy_server_test_state.rw_handler = c2p_server_rw_handler;
+
+    struct aws_channel_handler *endpoint_server_rw_handler = rw_handler_new(
+        allocator, s_tls_test_handle_read, s_tls_test_handle_write, true, 10000, &endpoint_channel_context);
+    ASSERT_NOT_NULL(endpoint_server_rw_handler);
+    endpoint_server_test_state.rw_handler = endpoint_server_rw_handler;
 
     struct tls_opt_tester client_tls_opt_tester;
     struct aws_byte_cursor server_name = aws_byte_cursor_from_c_str("localhost");
     ASSERT_SUCCESS(s_tls_client_opt_tester_init(allocator, &client_tls_opt_tester, server_name));
     aws_tls_connection_options_set_callbacks(
-        &client_tls_opt_tester.opt, s_tls_on_negotiated, NULL, NULL, &outgoing_args);
+        &client_tls_opt_tester.opt, s_tls_on_negotiated, NULL, NULL, &client_test_state);
 
-    outgoing_args.tls_options = &client_tls_opt_tester.opt;
-    incoming_args.tls_options = &client_tls_opt_tester.opt;
+    client_test_state.tls_options = &client_tls_opt_tester.opt;
+    proxy_server_test_state.tls_options = &client_tls_opt_tester.opt;
+    endpoint_server_test_state.tls_options = &client_tls_opt_tester.opt;
 
     struct aws_client_bootstrap_options bootstrap_options = {
         .event_loop_group = c_tester.el_group,
@@ -1839,27 +2147,39 @@ static int s_tls_double_channel_fn(struct aws_allocator *allocator, void *ctx) {
     };
     struct aws_client_bootstrap *client_bootstrap = aws_client_bootstrap_new(allocator, &bootstrap_options);
 
-    struct aws_socket_channel_bootstrap_options channel_options;
-    AWS_ZERO_STRUCT(channel_options);
-    channel_options.bootstrap = client_bootstrap;
-    channel_options.host_name = local_server_tester.endpoint.address;
-    channel_options.port = 0;
-    channel_options.socket_options = &local_server_tester.socket_options;
-    channel_options.tls_options = &client_tls_opt_tester.opt;
-    channel_options.setup_callback = s_tls_handler_test_client_setup_callback;
-    channel_options.shutdown_callback = s_tls_handler_test_client_shutdown_callback;
-    channel_options.user_data = &outgoing_args;
-    channel_options.enable_read_back_pressure = true;
+    struct aws_socket_channel_bootstrap_options client_to_proxy_channel_options;
+    AWS_ZERO_STRUCT(client_to_proxy_channel_options);
+    client_to_proxy_channel_options.bootstrap = client_bootstrap;
+    client_to_proxy_channel_options.host_name = proxy_server_tester.endpoint.address;
+    client_to_proxy_channel_options.port = 0;
+    client_to_proxy_channel_options.socket_options = &proxy_server_tester.socket_options;
+    client_to_proxy_channel_options.tls_options = &client_tls_opt_tester.opt;
+    client_to_proxy_channel_options.setup_callback = s_tls_handler_test_client_setup_callback;
+    client_to_proxy_channel_options.shutdown_callback = s_tls_handler_test_client_shutdown_callback;
+    client_to_proxy_channel_options.user_data = &client_test_state;
 
-    ASSERT_SUCCESS(aws_client_bootstrap_new_socket_channel(&channel_options));
+    struct aws_socket_channel_bootstrap_options proxy_to_endpoint_channel_options;
+    AWS_ZERO_STRUCT(proxy_to_endpoint_channel_options);
+    proxy_to_endpoint_channel_options.bootstrap = client_bootstrap;
+    proxy_to_endpoint_channel_options.host_name = endpoint_server_tester.endpoint.address;
+    proxy_to_endpoint_channel_options.port = 0;
+    proxy_to_endpoint_channel_options.socket_options = &endpoint_server_tester.socket_options;
+    proxy_to_endpoint_channel_options.tls_options = NULL;
+    proxy_to_endpoint_channel_options.setup_callback = s_proxy_to_endpoint_client_setup_callback;
+    proxy_to_endpoint_channel_options.shutdown_callback = s_proxy_to_endpoint_client_shutdown_callback;
+    proxy_to_endpoint_channel_options.user_data = &proxy_channel_context;
+
+    proxy_channel_context.to_endpoint_bootstrap_options = &proxy_to_endpoint_channel_options;
+    proxy_channel_context.c2p_server_test_args = &proxy_server_test_state;
+
+    ASSERT_SUCCESS(aws_client_bootstrap_new_socket_channel(&client_to_proxy_channel_options));
 
     /* wait for both ends to setup */
     ASSERT_SUCCESS(aws_mutex_lock(&c_tester.mutex));
     ASSERT_SUCCESS(aws_condition_variable_wait_pred(
-        &c_tester.condition_variable, &c_tester.mutex, s_tls_channel_setup_predicate, &incoming_args));
-    ASSERT_INT_EQUALS(2, incoming_args.tls_levels_negotiated);
+        &c_tester.condition_variable, &c_tester.mutex, s_tls_channel_setup_predicate, &endpoint_server_test_state));
     ASSERT_SUCCESS(aws_mutex_unlock(&c_tester.mutex));
-    ASSERT_FALSE(incoming_args.error_invoked);
+    ASSERT_FALSE(endpoint_server_test_state.error_invoked);
 
 /* currently it seems ALPN doesn't work in server mode. Just leaving this check out for now. */
 #ifndef __APPLE__
@@ -1870,17 +2190,17 @@ static int s_tls_double_channel_fn(struct aws_allocator *allocator, void *ctx) {
         ASSERT_BIN_ARRAYS_EQUALS(
             expected_protocol.buffer,
             expected_protocol.len,
-            incoming_args.negotiated_protocol.buffer,
-            incoming_args.negotiated_protocol.len);
+            endpoint_server_test_state.negotiated_protocol.buffer,
+            endpoint_server_test_state.negotiated_protocol.len);
     }
 #endif
 
     ASSERT_SUCCESS(aws_mutex_lock(&c_tester.mutex));
     ASSERT_SUCCESS(aws_condition_variable_wait_pred(
-        &c_tester.condition_variable, &c_tester.mutex, s_tls_channel_setup_predicate, &outgoing_args));
-    ASSERT_INT_EQUALS(2, outgoing_args.tls_levels_negotiated);
+        &c_tester.condition_variable, &c_tester.mutex, s_tls_channel_setup_predicate, &client_test_state));
+    ASSERT_INT_EQUALS(2, client_test_state.tls_levels_negotiated);
     ASSERT_SUCCESS(aws_mutex_unlock(&c_tester.mutex));
-    ASSERT_FALSE(outgoing_args.error_invoked);
+    ASSERT_FALSE(client_test_state.error_invoked);
 
 /* currently it seems ALPN doesn't work in server mode. Just leaving this check out for now. */
 #ifndef __MACH__
@@ -1888,45 +2208,66 @@ static int s_tls_double_channel_fn(struct aws_allocator *allocator, void *ctx) {
         ASSERT_BIN_ARRAYS_EQUALS(
             expected_protocol.buffer,
             expected_protocol.len,
-            outgoing_args.negotiated_protocol.buffer,
-            outgoing_args.negotiated_protocol.len);
+            client_test_state.negotiated_protocol.buffer,
+            client_test_state.negotiated_protocol.len);
     }
 #endif
 
-    ASSERT_FALSE(outgoing_args.error_invoked);
+    ASSERT_FALSE(client_test_state.error_invoked);
 
     /* Do the IO operations */
-    rw_handler_write(outgoing_args.rw_handler, outgoing_args.rw_slot, &write_tag);
-    rw_handler_write(incoming_args.rw_handler, incoming_args.rw_slot, &read_tag);
+    rw_handler_write(client_test_state.rw_handler, client_test_state.rw_slot, &write_tag);
+    rw_handler_write(endpoint_server_test_state.rw_handler, endpoint_server_test_state.rw_slot, &read_tag);
     ASSERT_SUCCESS(aws_mutex_lock(&c_tester.mutex));
     ASSERT_SUCCESS(aws_condition_variable_wait_pred(
-        &c_tester.condition_variable, &c_tester.mutex, s_tls_test_read_predicate, &incoming_rw_args));
+        &c_tester.condition_variable, &c_tester.mutex, s_tls_test_read_predicate, &endpoint_channel_context));
     ASSERT_SUCCESS(aws_condition_variable_wait_pred(
-        &c_tester.condition_variable, &c_tester.mutex, s_tls_test_read_predicate, &outgoing_rw_args));
+        &c_tester.condition_variable, &c_tester.mutex, s_tls_test_read_predicate, &client_channel_context));
     ASSERT_SUCCESS(aws_mutex_unlock(&c_tester.mutex));
 
-    ASSERT_INT_EQUALS(1, outgoing_rw_args.read_invocations);
-    ASSERT_INT_EQUALS(1, incoming_rw_args.read_invocations);
+    ASSERT_INT_EQUALS(1, client_channel_context.read_invocations);
+    ASSERT_INT_EQUALS(1, endpoint_channel_context.read_invocations);
 
-    aws_channel_shutdown(incoming_args.channel, AWS_OP_SUCCESS);
+    aws_channel_shutdown(endpoint_server_test_state.channel, AWS_OP_SUCCESS);
     ASSERT_SUCCESS(aws_mutex_lock(&c_tester.mutex));
     ASSERT_SUCCESS(aws_condition_variable_wait_pred(
-        &c_tester.condition_variable, &c_tester.mutex, s_tls_channel_shutdown_predicate, &incoming_args));
+        &c_tester.condition_variable, &c_tester.mutex, s_tls_channel_shutdown_predicate, &endpoint_server_test_state));
+    ASSERT_SUCCESS(aws_mutex_unlock(&c_tester.mutex));
+
+    aws_channel_shutdown(proxy_server_test_state.channel, AWS_OP_SUCCESS);
+    ASSERT_SUCCESS(aws_mutex_lock(&c_tester.mutex));
+    ASSERT_SUCCESS(aws_condition_variable_wait_pred(
+        &c_tester.condition_variable, &c_tester.mutex, s_tls_channel_shutdown_predicate, &proxy_server_test_state));
     ASSERT_SUCCESS(aws_mutex_unlock(&c_tester.mutex));
 
     /*no shutdown on the client necessary here (it should have been triggered by shutting down the other side). just
      * wait for the event to fire. */
     ASSERT_SUCCESS(aws_mutex_lock(&c_tester.mutex));
+
     ASSERT_SUCCESS(aws_condition_variable_wait_pred(
-        &c_tester.condition_variable, &c_tester.mutex, s_tls_channel_shutdown_predicate, &outgoing_args));
-    aws_server_bootstrap_destroy_socket_listener(local_server_tester.server_bootstrap, local_server_tester.listener);
+        &c_tester.condition_variable, &c_tester.mutex, s_tls_proxy_channel_shutdown_predicate, &proxy_channel_context));
+
     ASSERT_SUCCESS(aws_condition_variable_wait_pred(
-        &c_tester.condition_variable, &c_tester.mutex, s_tls_listener_destroy_predicate, &incoming_args));
+        &c_tester.condition_variable, &c_tester.mutex, s_tls_channel_shutdown_predicate, &client_test_state));
+
+    aws_server_bootstrap_destroy_socket_listener(
+        endpoint_server_tester.server_bootstrap, endpoint_server_tester.listener);
+    ASSERT_SUCCESS(aws_condition_variable_wait_pred(
+        &c_tester.condition_variable, &c_tester.mutex, s_tls_listener_destroy_predicate, &endpoint_server_test_state));
+
+    aws_server_bootstrap_destroy_socket_listener(proxy_server_tester.server_bootstrap, proxy_server_tester.listener);
+    ASSERT_SUCCESS(aws_condition_variable_wait_pred(
+        &c_tester.condition_variable, &c_tester.mutex, s_tls_listener_destroy_predicate, &proxy_server_test_state));
+
     aws_mutex_unlock(&c_tester.mutex);
+
+    s_tls_proxy_rw_args_clean_up(&proxy_channel_context);
+
     /* clean up */
     ASSERT_SUCCESS(s_tls_opt_tester_clean_up(&client_tls_opt_tester));
     aws_client_bootstrap_release(client_bootstrap);
-    ASSERT_SUCCESS(s_tls_local_server_tester_clean_up(&local_server_tester));
+    ASSERT_SUCCESS(s_tls_local_server_tester_clean_up(&endpoint_server_tester));
+    ASSERT_SUCCESS(s_tls_local_server_tester_clean_up(&proxy_server_tester));
     ASSERT_SUCCESS(s_tls_common_tester_clean_up(&c_tester));
 
     aws_tls_connection_options_clean_up(&client_tls_opt_tester.opt);

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -1769,7 +1769,12 @@ static int s_tls_destroy_null_context(struct aws_allocator *allocator, void *ctx
 AWS_TEST_CASE(tls_destroy_null_context, s_tls_destroy_null_context);
 
 /*
- * A variant of the backpressure-echo test, but this time using nested tls handlers and no backpressure
+ * A variant of the basic tls test, but this time using nested tls handlers on the client.
+ *
+ * We use two servers, each configured with tls.  The first server, on handshake success, then makes a plain (non-tls)
+ * socket connection to the second, and adds a pass-through handler for data coming to and from.  In this way, the
+ * client, with its nested tls handlers, will then drive tls negotiation with the second server directly, making for a
+ * very simple proxy simulation.
  */
 static int s_tls_double_channel_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -2248,7 +2248,11 @@ static int s_tls_double_channel_fn(struct aws_allocator *allocator, void *ctx) {
         &c_tester.condition_variable, &c_tester.mutex, s_tls_channel_shutdown_predicate, &endpoint_server_test_state));
     ASSERT_SUCCESS(aws_mutex_unlock(&c_tester.mutex));
 
-    aws_channel_shutdown(proxy_server_test_state.channel, AWS_OP_SUCCESS);
+    /*
+     * It turns out we only need to explicitly shut down the proxy-to-endpoint server channel since that will break
+     * the tls circuit all the way to client, which in turn causes both client channels to go away which in turn
+     * casues the client-to-proxy server channel to go away.
+     */
     ASSERT_SUCCESS(aws_mutex_lock(&c_tester.mutex));
     ASSERT_SUCCESS(aws_condition_variable_wait_pred(
         &c_tester.condition_variable, &c_tester.mutex, s_tls_channel_shutdown_predicate, &proxy_server_test_state));


### PR DESCRIPTION
Several of the tls channel handlers did incorrect calculations on upstream data writes, but nothing went wrong until the upstream overhead was non zero, which hasn't happened until now (double tls support: to-proxy, tunnel-to-endpoint).  In the double tls use case, this turned into an infinite loop because the message that we requested was not able to fit any actual data in it other than the overhead.  

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
