### PR TITLE
Update VCC proofs of epoll event loop

### DIFF
--- a/.github/workflows/proof-alarm.yml
+++ b/.github/workflows/proof-alarm.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Check
       run: |
-        git diff --quiet 955dfd950 source/linux/epoll_event_loop.c
+        git diff --quiet 735ba3d6c source/linux/epoll_event_loop.c
 
     # No further steps if successful
 

--- a/docs/epoll_event_loop_proof.md
+++ b/docs/epoll_event_loop_proof.md
@@ -2,7 +2,7 @@
 
 Verification tool: VCC (code-level proof)
 
-Proofs: tests/vcc/
+Proofs: `tests/vcc/`
 
 Implementation: Linux event loop (`source/linux/epoll_event_loop.c`)
 

--- a/tests/vcc/Makefile
+++ b/tests/vcc/Makefile
@@ -1,7 +1,7 @@
 VCC?=vcc
 VCC_ARGS+=/sm
 GIT?=git
-NO_CHANGE_EXPECTED_HASH=84bfb96d0
+NO_CHANGE_EXPECTED_HASH=9a565350c
 NO_CHANGE_FILE=source/linux/epoll_event_loop.c
 
 # The VCC proofs in this directory are based on a snapshot of
@@ -22,8 +22,9 @@ NO_CHANGE_FILE=source/linux/epoll_event_loop.c
 	$(VCC) $(VCC_ARGS) process_task_pre_queue.c /f:s_process_task_pre_queue
 	$(VCC) $(VCC_ARGS) lifecycle.c /f:s_stop_task /f:s_stop /f:s_wait_for_stop_completion /f:s_run
 	$(VCC) $(VCC_ARGS) main_loop.c /f:s_on_tasks_to_schedule /f:s_main_loop
-	$(VCC) $(VCC_ARGS) new_destroy.c /f:aws_event_loop_new_default /f:s_destroy /p:"-DUSE_EFD=0"
-	$(VCC) $(VCC_ARGS) new_destroy.c /f:aws_event_loop_new_default /f:s_destroy /p:"-DUSE_EFD=1"
+	$(VCC) $(VCC_ARGS) new_destroy.c /f:aws_event_loop_new_default
+	$(VCC) $(VCC_ARGS) new_destroy.c /f:aws_event_loop_new_default_with_options /f:s_destroy /p:"-DUSE_EFD=0"
+	$(VCC) $(VCC_ARGS) new_destroy.c /f:aws_event_loop_new_default_with_options /f:s_destroy /p:"-DUSE_EFD=1"
 	$(VCC) $(VCC_ARGS) client.c /f:test_new_destroy /f:test_subscribe_unsubscribe
 
 .phony: all

--- a/tests/vcc/Makefile
+++ b/tests/vcc/Makefile
@@ -1,7 +1,7 @@
 VCC?=vcc
 VCC_ARGS+=/sm
 GIT?=git
-NO_CHANGE_EXPECTED_HASH=9a565350c
+NO_CHANGE_EXPECTED_HASH=735ba3d6c
 NO_CHANGE_FILE=source/linux/epoll_event_loop.c
 
 # The VCC proofs in this directory are based on a snapshot of

--- a/tests/vcc/lifecycle.c
+++ b/tests/vcc/lifecycle.c
@@ -23,6 +23,7 @@ static void s_stop_task(struct aws_task *task, void *args, enum aws_task_status 
     struct aws_event_loop *event_loop = args;
     struct epoll_loop *epoll_loop = event_loop->impl_data;
 
+    /* now okay to reschedule stop tasks. */
     _(unwrap &epoll_loop->stop_task_ptr)
     aws_atomic_store_ptr(&epoll_loop->stop_task_ptr, NULL);
     _(wrap &epoll_loop->stop_task_ptr)
@@ -98,7 +99,7 @@ static int s_run(struct aws_event_loop *event_loop _(ghost \claim(c_mutex))) {
     AWS_LOGF_INFO(AWS_LS_IO_EVENT_LOOP, "id=%p: Starting event-loop thread.", (void *)event_loop);
 
     epoll_loop->should_continue = true;
-    if (aws_thread_launch(&epoll_loop->thread_created_on, /*&s_main_loop*/&dummy_main_loop, event_loop, NULL)) {
+    if (aws_thread_launch(&epoll_loop->thread_created_on, /*&s_main_loop*/&dummy_main_loop, event_loop, &epoll_loop->thread_options)) {
         AWS_LOGF_FATAL(AWS_LS_IO_EVENT_LOOP, "id=%p: thread creation failed.", (void *)event_loop);
         epoll_loop->should_continue = false;
         return AWS_OP_ERR;

--- a/tests/vcc/preamble.h
+++ b/tests/vcc/preamble.h
@@ -109,6 +109,7 @@ int epoll_create(int size)
 /* Definitions from aws/common/assert.h */
 /* Convert into VCC assertions */
 #define AWS_ASSERT(x) _(assert x)
+#define AWS_PRECONDITION(x) _(assert x)
 
 /* Definitions from aws/common/logging.h (no-ops for proof) */
 #define AWS_LOGF_INFO(...)
@@ -364,7 +365,7 @@ void aws_atomic_store_ptr(/*volatile*/ struct aws_atomic_var *var, void *val)
 /* Fake-up pthread.h */
 typedef uint64_t pthread_t;
 
-/* Definitions from aws/common.thread.h */
+/* Definitions from aws/common/thread.h */
 enum aws_thread_detach_state {
     AWS_THREAD_NOT_CREATED = 1,
     AWS_THREAD_JOINABLE,
@@ -381,6 +382,7 @@ struct aws_thread {
 
 struct aws_thread_options {
     size_t stack_size;
+    int32_t cpu_id;
 };
 
 _(pure) aws_thread_id_t aws_thread_current_thread_id(void)
@@ -427,6 +429,13 @@ typedef int(* aws_io_clock_fn_ptr)(uint64_t *timestamp)
 
 /* Definitions from aws/io/event_loop.h */
 struct aws_event_loop_vtable;
+
+struct aws_event_loop_options {
+    aws_io_clock_fn_ptr clock; /*< VCC change: fnptr */
+    struct aws_thread_options *thread_options;
+    _(invariant clock->\valid)
+    _(invariant thread_options != NULL <==> \mine(thread_options))
+};
 
 _(claimable) struct aws_event_loop {
     struct aws_event_loop_vtable *vtable;
@@ -519,6 +528,7 @@ struct epoll_loop {
     _(group scheduler)
     _(:scheduler) struct aws_task_scheduler scheduler;
     struct aws_thread thread_created_on;
+    struct aws_thread_options thread_options;
     aws_thread_id_t thread_joined_to;
     struct aws_atomic_var running_thread_id;
     _(group read_handle)
@@ -783,11 +793,28 @@ static void s_main_loop(void *args _(ghost \claim(c_mutex)))
     _(writes &epoll_loop_of(event_loop_of(args))->should_process_task_pre_queue)
 ;
 
-struct aws_event_loop *aws_event_loop_new_default(struct aws_allocator *alloc, aws_io_clock_fn_ptr clock
+struct aws_event_loop *aws_event_loop_new_default(
+    struct aws_allocator *alloc,
+    aws_io_clock_fn_ptr clock /*< VCC change: fnptr */
     _(out \claim(c_mutex))
 )
     _(requires \wrapped(alloc))
     _(requires clock->\valid)
+    _(ensures \result == NULL ||
+       (\wrapped0(\result) &&
+        \fresh(\result) && \malloc_root(\result) &&
+        \fresh(epoll_loop_of(\result)) && \malloc_root(epoll_loop_of(\result)) &&
+        ownership_of_epoll_loop_objects(epoll_loop_of(\result)) &&
+        \fresh(c_mutex) && \wrapped0(c_mutex) && \claims_object(c_mutex, &(epoll_loop_of(\result)->task_pre_queue_mutex))))
+;
+
+struct aws_event_loop *aws_event_loop_new_default_with_options(
+    struct aws_allocator *alloc,
+    const struct aws_event_loop_options *options
+    _(out \claim(c_mutex))
+)
+    _(requires \wrapped(alloc))
+    _(maintains \wrapped(options))
     _(ensures \result == NULL ||
        (\wrapped0(\result) &&
         \fresh(\result) && \malloc_root(\result) &&

--- a/tests/vcc/subscribe.c
+++ b/tests/vcc/subscribe.c
@@ -26,6 +26,7 @@ static int s_subscribe_to_io_events(
 ) {
     _(assert \always_by_claim(c_event_loop, event_loop))
 
+    AWS_LOGF_TRACE(AWS_LS_IO_EVENT_LOOP, "id=%p: subscribing to events on fd %d", (void *)event_loop, handle->data.fd);
     struct epoll_event_data *epoll_event_data = aws_mem_calloc(event_loop->alloc, 1, sizeof(struct epoll_event_data));
     _(unwrap handle)
     handle->additional_data = epoll_event_data;


### PR DESCRIPTION
Minor changes due to event-loop-new api

*Issue #, if available:* None

*Description of changes:* Re-synced the VCC proofs of the Linux epoll event loop wrt the minor changes to the event loop api for creating a new event loop.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
