### PR TITLE
socket write-completion callback always fires asynchronously 

### DIFF
--- a/source/posix/socket.c
+++ b/source/posix/socket.c
@@ -1265,6 +1265,7 @@ static void s_close_task(struct aws_task *task, void *arg, enum aws_task_status 
 int aws_socket_close(struct aws_socket *socket) {
     struct posix_socket *socket_impl = socket->impl;
     AWS_LOGF_DEBUG(AWS_LS_IO_SOCKET, "id=%p fd=%d: closing", (void *)socket, socket->io_handle.data.fd);
+    struct aws_event_loop *event_loop = socket->event_loop;
     if (socket->event_loop) {
         /* don't freak out on me, this almost never happens, and never occurs inside a channel
          * it only gets hit from a listening socket shutting down or from a unit test. */
@@ -1338,7 +1339,7 @@ int aws_socket_close(struct aws_socket *socket) {
         /* ensure callbacks for pending writes fire (in order) before this close function returns */
 
         if (socket_impl->written_task_scheduled) {
-            aws_event_loop_cancel_task(socket->event_loop, &socket_impl->written_task);
+            aws_event_loop_cancel_task(event_loop, &socket_impl->written_task);
         }
 
         while (!aws_linked_list_empty(&socket_impl->written_queue)) {

--- a/source/windows/iocp/socket.c
+++ b/source/windows/iocp/socket.c
@@ -2353,15 +2353,15 @@ static int s_wait_on_close(struct aws_socket *socket) {
         return aws_raise_error(AWS_IO_SOCKET_ILLEGAL_OPERATION_FOR_STATE);
     }
 
-    void *handle = socket->io_handle.data.handle; /* cached for logging */
-    (void)handle;
+    void *handle_for_logging = socket->io_handle.data.handle; /* socket's handle gets reset before final log */
+    (void)handle_for_logging;
 
     AWS_LOGF_INFO(
         AWS_LS_IO_SOCKET,
         "id=%p handle=%p: closing from a different thread than "
         "the socket is running from. Blocking until it closes down.",
         (void *)socket,
-        handle);
+        handle_for_logging);
 
     struct close_args args = {
         .mutex = AWS_MUTEX_INIT,
@@ -2379,7 +2379,7 @@ static int s_wait_on_close(struct aws_socket *socket) {
     aws_event_loop_schedule_task_now(socket->event_loop, &close_task);
     aws_condition_variable_wait_pred(&args.condition_var, &args.mutex, s_close_predicate, &args);
     aws_mutex_unlock(&args.mutex);
-    AWS_LOGF_INFO(AWS_LS_IO_SOCKET, "id=%p handle=%p: close task completed.", (void *)socket, handle);
+    AWS_LOGF_INFO(AWS_LS_IO_SOCKET, "id=%p handle=%p: close task completed.", (void *)socket, handle_for_logging);
 
     if (args.ret_code) {
         return aws_raise_error(args.ret_code);

--- a/source/windows/iocp/socket.c
+++ b/source/windows/iocp/socket.c
@@ -2353,12 +2353,15 @@ static int s_wait_on_close(struct aws_socket *socket) {
         return aws_raise_error(AWS_IO_SOCKET_ILLEGAL_OPERATION_FOR_STATE);
     }
 
+    void *handle = socket->io_handle.data.handle; /* cached for logging */
+    (void)handler;
+
     AWS_LOGF_INFO(
         AWS_LS_IO_SOCKET,
         "id=%p handle=%p: closing from a different thread than "
         "the socket is running from. Blocking until it closes down.",
         (void *)socket,
-        (void *)socket->io_handle.data.handle);
+        handle);
 
     struct close_args args = {
         .mutex = AWS_MUTEX_INIT,
@@ -2376,11 +2379,7 @@ static int s_wait_on_close(struct aws_socket *socket) {
     aws_event_loop_schedule_task_now(socket->event_loop, &close_task);
     aws_condition_variable_wait_pred(&args.condition_var, &args.mutex, s_close_predicate, &args);
     aws_mutex_unlock(&args.mutex);
-    AWS_LOGF_INFO(
-        AWS_LS_IO_SOCKET,
-        "id=%p handle=%p: close task completed.",
-        (void *)socket,
-        (void *)socket->io_handle.data.handle);
+    AWS_LOGF_INFO(AWS_LS_IO_SOCKET, "id=%p handle=%p: close task completed.", (void *)socket, handle);
 
     if (args.ret_code) {
         return aws_raise_error(args.ret_code);

--- a/source/windows/iocp/socket.c
+++ b/source/windows/iocp/socket.c
@@ -2354,7 +2354,7 @@ static int s_wait_on_close(struct aws_socket *socket) {
     }
 
     void *handle = socket->io_handle.data.handle; /* cached for logging */
-    (void)handler;
+    (void)handle;
 
     AWS_LOGF_INFO(
         AWS_LS_IO_SOCKET,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -67,6 +67,7 @@ add_test_case(wrong_thread_read_write_fails)
 add_net_test_case(cleanup_before_connect_or_timeout_doesnt_explode)
 add_test_case(cleanup_in_accept_doesnt_explode)
 add_test_case(cleanup_in_write_cb_doesnt_explode)
+add_test_case(sock_write_cb_is_async)
 
 if (WIN32)
     add_test_case(local_socket_pipe_connected_race)

--- a/tests/socket_test.c
+++ b/tests/socket_test.c
@@ -1336,6 +1336,7 @@ enum async_role {
 };
 
 static struct {
+    struct aws_allocator *allocator;
     struct aws_event_loop *event_loop;
     struct aws_socket *write_socket;
     struct aws_socket *read_socket;
@@ -1370,9 +1371,8 @@ static void s_async_read_task(struct aws_task *task, void *args, enum aws_task_s
             }
 
             /* other end must have hung up. clean up and signal completion */
-            struct aws_allocator *allocator = g_async_tester.read_socket->allocator;
             aws_socket_clean_up(g_async_tester.read_socket);
-            aws_mem_release(allocator, g_async_tester.read_socket);
+            aws_mem_release(g_async_tester.allocator, g_async_tester.read_socket);
 
             aws_mutex_lock(g_async_tester.mutex);
             g_async_tester.read_tasks_complete = true;
@@ -1385,7 +1385,7 @@ static void s_async_read_task(struct aws_task *task, void *args, enum aws_task_s
 
 static void s_async_write_completion(struct aws_socket *socket, int error_code, size_t bytes_written, void *user_data) {
     enum async_role role = *(enum async_role *)user_data;
-    aws_mem_release(socket->allocator, user_data);
+    aws_mem_release(g_async_tester.allocator, user_data);
 
     /* ensure callback is not firing synchronously from within aws_socket_write() */
     AWS_FATAL_ASSERT(!g_async_tester.currently_writing);
@@ -1400,7 +1400,7 @@ static void s_async_write_completion(struct aws_socket *socket, int error_code, 
             AWS_FATAL_ASSERT(1 == bytes_written);
             g_async_tester.currently_writing = true;
             struct aws_byte_cursor data = aws_byte_cursor_from_c_str("D");
-            enum async_role *d_role = aws_mem_acquire(socket->allocator, sizeof(enum async_role));
+            enum async_role *d_role = aws_mem_acquire(g_async_tester.allocator, sizeof(enum async_role));
             *d_role = ASYNC_ROLE_D_GOT_WRITTEN_VIA_CALLBACK;
             AWS_FATAL_ASSERT(0 == aws_socket_write(socket, &data, s_async_write_completion, d_role));
             g_async_tester.currently_writing = false;
@@ -1430,22 +1430,21 @@ static void s_async_write_task(struct aws_task *task, void *args, enum aws_task_
     (void)task;
     (void)args;
     (void)status;
-    struct aws_allocator *allocator = g_async_tester.read_socket->allocator;
 
     g_async_tester.currently_writing = true;
 
     struct aws_byte_cursor data = aws_byte_cursor_from_c_str("A");
-    enum async_role *role = aws_mem_acquire(allocator, sizeof(role));
+    enum async_role *role = aws_mem_acquire(g_async_tester.allocator, sizeof(role));
     *role = ASYNC_ROLE_A_CALLBACK_WRITES_D;
     AWS_FATAL_ASSERT(0 == aws_socket_write(g_async_tester.write_socket, &data, s_async_write_completion, role));
 
     data = aws_byte_cursor_from_c_str("B");
-    role = aws_mem_acquire(allocator, sizeof(role));
+    role = aws_mem_acquire(g_async_tester.allocator, sizeof(role));
     *role = ASYNC_ROLE_B_CALLBACK_CLEANS_UP_SOCKET;
     AWS_FATAL_ASSERT(0 == aws_socket_write(g_async_tester.write_socket, &data, s_async_write_completion, role));
 
     data = aws_byte_cursor_from_c_str("C");
-    role = aws_mem_acquire(allocator, sizeof(role));
+    role = aws_mem_acquire(g_async_tester.allocator, sizeof(role));
     *role = ASYNC_ROLE_C_IS_LAST_FROM_INITIAL_BATCH_OF_WRITES;
     AWS_FATAL_ASSERT(0 == aws_socket_write(g_async_tester.write_socket, &data, s_async_write_completion, role));
 
@@ -1525,6 +1524,7 @@ static int s_sock_write_cb_is_async(struct aws_allocator *allocator, void *ctx) 
     aws_socket_subscribe_to_readable_events(&outgoing, s_on_readable, NULL);
 
     /* set up g_async_tester */
+    g_async_tester.allocator = allocator;
     g_async_tester.event_loop = event_loop;
     g_async_tester.write_socket = &outgoing;
     g_async_tester.read_socket = server_sock;

--- a/tests/socket_test.c
+++ b/tests/socket_test.c
@@ -1434,17 +1434,17 @@ static void s_async_write_task(struct aws_task *task, void *args, enum aws_task_
     g_async_tester.currently_writing = true;
 
     struct aws_byte_cursor data = aws_byte_cursor_from_c_str("A");
-    enum async_role *role = aws_mem_acquire(g_async_tester.allocator, sizeof(role));
+    enum async_role *role = aws_mem_acquire(g_async_tester.allocator, sizeof(enum async_role));
     *role = ASYNC_ROLE_A_CALLBACK_WRITES_D;
     AWS_FATAL_ASSERT(0 == aws_socket_write(g_async_tester.write_socket, &data, s_async_write_completion, role));
 
     data = aws_byte_cursor_from_c_str("B");
-    role = aws_mem_acquire(g_async_tester.allocator, sizeof(role));
+    role = aws_mem_acquire(g_async_tester.allocator, sizeof(enum async_role));
     *role = ASYNC_ROLE_B_CALLBACK_CLEANS_UP_SOCKET;
     AWS_FATAL_ASSERT(0 == aws_socket_write(g_async_tester.write_socket, &data, s_async_write_completion, role));
 
     data = aws_byte_cursor_from_c_str("C");
-    role = aws_mem_acquire(g_async_tester.allocator, sizeof(role));
+    role = aws_mem_acquire(g_async_tester.allocator, sizeof(enum async_role));
     *role = ASYNC_ROLE_C_IS_LAST_FROM_INITIAL_BATCH_OF_WRITES;
     AWS_FATAL_ASSERT(0 == aws_socket_write(g_async_tester.write_socket, &data, s_async_write_completion, role));
 

--- a/tests/socket_test.c
+++ b/tests/socket_test.c
@@ -1326,6 +1326,238 @@ static int s_cleanup_in_write_cb_doesnt_explode(struct aws_allocator *allocator,
 }
 AWS_TEST_CASE(cleanup_in_write_cb_doesnt_explode, s_cleanup_in_write_cb_doesnt_explode)
 
+/* stuff for the sock_write_cb_is_async test */
+enum async_role {
+    ASYNC_ROLE_A_CALLBACK_WRITES_D,
+    ASYNC_ROLE_B_CALLBACK_CLEANS_UP_SOCKET,
+    ASYNC_ROLE_C_IS_LAST_FROM_INITIAL_BATCH_OF_WRITES,
+    ASYNC_ROLE_D_GOT_WRITTEN_VIA_CALLBACK,
+    ASYNC_ROLE_COUNT
+};
+
+static struct {
+    struct aws_event_loop *event_loop;
+    struct aws_socket *write_socket;
+    struct aws_socket *read_socket;
+    bool currently_writing;
+    enum async_role next_expected_callback;
+
+    struct aws_mutex *mutex;
+    struct aws_condition_variable *condition_variable;
+    bool write_tasks_complete;
+    bool read_tasks_complete;
+} g_async_tester;
+
+static bool s_async_tasks_complete_pred(void *arg) {
+    return g_async_tester.write_tasks_complete && g_async_tester.read_tasks_complete;
+}
+
+/* read until socket gets hung up on */
+static void s_async_read_task(struct aws_task *task, void *args, enum aws_task_status status) {
+    (void)args;
+    (void)status;
+    uint8_t buf_storage[100];
+    struct aws_byte_buf buf = aws_byte_buf_from_array(buf_storage, sizeof(buf_storage));
+    while (true) {
+        size_t amount_read = 0;
+        buf.len = 0;
+        if (aws_socket_read(g_async_tester.read_socket, &buf, &amount_read)) {
+            /* reschedule task to try reading more later */
+            if (AWS_IO_READ_WOULD_BLOCK == aws_last_error()) {
+                aws_event_loop_schedule_task_now(g_async_tester.event_loop, task);
+                break;
+            }
+
+            /* other end must have hung up. clean up and signal completion */
+            struct aws_allocator *allocator = g_async_tester.read_socket->allocator;
+            aws_socket_clean_up(g_async_tester.read_socket);
+            aws_mem_release(allocator, g_async_tester.read_socket);
+
+            aws_mutex_lock(g_async_tester.mutex);
+            g_async_tester.read_tasks_complete = true;
+            aws_mutex_unlock(g_async_tester.mutex);
+            aws_condition_variable_notify_all(g_async_tester.condition_variable);
+            break;
+        }
+    }
+}
+
+static void s_async_write_completion(struct aws_socket *socket, int error_code, size_t bytes_written, void *user_data) {
+    enum async_role role = (enum async_role)user_data;
+
+    /* ensure callback is not firing synchronously from within aws_socket_write() */
+    AWS_FATAL_ASSERT(!g_async_tester.currently_writing);
+
+    /* ensure callbacks arrive in order */
+    AWS_FATAL_ASSERT(g_async_tester.next_expected_callback == role);
+    g_async_tester.next_expected_callback++;
+
+    switch (role) {
+        case ASYNC_ROLE_A_CALLBACK_WRITES_D: {
+            AWS_FATAL_ASSERT(0 == error_code);
+            AWS_FATAL_ASSERT(1 == bytes_written);
+            g_async_tester.currently_writing = true;
+            struct aws_byte_cursor data = aws_byte_cursor_from_c_str("D");
+            AWS_FATAL_ASSERT(
+                0 == aws_socket_write(
+                         g_async_tester.write_socket,
+                         &data,
+                         s_async_write_completion,
+                         (void *)ASYNC_ROLE_D_GOT_WRITTEN_VIA_CALLBACK));
+            g_async_tester.currently_writing = false;
+            break;
+        }
+        case ASYNC_ROLE_B_CALLBACK_CLEANS_UP_SOCKET:
+            AWS_FATAL_ASSERT(0 == error_code);
+            AWS_FATAL_ASSERT(1 == bytes_written);
+            aws_socket_clean_up(g_async_tester.write_socket);
+            break;
+        case ASYNC_ROLE_C_IS_LAST_FROM_INITIAL_BATCH_OF_WRITES:
+            /* C might succeed or fail (since socket killed after B completes), either is valid */
+            break;
+        case ASYNC_ROLE_D_GOT_WRITTEN_VIA_CALLBACK:
+            /* write tasks complete! */
+            aws_mutex_lock(g_async_tester.mutex);
+            g_async_tester.write_tasks_complete = true;
+            aws_mutex_unlock(g_async_tester.mutex);
+            aws_condition_variable_notify_all(g_async_tester.condition_variable);
+            break;
+        default:
+            AWS_FATAL_ASSERT(0);
+    }
+}
+
+static void s_async_write_task(struct aws_task *task, void *args, enum aws_task_status status) {
+    (void)task;
+    (void)args;
+    (void)status;
+
+    g_async_tester.currently_writing = true;
+
+    struct aws_byte_cursor data = aws_byte_cursor_from_c_str("A");
+    AWS_FATAL_ASSERT(
+        0 == aws_socket_write(
+                 g_async_tester.write_socket, &data, s_async_write_completion, (void *)ASYNC_ROLE_A_CALLBACK_WRITES_D));
+
+    data = aws_byte_cursor_from_c_str("B");
+    AWS_FATAL_ASSERT(
+        0 == aws_socket_write(
+                 g_async_tester.write_socket,
+                 &data,
+                 s_async_write_completion,
+                 (void *)ASYNC_ROLE_B_CALLBACK_CLEANS_UP_SOCKET));
+
+    data = aws_byte_cursor_from_c_str("C");
+    AWS_FATAL_ASSERT(
+        0 == aws_socket_write(
+                 g_async_tester.write_socket,
+                 &data,
+                 s_async_write_completion,
+                 (void *)ASYNC_ROLE_C_IS_LAST_FROM_INITIAL_BATCH_OF_WRITES));
+
+    g_async_tester.currently_writing = false;
+}
+
+/**
+ * aws_socket_write()'s completion callback MUST fire asynchronously.
+ * Otherwise, we can get multiple write() calls in the same callstack, which
+ * leads to esoteric bugs (https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/194).
+ */
+static int s_sock_write_cb_is_async(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    /* set up server (read) and client (write) sockets */
+    struct aws_event_loop *event_loop = aws_event_loop_new_default(allocator, aws_high_res_clock_get_ticks);
+
+    ASSERT_NOT_NULL(event_loop, "Event loop creation failed with error: %s", aws_error_debug_str(aws_last_error()));
+    ASSERT_SUCCESS(aws_event_loop_run(event_loop));
+
+    struct aws_mutex mutex = AWS_MUTEX_INIT;
+    struct aws_condition_variable condition_variable = AWS_CONDITION_VARIABLE_INIT;
+
+    struct local_listener_args listener_args = {
+        .mutex = &mutex,
+        .condition_variable = &condition_variable,
+        .incoming = NULL,
+        .incoming_invoked = false,
+        .error_invoked = false,
+    };
+
+    struct aws_socket_options options;
+    AWS_ZERO_STRUCT(options);
+    options.connect_timeout_ms = 3000;
+    options.keepalive = true;
+    options.keep_alive_interval_sec = 1000;
+    options.keep_alive_timeout_sec = 60000;
+    options.type = AWS_SOCKET_STREAM;
+    options.domain = AWS_SOCKET_LOCAL;
+
+    uint64_t timestamp = 0;
+    ASSERT_SUCCESS(aws_sys_clock_get_ticks(&timestamp));
+    struct aws_socket_endpoint endpoint;
+    AWS_ZERO_STRUCT(endpoint);
+    snprintf(endpoint.address, sizeof(endpoint.address), LOCAL_SOCK_TEST_PATTERN, (long long unsigned)timestamp);
+
+    struct aws_socket listener;
+    ASSERT_SUCCESS(aws_socket_init(&listener, allocator, &options));
+
+    ASSERT_SUCCESS(aws_socket_bind(&listener, &endpoint));
+    ASSERT_SUCCESS(aws_socket_listen(&listener, 1024));
+    ASSERT_SUCCESS(aws_socket_start_accept(&listener, event_loop, s_local_listener_incoming, &listener_args));
+
+    struct local_outgoing_args outgoing_args = {
+        .mutex = &mutex, .condition_variable = &condition_variable, .connect_invoked = false, .error_invoked = false};
+
+    struct aws_socket outgoing;
+    ASSERT_SUCCESS(aws_socket_init(&outgoing, allocator, &options));
+    ASSERT_SUCCESS(aws_socket_connect(&outgoing, &endpoint, event_loop, s_local_outgoing_connection, &outgoing_args));
+
+    ASSERT_SUCCESS(aws_mutex_lock(&mutex));
+    ASSERT_SUCCESS(aws_condition_variable_wait_pred(&condition_variable, &mutex, s_incoming_predicate, &listener_args));
+    ASSERT_SUCCESS(aws_condition_variable_wait_pred(
+        &condition_variable, &mutex, s_connection_completed_predicate, &outgoing_args));
+    ASSERT_SUCCESS(aws_mutex_unlock(&mutex));
+
+    ASSERT_TRUE(listener_args.incoming_invoked);
+    ASSERT_FALSE(listener_args.error_invoked);
+    struct aws_socket *server_sock = listener_args.incoming;
+    ASSERT_TRUE(outgoing_args.connect_invoked);
+    ASSERT_FALSE(outgoing_args.error_invoked);
+    ASSERT_INT_EQUALS(options.domain, listener_args.incoming->options.domain);
+    ASSERT_INT_EQUALS(options.type, listener_args.incoming->options.type);
+
+    ASSERT_SUCCESS(aws_socket_assign_to_event_loop(server_sock, event_loop));
+    aws_socket_subscribe_to_readable_events(server_sock, s_on_readable, NULL);
+    aws_socket_subscribe_to_readable_events(&outgoing, s_on_readable, NULL);
+
+    /* set up g_async_tester */
+    g_async_tester.event_loop = event_loop;
+    g_async_tester.write_socket = &outgoing;
+    g_async_tester.read_socket = server_sock;
+    g_async_tester.mutex = &mutex;
+    g_async_tester.condition_variable = &condition_variable;
+
+    /* kick off writer and reader tasks */
+    struct aws_task writer_task;
+    aws_task_init(&writer_task, s_async_write_task, NULL, "async_test_write_task");
+    aws_event_loop_schedule_task_now(event_loop, &writer_task);
+
+    struct aws_task reader_task;
+    aws_task_init(&reader_task, s_async_read_task, NULL, "async_test_read_task");
+    aws_event_loop_schedule_task_now(event_loop, &reader_task);
+
+    /* wait for tasks to complete */
+    aws_mutex_lock(&mutex);
+    aws_condition_variable_wait_pred(&condition_variable, &mutex, s_async_tasks_complete_pred, NULL);
+    aws_mutex_unlock(&mutex);
+
+    /* cleanup */
+    aws_socket_clean_up(&listener);
+    aws_event_loop_destroy(event_loop);
+    return 0;
+}
+AWS_TEST_CASE(sock_write_cb_is_async, s_sock_write_cb_is_async)
+
 #ifdef _WIN32
 static int s_local_socket_pipe_connected_race(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;


### PR DESCRIPTION
Previously, the callback could fire syncronously within a write() call. This was leading to bugs if multiple writes occurred in the same callstack (ex: https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/194).

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
