### PR TITLE
Fix vcc proofs for thread join

### DIFF
--- a/.github/workflows/proof-alarm.yml
+++ b/.github/workflows/proof-alarm.yml
@@ -15,7 +15,7 @@ jobs:
 
     - name: Check
       run: |
-        git diff --quiet 735ba3d6c source/linux/epoll_event_loop.c
+        git diff --quiet 754ba168f source/linux/epoll_event_loop.c
 
     # No further steps if successful
 

--- a/docs/epoll_event_loop_proof.md
+++ b/docs/epoll_event_loop_proof.md
@@ -45,7 +45,7 @@ assumptions due to limitations in VCC. More precisely, the proofs assume:
         aws_task_init
         aws_task_scheduler_schedule_{now, future}
         aws_task_scheduler_{init, run_all, clean_up, cancel_tasks, has_tasks}
-        aws_thread_{init, current_thread_id, launch, join, clean_up, thread_id_equal}
+        aws_thread_{clean_up, current_thread_id, decrement_unjoined_count, increment_unjoined_count, init, join, launch, thread_id_equal}
 
     and similarly for the AWS C-IO functions:
 

--- a/tests/vcc/Makefile
+++ b/tests/vcc/Makefile
@@ -1,7 +1,7 @@
 VCC?=vcc
 VCC_ARGS+=/sm
 GIT?=git
-NO_CHANGE_EXPECTED_HASH=735ba3d6c
+NO_CHANGE_EXPECTED_HASH=754ba168f
 NO_CHANGE_FILE=source/linux/epoll_event_loop.c
 
 # The VCC proofs in this directory are based on a snapshot of

--- a/tests/vcc/lifecycle.c
+++ b/tests/vcc/lifecycle.c
@@ -78,7 +78,9 @@ static int s_wait_for_stop_completion(struct aws_event_loop *event_loop
     _(ghost \claim(c_event_loop)) _(ghost \claim(c_mutex))
 ) {
     struct epoll_loop *epoll_loop = _(by_claim c_event_loop) event_loop->impl_data;
-    return aws_thread_join(&epoll_loop->thread_created_on _(ghost event_loop) _(ghost c_event_loop) _(ghost c_mutex));
+    int result = aws_thread_join(&epoll_loop->thread_created_on _(ghost event_loop) _(ghost c_event_loop) _(ghost c_mutex));
+    aws_thread_decrement_unjoined_count();
+    return result;
 }
 
 int aws_thread_launch(
@@ -99,7 +101,9 @@ static int s_run(struct aws_event_loop *event_loop _(ghost \claim(c_mutex))) {
     AWS_LOGF_INFO(AWS_LS_IO_EVENT_LOOP, "id=%p: Starting event-loop thread.", (void *)event_loop);
 
     epoll_loop->should_continue = true;
+    aws_thread_increment_unjoined_count();
     if (aws_thread_launch(&epoll_loop->thread_created_on, /*&s_main_loop*/&dummy_main_loop, event_loop, &epoll_loop->thread_options)) {
+        aws_thread_decrement_unjoined_count();
         AWS_LOGF_FATAL(AWS_LS_IO_EVENT_LOOP, "id=%p: thread creation failed.", (void *)event_loop);
         epoll_loop->should_continue = false;
         return AWS_OP_ERR;

--- a/tests/vcc/preamble.h
+++ b/tests/vcc/preamble.h
@@ -404,6 +404,10 @@ _(pure) bool aws_thread_thread_id_equal(aws_thread_id_t t1, aws_thread_id_t t2)
   _(ensures \result == (t1 == t2))
 ;
 
+/* Pure from point-of-view of the event loop since the following functions lock and mutate private aws-c-common state */
+_(pure) void aws_thread_increment_unjoined_count();
+_(pure) void aws_thread_decrement_unjoined_count();
+
 /* Definitions from aws/io/io.h */
 enum aws_io_event_type {
     AWS_IO_EVENT_TYPE_READABLE = 1,


### PR DESCRIPTION
Minor changes to VCC proofs for thread join incr/decr and update proof alarm

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
