### PR TITLE
Don't hardcode the path to the macOS SDK

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -130,7 +130,7 @@ elseif (APPLE)
     endif ()
 
     #No choice on TLS for apple, darwinssl will always be used.
-    set(PLATFORM_LIBS ${SECURITY_LIB})
+    list(APPEND PLATFORM_LIBS "-framework Security")
     set(EVENT_LOOP_DEFINE "KQUEUE")
 
 elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "NetBSD")


### PR DESCRIPTION
Use the -framework flag instead of the full path to link to the
Security framework on macOS.

Same reasoning as https://github.com/awslabs/aws-c-cal/pull/60

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
