### PR TITLE
Honor the s2n connection shutdown delay when set

### DIFF
--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -5,7 +5,6 @@
 #include <aws/io/tls_channel_handler.h>
 
 #include <aws/common/clock.h>
-#include <aws/common/task_scheduler.h>
 
 #include <aws/io/channel.h>
 #include <aws/io/event_loop.h>

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -550,17 +550,7 @@ static int s_s2n_do_delayed_shutdown(
     uint64_t shutdown_delay = s2n_connection_get_delay(s2n_handler->connection);
     uint64_t now = 0;
 
-    struct aws_event_loop *loop = aws_channel_get_event_loop(slot->channel);
-    if (loop == NULL) {
-        return AWS_OP_ERR;
-    }
-
-    aws_io_clock_fn *clock_fn = loop->clock;
-    if (clock_fn == NULL) {
-        clock_fn = aws_high_res_clock_get_ticks;
-    }
-
-    if (clock_fn(&now)) {
+    if (aws_channel_current_clock_time(slot->channel, &now)) {
         return AWS_OP_ERR;
     }
 


### PR DESCRIPTION
TLS negotiation failure unit tests will see 10-30 seconds tacked on to their runtime.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
