### PR TITLE
Changing fopen flags in aws_input_stream_new_from_file to r+b

### DIFF
--- a/source/stream.c
+++ b/source/stream.c
@@ -326,7 +326,7 @@ struct aws_input_stream *aws_input_stream_new_from_file(struct aws_allocator *al
     input_stream->vtable = &s_aws_input_stream_file_vtable;
     input_stream->impl = impl;
 
-    impl->file = fopen(file_name, "r");
+    impl->file = fopen(file_name, "r+b");
     if (impl->file == NULL) {
         aws_translate_and_raise_io_error(errno);
         goto on_error;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -180,6 +180,7 @@ add_test_case(test_input_stream_file_seek_beginning)
 add_test_case(test_input_stream_file_seek_end)
 add_test_case(test_input_stream_memory_length)
 add_test_case(test_input_stream_file_length)
+add_test_case(test_input_stream_binary)
 
 add_test_case(open_channel_statistics_test)
 

--- a/tests/stream_test.c
+++ b/tests/stream_test.c
@@ -16,7 +16,7 @@ AWS_STATIC_STRING_FROM_LITERAL(s_simple_test, "SimpleTest");
 
 /* 0x1A represents the Windows end-of-file character. Having this in the test data set allows us to verify that file
  * stream reads on binary files do not terminate early on Windows.*/
-const uint8_t s_simple_binary_test[] = "abcdef\x1Aghijk";
+const uint8_t s_simple_binary_test[] = {'a', 'b', 'c', 'd', 'e', 'f', 0x1A, 'g', 'h', 'i', 'j', 'k'};
 
 const char *s_test_file_name = "stream.dat";
 

--- a/tests/stream_test.c
+++ b/tests/stream_test.c
@@ -18,7 +18,7 @@ AWS_STATIC_STRING_FROM_LITERAL(s_simple_test, "SimpleTest");
  * stream reads on binary files do not terminate early on Windows.*/
 const uint8_t s_simple_binary_test[] = "abcdef\x1Aghijk";
 
-const char *s_test_file_name = "stream.txt";
+const char *s_test_file_name = "stream.dat";
 
 static struct aws_input_stream *s_create_memory_stream(struct aws_allocator *allocator) {
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_string(s_simple_test);
@@ -348,7 +348,7 @@ static int s_test_input_stream_binary(struct aws_allocator *allocator, void *ctx
 
     ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AWS_OP_SUCCESS);
 
-    s_destroy_memory_stream(stream);
+    s_destroy_file_stream(stream);
 
     return AWS_OP_SUCCESS;
 }

--- a/tests/stream_test.c
+++ b/tests/stream_test.c
@@ -13,6 +13,9 @@
 #endif
 
 AWS_STATIC_STRING_FROM_LITERAL(s_simple_test, "SimpleTest");
+
+/* 0x1A represents the Windows end-of-file character. Having this in the test data set allows us to verify that file
+ * stream reads on binary files do not terminate early on Windows.*/
 const uint8_t s_simple_binary_test[] = "abcdef\x1Ahijk";
 
 const char *s_test_file_name = "stream.txt";

--- a/tests/stream_test.c
+++ b/tests/stream_test.c
@@ -16,7 +16,7 @@ AWS_STATIC_STRING_FROM_LITERAL(s_simple_test, "SimpleTest");
 
 /* 0x1A represents the Windows end-of-file character. Having this in the test data set allows us to verify that file
  * stream reads on binary files do not terminate early on Windows.*/
-const uint8_t s_simple_binary_test[] = "abcdef\x1Ahijk";
+const uint8_t s_simple_binary_test[] = "abcdef\x1Aghijk";
 
 const char *s_test_file_name = "stream.txt";
 

--- a/tests/stream_test.c
+++ b/tests/stream_test.c
@@ -42,7 +42,7 @@ static struct aws_input_stream *s_create_file_stream(struct aws_allocator *alloc
 static struct aws_input_stream *s_create_binary_file_stream(struct aws_allocator *allocator) {
     remove(s_test_file_name);
 
-    FILE *file = fopen(s_test_file_name, "w+");
+    FILE *file = fopen(s_test_file_name, "w+b");
     fwrite(s_simple_binary_test, sizeof(uint8_t), sizeof(s_simple_binary_test), file);
     fclose(file);
 

--- a/tests/stream_test.c
+++ b/tests/stream_test.c
@@ -38,6 +38,7 @@ static struct aws_input_stream *s_create_file_stream(struct aws_allocator *alloc
 
     return aws_input_stream_new_from_file(allocator, s_test_file_name);
 }
+
 static struct aws_input_stream *s_create_binary_file_stream(struct aws_allocator *allocator) {
     remove(s_test_file_name);
 


### PR DESCRIPTION
*Description of changes:*
If a binary stream contains a 0x1A character, currently it will terminate early on Windows due to the missing binary flag.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
