### PR TITLE
Mac Tls Api Consistency Update

### DIFF
--- a/include/aws/io/tls_channel_handler.h
+++ b/include/aws/io/tls_channel_handler.h
@@ -284,7 +284,7 @@ AWS_IO_API int aws_tls_ctx_options_init_client_mtls(
  */
 AWS_IO_API int aws_tls_ctx_options_set_keychain_path(
     struct aws_tls_ctx_options *options,
-    struct aws_byte_cursor keychain_path_cursor);
+    struct aws_byte_cursor *keychain_path_cursor);
 #    endif
 
 /**

--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -155,8 +155,8 @@ int aws_tls_ctx_options_init_client_mtls_from_path(
 #    if defined(__APPLE__)
 int aws_tls_ctx_options_set_keychain_path(
     struct aws_tls_ctx_options *options,
-    struct aws_byte_cursor keychain_path_cursor) {
-    options->keychain_path = aws_string_new_from_cursor(options->allocator, &keychain_path_cursor);
+    struct aws_byte_cursor *keychain_path_cursor) {
+    options->keychain_path = aws_string_new_from_cursor(options->allocator, keychain_path_cursor);
     if (!options->keychain_path) {
         return AWS_OP_ERR;
     }


### PR DESCRIPTION
Mac keychain path by-value to by-pointer since that's the way the rest of the tls API operates

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
