### PR TITLE
Fix for shutdown crash when peer hangs up immediately following first non-TLS write

### DIFF
--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -657,6 +657,7 @@ static int s_process_read_message(
         if (slot->adj_right) {
             if (aws_channel_slot_send_message(slot, outgoing_read_message, AWS_CHANNEL_DIR_READ)) {
                 aws_mem_release(outgoing_read_message->allocator, outgoing_read_message);
+                aws_channel_shutdown(secure_transport_handler->parent_slot->channel, aws_last_error());
                 /* incoming message was pushed to the input_queue, so this handler owns it now */
                 return AWS_OP_SUCCESS;
             }

--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -612,7 +612,8 @@ static int s_process_read_message(
         struct aws_io_message *outgoing_read_message = aws_channel_acquire_message_from_pool(
             slot->channel, AWS_IO_MESSAGE_APPLICATION_DATA, downstream_window - processed);
         if (!outgoing_read_message) {
-            return AWS_OP_ERR;
+            /* even though this is a failure, this handler has taken ownership of the message */
+            return AWS_OP_SUCCESS;
         }
 
         size_t read = 0;

--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -613,6 +613,7 @@ static int s_process_read_message(
             slot->channel, AWS_IO_MESSAGE_APPLICATION_DATA, downstream_window - processed);
         if (!outgoing_read_message) {
             /* even though this is a failure, this handler has taken ownership of the message */
+            aws_channel_shutdown(secure_transport_handler->parent_slot->channel, aws_last_error());
             return AWS_OP_SUCCESS;
         }
 

--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -657,6 +657,7 @@ static int s_process_read_message(
         if (slot->adj_right) {
             if (aws_channel_slot_send_message(slot, outgoing_read_message, AWS_CHANNEL_DIR_READ)) {
                 aws_mem_release(outgoing_read_message->allocator, outgoing_read_message);
+                /* incoming message was pushed to the input_queue, so this handler owns it now */
                 return AWS_OP_SUCCESS;
             }
         } else {

--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -568,9 +568,7 @@ static int s_handle_shutdown(
         while (!aws_linked_list_empty(&secure_transport_handler->input_queue)) {
             struct aws_linked_list_node *node = aws_linked_list_pop_front(&secure_transport_handler->input_queue);
             struct aws_io_message *message = AWS_CONTAINER_OF(node, struct aws_io_message, queueing_handle);
-            if (message->allocator) {
-                aws_mem_release(message->allocator, message);
-            }
+            aws_mem_release(message->allocator, message);
         }
     }
 
@@ -658,7 +656,7 @@ static int s_process_read_message(
         if (slot->adj_right) {
             if (aws_channel_slot_send_message(slot, outgoing_read_message, AWS_CHANNEL_DIR_READ)) {
                 aws_mem_release(outgoing_read_message->allocator, outgoing_read_message);
-                return AWS_OP_ERR;
+                return AWS_OP_SUCCESS;
             }
         } else {
             aws_mem_release(outgoing_read_message->allocator, outgoing_read_message);

--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -568,7 +568,9 @@ static int s_handle_shutdown(
         while (!aws_linked_list_empty(&secure_transport_handler->input_queue)) {
             struct aws_linked_list_node *node = aws_linked_list_pop_front(&secure_transport_handler->input_queue);
             struct aws_io_message *message = AWS_CONTAINER_OF(node, struct aws_io_message, queueing_handle);
-            aws_mem_release(message->allocator, message);
+            if (message->allocator) {
+                aws_mem_release(message->allocator, message);
+            }
         }
     }
 


### PR DESCRIPTION
Found while assisting on  https://github.com/awslabs/aws-crt-swift/pull/17

TLS negotation completes after connecting to https://example.com:443 via MQTT. When the MQTT CONNECT packet is sent, the server immediately hangs up, causing an eventual empty message in the input queue with a NULL allocator.

This was a double-release due to aliasing the incoming message pointer without notifying the upstream handler (socket, in this case) that the SecureTransport handler had taken ownership in all code paths.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
