### PR TITLE
path uri encoding was incorrectly leaving out some characters

### DIFF
--- a/source/uri.c
+++ b/source/uri.c
@@ -437,23 +437,21 @@ static void s_unchecked_append_canonicalized_path_character(struct aws_byte_buf 
     }
 
     switch (value) {
+        /* non-alpha-numeric unreserved, don't % encode them */
         case '-':
         case '_':
         case '.':
         case '~':
-        case '$':
-        case '&':
-        case ',':
+
+        /* reserved characters that we should not % encode in the path component */
         case '/':
-        case ':':
-        case ';':
-        case '=':
-        case '@': {
             ++buffer->len;
             *dest_ptr = value;
             return;
-        }
 
+        /*
+         * everything else we should % encode, including from the reserved list
+         */
         default:
             buffer->len += 3;
             *dest_ptr++ = '%';

--- a/tests/uri_test.c
+++ b/tests/uri_test.c
@@ -530,7 +530,9 @@ static int s_test_uri_encode_path_rfc3986(struct aws_allocator *allocator, void 
     ASSERT_SUCCESS(s_test_uri_encode_path_case(
         allocator, "/ABCDEFGHIJKLMNOPQRSTUVWXYZ/1234567890/", "/ABCDEFGHIJKLMNOPQRSTUVWXYZ/1234567890/"));
     ASSERT_SUCCESS(s_test_uri_encode_path_case(
-        allocator, "/ABCDEFGHIJKLMNOPQRSTUVWXYZ/_~./$@-&,:;/=/", "/ABCDEFGHIJKLMNOPQRSTUVWXYZ/_~./$@-&,:;/=/"));
+        allocator,
+        "/ABCDEFGHIJKLMNOPQRSTUVWXYZ/_-~./$@&,:;=/",
+        "/ABCDEFGHIJKLMNOPQRSTUVWXYZ/_-~./%24%40%26%2C%3A%3B%3D/"));
     ASSERT_SUCCESS(s_test_uri_encode_path_case(allocator, "/path/%^#! /", "/path/%25%5E%23%21%20/"));
     ASSERT_SUCCESS(s_test_uri_encode_path_case(allocator, "/path/ሴ", "/path/%E1%88%B4"));
     ASSERT_SUCCESS(s_test_uri_encode_path_case(


### PR DESCRIPTION
* Update path uri encoding to encode every reserved character except '/'

TODO: refactor to something like Python where skipped characters are a parameterization


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
