### PR TITLE
Pem fix alternate

### DIFF
--- a/source/pem_utils.c
+++ b/source/pem_utils.c
@@ -80,7 +80,15 @@ int aws_sanitize_pem(struct aws_byte_buf *pem, struct aws_allocator *allocator) 
     }
     struct aws_byte_cursor clean_pem_cursor = aws_byte_cursor_from_buf(&clean_pem_buf);
     aws_byte_buf_reset(pem, true);
-    aws_byte_buf_append(pem, &clean_pem_cursor);
+    int result = aws_byte_buf_append_dynamic(pem, &clean_pem_cursor);
     aws_byte_buf_clean_up(&clean_pem_buf);
-    return AWS_OP_SUCCESS;
+
+    if (result == AWS_OP_SUCCESS) {
+        result = aws_byte_buf_reserve(pem, pem->len + 1);
+        if (result == AWS_OP_SUCCESS) {
+            pem->buffer[pem->len] = 0;
+        }
+    }
+
+    return result;
 }

--- a/source/pem_utils.c
+++ b/source/pem_utils.c
@@ -93,7 +93,7 @@ int aws_sanitize_pem(struct aws_byte_buf *pem, struct aws_allocator *allocator) 
         pem->buffer[pem->len] = 0;
     }
 
-    aws_byte_buf_clean_up(&clean_pem_buf);
+    aws_byte_buf_clean_up_secure(&clean_pem_buf);
 
     return result;
 }

--- a/tests/pem_utils_test.c
+++ b/tests/pem_utils_test.c
@@ -15,6 +15,10 @@ static int s_check_clean_pem_result(
     ASSERT_SUCCESS(aws_byte_buf_init_copy_from_cursor(&pem_buf, allocator, dirty_pem));
     ASSERT_SUCCESS(aws_sanitize_pem(&pem_buf, allocator));
     ASSERT_TRUE(aws_byte_cursor_eq_byte_buf(&expected_clean_pem, &pem_buf));
+
+    /* Verify the buffer is still zero-terminated correctly */
+    ASSERT_INT_EQUALS(pem_buf.len, strlen((const char *)pem_buf.buffer));
+
     aws_byte_buf_clean_up(&pem_buf);
     return AWS_OP_SUCCESS;
 }


### PR DESCRIPTION
* Pem sanitization was removing the zero-padding at the end of the certificate/privatekey/ca_file buffers, leading to unpredictable tls context init failures on linux

This is not the ideal fix, but moving to strings was problematic and this needs to be resolved very quickly.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
