### PR TITLE
Fix thread handle leak on Windows

### DIFF
--- a/source/host_resolver.c
+++ b/source/host_resolver.c
@@ -1364,6 +1364,8 @@ static inline int create_and_init_host_entry(
     aws_thread_launch(&resolver_thread, resolver_thread_fn, new_host_entry, &thread_options);
     ++default_host_resolver->pending_host_entry_shutdown_completion_callbacks;
 
+    aws_thread_clean_up(&resolver_thread);
+
     return AWS_OP_SUCCESS;
 
 setup_host_entry_error:


### PR DESCRIPTION
* Tentative fix for issue #398

* Removed unused 'resolver_thread' in 'struct host_entry'
   * `host_entry->resolver_thread` was used only in function `create_and_init_host_entry()`, converted it to a local variable.
* Clean up 'resolver_thread' to avoid leaking a thread handle on Windows
   * The thread handle inside `struct aws_thread` was never closed, calling `aws_thread_clean_up()` fixes this.
   * There is a copy of the thread struct in `thread_wrapper` with a unique thread handle which is used to synchronize thread exit and it gets properly closed.
   * I noticed that the semantics of `aws_thread_clean_up()` on Linux are a bit different: it calls `pthread_detach()`. Not sure if this matters.

----
By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
