### PR TITLE
Part 2 of aws_thread_clean_up fix and contract clarification

### DIFF
--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -72,8 +72,6 @@ static void s_aws_event_loop_group_shutdown_async(struct aws_event_loop_group *e
     AWS_FATAL_ASSERT(
         aws_thread_launch(&cleanup_thread, s_event_loop_destroy_async_thread_fn, el_group, &thread_options) ==
         AWS_OP_SUCCESS);
-
-    aws_thread_clean_up(&cleanup_thread);
 }
 
 static struct aws_event_loop_group *s_event_loop_group_new(


### PR DESCRIPTION
* Let the managed thread system call aws_thread_clean_up on the async event loop group cleanup thread.

This PR requires https://github.com/awslabs/aws-c-common/pull/814

The two PRs together are intended to resolve https://github.com/awslabs/aws-c-io/issues/398

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
