### PR TITLE
Fix aws_sanitize_pem() bug

### DIFF
--- a/source/pem_utils.c
+++ b/source/pem_utils.c
@@ -88,7 +88,7 @@ int aws_sanitize_pem(struct aws_byte_buf *pem, struct aws_allocator *allocator) 
 
     struct aws_byte_cursor clean_pem_cursor = aws_byte_cursor_from_buf(&clean_pem_buf);
     aws_byte_buf_reset(pem, true);
-    aws_byte_buf_append(pem, &clean_pem_cursor);
+    aws_byte_buf_append_dynamic(pem, &clean_pem_cursor);
     aws_byte_buf_clean_up(&clean_pem_buf);
     return AWS_OP_SUCCESS;
 


### PR DESCRIPTION
We were using the wrong append function, it was failing when PEM file was missing trailing newline.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
