### PR TITLE
Allow user to change Windows Named Pipe open flags via aws_socket_options

### DIFF
--- a/include/aws/io/socket.h
+++ b/include/aws/io/socket.h
@@ -41,6 +41,7 @@ struct aws_socket_options {
      * lost. If zero OS defaults are used. On Windows, this option is meaningless until Windows 10 1703.*/
     uint16_t keep_alive_max_failed_probes;
     bool keepalive;
+    uint32_t windows_named_pipe_open_flags;
 };
 
 struct aws_socket;

--- a/source/windows/iocp/socket.c
+++ b/source/windows/iocp/socket.c
@@ -1519,7 +1519,7 @@ static int s_local_bind(struct aws_socket *socket, const struct aws_socket_endpo
     socket->local_endpoint = *local_endpoint;
     socket->io_handle.data.handle = CreateNamedPipeA(
         local_endpoint->address,
-        PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
+        PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED | socket->options.windows_named_pipe_open_flags,
         PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT | PIPE_ACCEPT_REMOTE_CLIENTS,
         PIPE_UNLIMITED_INSTANCES,
         PIPE_BUFFER_SIZE,
@@ -1678,7 +1678,7 @@ static void s_incoming_pipe_connection_event(
 
         socket->io_handle.data.handle = CreateNamedPipeA(
             socket->local_endpoint.address,
-            PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED,
+            PIPE_ACCESS_DUPLEX | FILE_FLAG_OVERLAPPED | socket->options.windows_named_pipe_open_flags,
             PIPE_TYPE_BYTE | PIPE_READMODE_BYTE | PIPE_WAIT | PIPE_ACCEPT_REMOTE_CLIENTS,
             PIPE_UNLIMITED_INSTANCES,
             PIPE_BUFFER_SIZE,


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
Adds new bitfield option in aws_socket_options to be used by Windows named pipes in order to allow overriding the open flags. This will allow the Greengrass team to override the flags in order to include WRITE_DAC so that we can modify the ACLs after the pipe has been created.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
