### PR TITLE
Tls double channel

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -4,7 +4,8 @@
         { "name": "aws-c-common" },
         {
             "name": "s2n",
-            "targets": ["linux", "android"]
+            "targets": ["linux", "android"],
+            "revision": "v1.0.19", "_comment": "tls_double_channel test broken by 1.1.*"
         },
         { "name": "aws-c-cal" }
     ],

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -1085,6 +1085,11 @@ static inline int s_setup_server_tls(struct server_channel_data *channel_data, s
         }
     }
 
+    struct aws_socket *socket = channel_data->socket;
+    if (socket && socket->readable_fn) {
+        socket->readable_fn(socket, AWS_OP_SUCCESS, socket->readable_user_data);
+    }
+
     return AWS_OP_SUCCESS;
 }
 

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -961,23 +961,25 @@ static struct aws_tls_ctx *s_tls_ctx_new(
 
     switch (options->minimum_tls_version) {
         case AWS_IO_SSLv3:
-            s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-SSLv3.0");
+            s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "CloudFront-SSL-v-3");
             break;
         case AWS_IO_TLSv1:
-            s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-TLSv1.0");
+            s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "CloudFront-TLS-1-0-2014");
             break;
         case AWS_IO_TLSv1_1:
-            s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-TLSv1.1");
+            s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "ELBSecurityPolicy-TLS-1-1-2017-01");
             break;
         case AWS_IO_TLSv1_2:
-            s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-TLSv1.2");
+            s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "ELBSecurityPolicy-TLS-1-2-Ext-2018-06");
             break;
         case AWS_IO_TLSv1_3:
-            s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-TLSv1.3");
-            break;
+            AWS_LOGF_ERROR(AWS_LS_IO_TLS, "TLS 1.3 is not supported yet.");
+            /* sorry guys, we'll add this as soon as s2n does. */
+            aws_raise_error(AWS_IO_TLS_VERSION_UNSUPPORTED);
+            goto cleanup_s2n_config;
         case AWS_IO_TLS_VER_SYS_DEFAULTS:
         default:
-            s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-TLSv1.0");
+            s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "ELBSecurityPolicy-TLS-1-1-2017-01");
     }
 
     switch (options->cipher_pref) {


### PR DESCRIPTION
Let's see how CI reacts to forcing a read after installing the server-side tls handler

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
