### PR TITLE
Revert "refcount input stream (#435)"

### DIFF
--- a/include/aws/io/stream.h
+++ b/include/aws/io/stream.h
@@ -6,7 +6,6 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-#include <aws/common/ref_count.h>
 #include <aws/io/io.h>
 
 struct aws_input_stream;
@@ -46,22 +45,9 @@ struct aws_input_stream {
     struct aws_allocator *allocator;
     void *impl;
     struct aws_input_stream_vtable *vtable;
-    struct aws_ref_count ref_count;
 };
 
 AWS_EXTERN_C_BEGIN
-
-/**
- * Increments the reference count on the input stream, allowing the caller to take a reference to it.
- *
- * Returns the same input stream passed in.
- */
-AWS_IO_API struct aws_input_stream *aws_input_stream_acquire(struct aws_input_stream *stream);
-
-/**
- * Decrements a input stream's ref count.  When the ref count drops to zero, the input stream will be destroyed.
- */
-AWS_IO_API void aws_input_stream_release(struct aws_input_stream *stream);
 
 /*
  * Seek to a position within a stream; analagous to fseek() and its relatives
@@ -86,8 +72,8 @@ AWS_IO_API int aws_input_stream_get_status(struct aws_input_stream *stream, stru
  */
 AWS_IO_API int aws_input_stream_get_length(struct aws_input_stream *stream, int64_t *out_length);
 
-/* DEPRECATED
- * Tears down the stream. Equivalent to aws_input_stream_release()
+/*
+ * Tears down the stream
  */
 AWS_IO_API void aws_input_stream_destroy(struct aws_input_stream *stream);
 

--- a/source/darwin/secure_transport_tls_channel_handler.c
+++ b/source/darwin/secure_transport_tls_channel_handler.c
@@ -1096,4 +1096,28 @@ struct aws_tls_ctx *aws_tls_client_ctx_new(struct aws_allocator *alloc, const st
     return s_tls_ctx_new(alloc, options);
 }
 
+void aws_tls_ctx_destroy(struct aws_tls_ctx *ctx) {
+
+    if (ctx == NULL) {
+        return;
+    }
+
+    struct secure_transport_ctx *secure_transport_ctx = ctx->impl;
+
+    if (secure_transport_ctx->certs) {
+        aws_release_identity(secure_transport_ctx->certs);
+    }
+
+    if (secure_transport_ctx->ca_cert) {
+        aws_release_certificates(secure_transport_ctx->ca_cert);
+    }
+
+    if (secure_transport_ctx->alpn_list) {
+        aws_string_destroy(secure_transport_ctx->alpn_list);
+    }
+
+    CFRelease(secure_transport_ctx->wrapped_allocator);
+    aws_mem_release(secure_transport_ctx->ctx.alloc, secure_transport_ctx);
+}
+
 #pragma clang diagnostic pop

--- a/source/stream.c
+++ b/source/stream.c
@@ -59,7 +59,7 @@ int aws_input_stream_get_length(struct aws_input_stream *stream, int64_t *out_le
     return stream->vtable->get_length(stream, out_length);
 }
 
-void s_aws_input_stream_destroy(struct aws_input_stream *stream) {
+void aws_input_stream_destroy(struct aws_input_stream *stream) {
     if (stream != NULL) {
         AWS_ASSERT(stream->vtable && stream->vtable->destroy);
 
@@ -198,11 +198,6 @@ static struct aws_input_stream_vtable s_aws_input_stream_byte_cursor_vtable = {
     .get_length = s_aws_input_stream_byte_cursor_get_length,
     .destroy = s_aws_input_stream_byte_cursor_destroy};
 
-static void s_input_stream_ref_count_init(struct aws_input_stream *input_stream) {
-    aws_ref_count_init(
-        &input_stream->ref_count, input_stream, (aws_simple_completion_callback *)s_aws_input_stream_destroy);
-}
-
 struct aws_input_stream *aws_input_stream_new_from_cursor(
     struct aws_allocator *allocator,
     const struct aws_byte_cursor *cursor) {
@@ -231,7 +226,6 @@ struct aws_input_stream *aws_input_stream_new_from_cursor(
 
     impl->original_cursor = *cursor;
     impl->current_cursor = *cursor;
-    s_input_stream_ref_count_init(input_stream);
 
     return input_stream;
 }
@@ -332,7 +326,6 @@ struct aws_input_stream *aws_input_stream_new_from_file(struct aws_allocator *al
     }
 
     impl->close_on_clean_up = true;
-    s_input_stream_ref_count_init(input_stream);
 
     return input_stream;
 
@@ -363,24 +356,6 @@ struct aws_input_stream *aws_input_stream_new_from_open_file(struct aws_allocato
 
     impl->file = file;
     impl->close_on_clean_up = false;
-    s_input_stream_ref_count_init(input_stream);
 
     return input_stream;
-}
-
-struct aws_input_stream *aws_input_stream_acquire(struct aws_input_stream *stream) {
-    if (stream != NULL) {
-        aws_ref_count_acquire(&stream->ref_count);
-    }
-    return stream;
-}
-
-void aws_input_stream_release(struct aws_input_stream *stream) {
-    if (stream != NULL) {
-        aws_ref_count_release(&stream->ref_count);
-    }
-}
-
-void aws_input_stream_destroy(struct aws_input_stream *stream) {
-    aws_input_stream_release(stream);
 }


### PR DESCRIPTION
This reverts commit 55806e4d047583af07830b220916ab77b5f02bb0.

It's not ready to go. The down stream is broken.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
