### PR TITLE
Moved aws_path_exist checks over to the safe variant.

### DIFF
--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -65,59 +65,71 @@ struct s2n_ctx {
     struct s2n_config *s2n_config;
 };
 
+AWS_STATIC_STRING_FROM_LITERAL(s_debian_path, "/etc/ssl/certs");
+AWS_STATIC_STRING_FROM_LITERAL(s_rhel_path, "/etc/pki/tls/certs");
+AWS_STATIC_STRING_FROM_LITERAL(s_android_path, "/system/etc/security/cacerts");
+AWS_STATIC_STRING_FROM_LITERAL(s_free_bsd_path, "/usr/local/share/certs");
+AWS_STATIC_STRING_FROM_LITERAL(s_net_bsd_path, "/etc/openssl/certs");
+
 static const char *s_determine_default_pki_dir(void) {
     /* debian variants */
-    if (aws_path_exists("/etc/ssl/certs")) {
-        return "/etc/ssl/certs";
+    if (aws_path_exists(s_debian_path)) {
+        return aws_string_c_str(s_debian_path);
     }
 
     /* RHEL variants */
-    if (aws_path_exists("/etc/pki/tls/certs")) {
-        return "/etc/pki/tls/certs";
+    if (aws_path_exists(s_rhel_path)) {
+        return aws_string_c_str(s_rhel_path);
     }
 
     /* android */
-    if (aws_path_exists("/system/etc/security/cacerts")) {
-        return "/system/etc/security/cacerts";
+    if (aws_path_exists(s_android_path)) {
+        return aws_string_c_str(s_android_path);
     }
 
     /* Free BSD */
-    if (aws_path_exists("/usr/local/share/certs")) {
-        return "/usr/local/share/certs";
+    if (aws_path_exists(s_free_bsd_path)) {
+        return aws_string_c_str(s_free_bsd_path);
     }
 
     /* Net BSD */
-    if (aws_path_exists("/etc/openssl/certs")) {
-        return "/etc/openssl/certs";
+    if (aws_path_exists(s_net_bsd_path)) {
+        return aws_string_c_str(s_net_bsd_path);
     }
 
     return NULL;
 }
 
+AWS_STATIC_STRING_FROM_LITERAL(s_debian_ca_file_path, "/etc/ssl/certs/ca-certificates.crt");
+AWS_STATIC_STRING_FROM_LITERAL(s_old_rhel_ca_file_path, "/etc/pki/tls/certs/ca-bundle.crt");
+AWS_STATIC_STRING_FROM_LITERAL(s_open_suse_ca_file_path, "/etc/ssl/ca-bundle.pem");
+AWS_STATIC_STRING_FROM_LITERAL(s_open_elec_ca_file_path, "/etc/pki/tls/cacert.pem");
+AWS_STATIC_STRING_FROM_LITERAL(s_modern_rhel_ca_file_path, "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem");
+
 static const char *s_determine_default_pki_ca_file(void) {
     /* debian variants */
-    if (aws_path_exists("/etc/ssl/certs/ca-certificates.crt")) {
-        return "/etc/ssl/certs/ca-certificates.crt";
+    if (aws_path_exists(s_debian_ca_file_path)) {
+        return aws_string_c_str(s_debian_ca_file_path);
     }
 
     /* Old RHEL variants */
-    if (aws_path_exists("/etc/pki/tls/certs/ca-bundle.crt")) {
-        return "/etc/pki/tls/certs/ca-bundle.crt";
+    if (aws_path_exists(s_old_rhel_ca_file_path)) {
+        return aws_string_c_str(s_old_rhel_ca_file_path);
     }
 
     /* Open SUSE */
-    if (aws_path_exists("/etc/ssl/ca-bundle.pem")) {
-        return "/etc/ssl/ca-bundle.pem";
+    if (aws_path_exists(s_open_suse_ca_file_path)) {
+        return aws_string_c_str(s_open_suse_ca_file_path);
     }
 
     /* Open ELEC */
-    if (aws_path_exists("/etc/pki/tls/cacert.pem")) {
-        return "/etc/pki/tls/cacert.pem";
+    if (aws_path_exists(s_open_elec_ca_file_path)) {
+        return aws_string_c_str(s_open_elec_ca_file_path);
     }
 
     /* Modern RHEL variants */
-    if (aws_path_exists("/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem")) {
-        return "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem";
+    if (aws_path_exists(s_modern_rhel_ca_file_path)) {
+        return aws_string_c_str(s_modern_rhel_ca_file_path);
     }
 
     return NULL;


### PR DESCRIPTION

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
