### PR TITLE
Remove windows.h inclusion from public headers

### DIFF
--- a/source/windows/iocp/iocp_event_loop.c
+++ b/source/windows/iocp/iocp_event_loop.c
@@ -12,6 +12,8 @@
 
 #include <aws/io/logging.h>
 
+#include <Windows.h>
+
 /* The next set of struct definitions are taken directly from the
     windows documentation. We can't include the header files directly
     due to winsock. Also some of the definitions here aren't in the public API
@@ -121,6 +123,10 @@ void aws_overlapped_init(
 void aws_overlapped_reset(struct aws_overlapped *overlapped) {
     AWS_ASSERT(overlapped);
     AWS_ZERO_STRUCT(overlapped->overlapped);
+}
+
+struct _OVERLAPPED *aws_overlapped_LPOVERLAPPED(struct aws_overlapped *overlapped) {
+    return (struct _OVERLAPPED *)&overlapped->overlapped;
 }
 
 struct aws_event_loop_vtable s_iocp_vtable = {

--- a/source/windows/iocp/pipe.c
+++ b/source/windows/iocp/pipe.c
@@ -11,6 +11,8 @@
 #include <stdbool.h>
 #include <stdio.h>
 
+#include <Windows.h>
+
 enum read_end_state {
     /* Pipe is open. */
     READ_END_STATE_OPEN,
@@ -443,7 +445,7 @@ static void s_read_end_request_async_monitoring(struct aws_pipe_read_end *read_e
         &fake_buffer,
         0,    /*nNumberOfBytesToRead*/
         NULL, /*lpNumberOfBytesRead: NULL for an overlapped operation*/
-        &read_impl->async_monitoring->op.overlapped.overlapped);
+        aws_overlapped_LPOVERLAPPED(&read_impl->async_monitoring->op.overlapped));
 
     if (success || (GetLastError() == ERROR_IO_PENDING)) {
         /* Success launching zero-byte-read, aka async monitoring operation */
@@ -754,7 +756,7 @@ int aws_pipe_write(
         src_buffer.ptr,                 /*lpBuffer*/
         num_bytes_to_write,             /*nNumberOfBytesToWrite*/
         NULL,                           /*lpNumberOfBytesWritten*/
-        &write->overlapped.overlapped); /*lpOverlapped*/
+        aws_overlapped_LPOVERLAPPED(&write->overlapped)); /*lpOverlapped*/
 
     /* Overlapped WriteFile() calls may succeed immediately, or they may queue the work. In either of these cases, IOCP
      * on the event-loop will alert us when the operation completes and we'll invoke user callbacks then. */

--- a/source/windows/iocp/socket.c
+++ b/source/windows/iocp/socket.c
@@ -953,7 +953,7 @@ static inline int s_tcp_connect(
         &fake_buffer,
         0,
         NULL,
-        &socket_impl->read_io_data->signal.overlapped);
+        aws_overlapped_LPOVERLAPPED(&socket_impl->read_io_data->signal));
 
     uint64_t time_to_run = 0;
     /* if the connect succeeded immediately, let the timeout task still run, but it can run immediately. This is cleaner
@@ -1719,7 +1719,8 @@ static void s_incoming_pipe_connection_event(
         }
 
         socket_impl->read_io_data->in_use = true;
-        BOOL res = ConnectNamedPipe(socket->io_handle.data.handle, &socket_impl->read_io_data->signal.overlapped);
+        BOOL res = ConnectNamedPipe(
+            socket->io_handle.data.handle, aws_overlapped_LPOVERLAPPED(&socket_impl->read_io_data->signal));
 
         continue_accept_loop = false;
 
@@ -1804,7 +1805,7 @@ static int s_socket_setup_accept(struct aws_socket *socket, struct aws_event_loo
             SOCK_STORAGE_SIZE,
             SOCK_STORAGE_SIZE,
             NULL,
-            &socket_impl->read_io_data->signal.overlapped);
+            aws_overlapped_LPOVERLAPPED(&socket_impl->read_io_data->signal));
 
         if (!res) {
             int win_err = WSAGetLastError();
@@ -2164,7 +2165,8 @@ static int s_local_start_accept(
         return AWS_OP_ERR;
     }
 
-    BOOL res = ConnectNamedPipe(socket->io_handle.data.handle, &socket_impl->read_io_data->signal.overlapped);
+    BOOL res =
+        ConnectNamedPipe(socket->io_handle.data.handle, aws_overlapped_LPOVERLAPPED(&socket_impl->read_io_data->signal));
 
     if (!res) {
         int error_code = GetLastError();
@@ -2664,8 +2666,12 @@ static int s_stream_subscribe_to_read(
 
     int fake_buffer = 0;
     socket->state |= CONNECTED_WAITING_ON_READABLE;
-    BOOL success =
-        ReadFile(socket->io_handle.data.handle, &fake_buffer, 0, NULL, &iocp_socket->read_io_data->signal.overlapped);
+    BOOL success = ReadFile(
+        socket->io_handle.data.handle,
+        &fake_buffer,
+        0,
+        NULL,
+        aws_overlapped_LPOVERLAPPED(&iocp_socket->read_io_data->signal));
     if (!success) {
         int wsa_err = WSAGetLastError();
         if (wsa_err != ERROR_IO_PENDING) {
@@ -2721,7 +2727,7 @@ static int s_dgram_subscribe_to_read(
         1,
         NULL,
         &flags,
-        &iocp_socket->read_io_data->signal.overlapped,
+        aws_overlapped_LPOVERLAPPED(&iocp_socket->read_io_data->signal),
         NULL);
 
     if (err) {
@@ -2775,7 +2781,11 @@ static int s_local_read(struct aws_socket *socket, struct aws_byte_buf *buffer, 
             aws_overlapped_init(&iocp_socket->read_io_data->signal, s_stream_readable_event, socket);
             int fake_buffer = 0;
             BOOL success = ReadFile(
-                socket->io_handle.data.handle, &fake_buffer, 0, NULL, &iocp_socket->read_io_data->signal.overlapped);
+                socket->io_handle.data.handle,
+                &fake_buffer,
+                0,
+                NULL,
+                aws_overlapped_LPOVERLAPPED(&iocp_socket->read_io_data->signal));
             if (!success) {
                 int wsa_err = GetLastError();
                 if (wsa_err != ERROR_IO_PENDING) {
@@ -2895,7 +2905,11 @@ static int s_tcp_read(struct aws_socket *socket, struct aws_byte_buf *buffer, si
             aws_overlapped_init(&iocp_socket->read_io_data->signal, s_stream_readable_event, socket);
             int fake_buffer = 0;
             BOOL success = ReadFile(
-                socket->io_handle.data.handle, &fake_buffer, 0, NULL, &iocp_socket->read_io_data->signal.overlapped);
+                socket->io_handle.data.handle,
+                &fake_buffer,
+                0,
+                NULL,
+                aws_overlapped_LPOVERLAPPED(&iocp_socket->read_io_data->signal));
             if (!success) {
                 int wsa_err = GetLastError();
                 if (wsa_err != ERROR_IO_PENDING) {
@@ -2998,7 +3012,7 @@ static int s_dgram_read(struct aws_socket *socket, struct aws_byte_buf *buffer, 
                 1,
                 NULL,
                 &flags,
-                &iocp_socket->read_io_data->signal.overlapped,
+                aws_overlapped_LPOVERLAPPED(&iocp_socket->read_io_data->signal),
                 NULL);
             if (err) {
                 int wsa_err = WSAGetLastError();
@@ -3152,7 +3166,7 @@ int aws_socket_write(
         cursor->ptr,
         (DWORD)cursor->len,
         NULL,
-        &write_cb_data->io_data.signal.overlapped);
+        aws_overlapped_LPOVERLAPPED(&write_cb_data->io_data.signal));
 
     if (!res) {
         int error_code = GetLastError();


### PR DESCRIPTION
As of AWS C++ SDK 1.9, windows.h is being pulled in via aws/io/event_loop.h, which is causing lots of pre-existing code to suddenly pull in a bunch of ill-behaved Windows SDK macros such as `#define GetMessage GetMessageA`.

This pull request hides windows.h as an internal-only dependency, duplicating the Windows `struct _OVERLAPPED` layout into `struct aws_win32_OVERLAPPED` and adding a centralized type-cast function to avoid the proliferation of unsafe casts throughout the codebase.

This resolves https://github.com/awslabs/aws-c-io/issues/401
