### PR TITLE
Set default cpu_id on thread_options

### DIFF
--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -67,6 +67,7 @@ static void s_aws_event_loop_group_shutdown_async(struct aws_event_loop_group *e
 
     struct aws_thread_options thread_options;
     AWS_ZERO_STRUCT(thread_options);
+    thread_options.cpu_id = -1;
     thread_options.join_strategy = AWS_TJS_MANAGED;
 
     AWS_FATAL_ASSERT(


### PR DESCRIPTION
*Issue #, if available:* Fixes #392

*Description of changes:*

This implements the suggested fix from #392, i.e. removes the CPU pinning to `cpu_id=0` and allows the use of any CPU for the spawned thread.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
