### PR TITLE
options-structs should use const pointers

### DIFF
--- a/include/aws/io/tls_channel_handler.h
+++ b/include/aws/io/tls_channel_handler.h
@@ -330,7 +330,7 @@ struct aws_tls_ctx_pkcs11_options {
      * If set to NULL, the token will be chosen based on other criteria
      * (such as token label).
      */
-    uint64_t *slot_id;
+    const uint64_t *slot_id;
 
     /**
      * Label of PKCS#11 token to use.


### PR DESCRIPTION
For great const-correctness!

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
