### PR TITLE
Fix null-pointer crash when s2n_connection_new() fails

### DIFF
--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -318,7 +318,9 @@ static void s_s2n_handler_destroy(struct aws_channel_handler *handler) {
         if (s2n_handler->connection) {
             s2n_connection_free(s2n_handler->connection);
         }
-        aws_tls_ctx_release(&s2n_handler->s2n_ctx->ctx);
+        if (s2n_handler->s2n_ctx) {
+            aws_tls_ctx_release(&s2n_handler->s2n_ctx->ctx);
+        }
         aws_mem_release(handler->alloc, (void *)s2n_handler);
     }
 }


### PR DESCRIPTION
Fix bug introduced in [PR #451](https://github.com/awslabs/aws-c-io/pull/451) (by yours truly, when trying to clean up error handling code and make it safer, oh the irony), and released in v0.10.13.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
