### PR TITLE
Remove platform ifdefs from tls_channel_handler.h

### DIFF
--- a/include/aws/io/tls_channel_handler.h
+++ b/include/aws/io/tls_channel_handler.h
@@ -411,10 +411,12 @@ AWS_IO_API int aws_tls_ctx_options_init_default_server(
     struct aws_byte_cursor *pkey);
 
 /**
- * Initializes options for use with mutual tls in client mode. This function only works on
- * Windows. cert_reg_path is the path to a system
+ * Initializes options for use with mutual tls in client mode.
+ * cert_reg_path is the path to a system
  * installed certficate/private key pair. Example:
  * CurrentUser\\MY\\<thumprint>
+ *
+ * NOTE: This only works on Windows.
  */
 AWS_IO_API int aws_tls_ctx_options_init_client_mtls_from_system_path(
     struct aws_tls_ctx_options *options,
@@ -422,10 +424,12 @@ AWS_IO_API int aws_tls_ctx_options_init_client_mtls_from_system_path(
     const char *cert_reg_path);
 
 /**
- * Initializes options for use with server mode. This function only works on
- * Windows. cert_reg_path is the path to a system
+ * Initializes options for use with server mode.
+ * cert_reg_path is the path to a system
  * installed certficate/private key pair. Example:
  * CurrentUser\\MY\\<thumprint>
+ *
+ * NOTE: This only works on Windows.
  */
 AWS_IO_API int aws_tls_ctx_options_init_default_server_from_system_path(
     struct aws_tls_ctx_options *options,
@@ -433,9 +437,11 @@ AWS_IO_API int aws_tls_ctx_options_init_default_server_from_system_path(
     const char *cert_reg_path);
 
 /**
- * Initializes options for use with mutual tls in client mode. This function only works on
- * Apple machines. pkcs12_path is a path to a file on disk containing a pkcs#12 file. The file is loaded
+ * Initializes options for use with mutual tls in client mode.
+ * pkcs12_path is a path to a file on disk containing a pkcs#12 file. The file is loaded
  * into an internal buffer. pkcs_pwd is the corresponding password for the pkcs#12 file; it is copied.
+ *
+ * NOTE: This only works on Apple devices.
  */
 AWS_IO_API int aws_tls_ctx_options_init_client_mtls_pkcs12_from_path(
     struct aws_tls_ctx_options *options,
@@ -444,9 +450,11 @@ AWS_IO_API int aws_tls_ctx_options_init_client_mtls_pkcs12_from_path(
     struct aws_byte_cursor *pkcs_pwd);
 
 /**
- * Initializes options for use with mutual tls in client mode. This function only works on
- * Apple machines. pkcs12 is a buffer containing a pkcs#12 certificate and private key; it is copied.
+ * Initializes options for use with mutual tls in client mode.
+ * pkcs12 is a buffer containing a pkcs#12 certificate and private key; it is copied.
  * pkcs_pwd is the corresponding password for the pkcs#12 buffer; it is copied.
+ *
+ * NOTE: This only works on Apple devices.
  */
 AWS_IO_API int aws_tls_ctx_options_init_client_mtls_pkcs12(
     struct aws_tls_ctx_options *options,
@@ -455,9 +463,11 @@ AWS_IO_API int aws_tls_ctx_options_init_client_mtls_pkcs12(
     struct aws_byte_cursor *pkcs_pwd);
 
 /**
- * Initializes options for use in server mode. This function only works on
- * Apple machines. pkcs12_path is a path to a file on disk containing a pkcs#12 file. The file is loaded
+ * Initializes options for use in server mode.
+ * pkcs12_path is a path to a file on disk containing a pkcs#12 file. The file is loaded
  * into an internal buffer. pkcs_pwd is the corresponding password for the pkcs#12 file; it is copied.
+ *
+ * NOTE: This only works on Apple devices.
  */
 AWS_IO_API int aws_tls_ctx_options_init_server_pkcs12_from_path(
     struct aws_tls_ctx_options *options,
@@ -466,9 +476,11 @@ AWS_IO_API int aws_tls_ctx_options_init_server_pkcs12_from_path(
     struct aws_byte_cursor *pkcs_password);
 
 /**
- * Initializes options for use in server mode. This function only works on
- * Apple machines. pkcs12 is a buffer containing a pkcs#12 certificate and private key; it is copied.
+ * Initializes options for use in server mode.
+ * pkcs12 is a buffer containing a pkcs#12 certificate and private key; it is copied.
  * pkcs_pwd is the corresponding password for the pkcs#12 buffer; it is copied.
+ *
+ * NOTE: This only works on Apple devices.
  */
 AWS_IO_API int aws_tls_ctx_options_init_server_pkcs12(
     struct aws_tls_ctx_options *options,

--- a/include/aws/io/tls_channel_handler.h
+++ b/include/aws/io/tls_channel_handler.h
@@ -268,13 +268,13 @@ AWS_IO_API void aws_tls_ctx_options_init_default_client(
  */
 AWS_IO_API void aws_tls_ctx_options_clean_up(struct aws_tls_ctx_options *options);
 
-#if !defined(AWS_OS_IOS)
-
 /**
  * Initializes options for use with mutual tls in client mode.
  * cert_path and pkey_path are paths to files on disk. cert_path
  * and pkey_path are treated as PKCS#7 PEM armored. They are loaded
  * from disk and stored in buffers internally.
+ *
+ * NOTE: This is unsupported on iOS.
  */
 AWS_IO_API int aws_tls_ctx_options_init_client_mtls_from_path(
     struct aws_tls_ctx_options *options,
@@ -286,6 +286,8 @@ AWS_IO_API int aws_tls_ctx_options_init_client_mtls_from_path(
  * Initializes options for use with mutual tls in client mode.
  * cert and pkey are copied. cert and pkey are treated as PKCS#7 PEM
  * armored.
+ *
+ * NOTE: This is unsupported on iOS.
  */
 AWS_IO_API int aws_tls_ctx_options_init_client_mtls(
     struct aws_tls_ctx_options *options,
@@ -365,6 +367,8 @@ struct aws_tls_ctx_pkcs11_options {
  * Initializes options for use with mutual TLS in client mode,
  * where a PKCS#11 library provides access to the private key.
  *
+ * NOTE: This only works on Unix devices.
+ *
  * @param options           aws_tls_ctx_options to be initialized.
  * @param allocator         Allocator to use.
  * @param pkcs11_options    Options for using PKCS#11 (contents are copied)
@@ -374,14 +378,14 @@ AWS_IO_API int aws_tls_ctx_options_init_client_mtls_with_pkcs11(
     struct aws_allocator *allocator,
     const struct aws_tls_ctx_pkcs11_options *pkcs11_options);
 
-#    ifdef __APPLE__
 /**
  * Sets a custom keychain path for storing the cert and pkey with mutual tls in client mode.
+ *
+ * NOTE: This only works on MacOS.
  */
 AWS_IO_API int aws_tls_ctx_options_set_keychain_path(
     struct aws_tls_ctx_options *options,
     struct aws_byte_cursor *keychain_path_cursor);
-#    endif
 
 /**
  * Initializes options for use with in server mode.
@@ -406,36 +410,31 @@ AWS_IO_API int aws_tls_ctx_options_init_default_server(
     struct aws_byte_cursor *cert,
     struct aws_byte_cursor *pkey);
 
-#endif /* AWS_OS_IOS */
-
-#ifdef _WIN32
 /**
- * Initializes options for use with mutual tls in client mode. This function is only available on
- * windows. cert_reg_path is the path to a system
+ * Initializes options for use with mutual tls in client mode. This function only works on
+ * Windows. cert_reg_path is the path to a system
  * installed certficate/private key pair. Example:
  * CurrentUser\\MY\\<thumprint>
  */
-AWS_IO_API void aws_tls_ctx_options_init_client_mtls_from_system_path(
+AWS_IO_API int aws_tls_ctx_options_init_client_mtls_from_system_path(
     struct aws_tls_ctx_options *options,
     struct aws_allocator *allocator,
     const char *cert_reg_path);
 
 /**
- * Initializes options for use with server mode. This function is only available on
- * windows. cert_reg_path is the path to a system
+ * Initializes options for use with server mode. This function only works on
+ * Windows. cert_reg_path is the path to a system
  * installed certficate/private key pair. Example:
  * CurrentUser\\MY\\<thumprint>
  */
-AWS_IO_API void aws_tls_ctx_options_init_default_server_from_system_path(
+AWS_IO_API int aws_tls_ctx_options_init_default_server_from_system_path(
     struct aws_tls_ctx_options *options,
     struct aws_allocator *allocator,
     const char *cert_reg_path);
-#endif /* _WIN32 */
 
-#ifdef __APPLE__
 /**
- * Initializes options for use with mutual tls in client mode. This function is only available on
- * apple machines. pkcs12_path is a path to a file on disk containing a pkcs#12 file. The file is loaded
+ * Initializes options for use with mutual tls in client mode. This function only works on
+ * Apple machines. pkcs12_path is a path to a file on disk containing a pkcs#12 file. The file is loaded
  * into an internal buffer. pkcs_pwd is the corresponding password for the pkcs#12 file; it is copied.
  */
 AWS_IO_API int aws_tls_ctx_options_init_client_mtls_pkcs12_from_path(
@@ -445,8 +444,8 @@ AWS_IO_API int aws_tls_ctx_options_init_client_mtls_pkcs12_from_path(
     struct aws_byte_cursor *pkcs_pwd);
 
 /**
- * Initializes options for use with mutual tls in client mode. This function is only available on
- * apple machines. pkcs12 is a buffer containing a pkcs#12 certificate and private key; it is copied.
+ * Initializes options for use with mutual tls in client mode. This function only works on
+ * Apple machines. pkcs12 is a buffer containing a pkcs#12 certificate and private key; it is copied.
  * pkcs_pwd is the corresponding password for the pkcs#12 buffer; it is copied.
  */
 AWS_IO_API int aws_tls_ctx_options_init_client_mtls_pkcs12(
@@ -456,8 +455,8 @@ AWS_IO_API int aws_tls_ctx_options_init_client_mtls_pkcs12(
     struct aws_byte_cursor *pkcs_pwd);
 
 /**
- * Initializes options for use in server mode. This function is only available on
- * apple machines. pkcs12_path is a path to a file on disk containing a pkcs#12 file. The file is loaded
+ * Initializes options for use in server mode. This function only works on
+ * Apple machines. pkcs12_path is a path to a file on disk containing a pkcs#12 file. The file is loaded
  * into an internal buffer. pkcs_pwd is the corresponding password for the pkcs#12 file; it is copied.
  */
 AWS_IO_API int aws_tls_ctx_options_init_server_pkcs12_from_path(
@@ -467,8 +466,8 @@ AWS_IO_API int aws_tls_ctx_options_init_server_pkcs12_from_path(
     struct aws_byte_cursor *pkcs_password);
 
 /**
- * Initializes options for use in server mode. This function is only available on
- * apple machines. pkcs12 is a buffer containing a pkcs#12 certificate and private key; it is copied.
+ * Initializes options for use in server mode. This function only works on
+ * Apple machines. pkcs12 is a buffer containing a pkcs#12 certificate and private key; it is copied.
  * pkcs_pwd is the corresponding password for the pkcs#12 buffer; it is copied.
  */
 AWS_IO_API int aws_tls_ctx_options_init_server_pkcs12(
@@ -476,7 +475,6 @@ AWS_IO_API int aws_tls_ctx_options_init_server_pkcs12(
     struct aws_allocator *allocator,
     struct aws_byte_cursor *pkcs12,
     struct aws_byte_cursor *pkcs_password);
-#endif /* __APPLE__ */
 
 /**
  * Sets alpn list in the form <protocol1;protocol2;...>. A maximum of 4 protocols are supported.

--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -88,7 +88,7 @@ error:
     (void)pkey;
     AWS_ZERO_STRUCT(*options);
     AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: This platform does not support PEM certificates");
-    return aws_raise_error(AWS_ERROR_UNIMPLEMENTED);
+    return aws_raise_error(AWS_ERROR_PLATFORM_NOT_SUPPORTED);
 #endif
 }
 
@@ -130,7 +130,7 @@ error:
     (void)pkey_path;
     AWS_ZERO_STRUCT(*options);
     AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: This platform does not support PEM certificates");
-    return aws_raise_error(AWS_ERROR_UNIMPLEMENTED);
+    return aws_raise_error(AWS_ERROR_PLATFORM_NOT_SUPPORTED);
 #endif
 }
 
@@ -144,7 +144,7 @@ int aws_tls_ctx_options_init_client_mtls_with_pkcs11(
     (void)pkcs11_options;
     AWS_ZERO_STRUCT(*options);
     AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: This platform does not currently support TLS with PKCS#11.");
-    return aws_raise_error(AWS_ERROR_UNIMPLEMENTED);
+    return aws_raise_error(AWS_ERROR_PLATFORM_NOT_SUPPORTED);
 #else
 
     aws_tls_ctx_options_init_default_client(options, allocator);
@@ -231,7 +231,7 @@ int aws_tls_ctx_options_set_keychain_path(
     (void)options;
     (void)keychain_path_cursor;
     AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: Keychain path can only be set on MacOS.");
-    return aws_raise_error(AWS_ERROR_UNIMPLEMENTED);
+    return aws_raise_error(AWS_ERROR_PLATFORM_NOT_SUPPORTED);
 #endif
 }
 
@@ -249,7 +249,7 @@ int aws_tls_ctx_options_init_client_mtls_from_system_path(
     (void)cert_reg_path;
     AWS_ZERO_STRUCT(*options);
     AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: System certificate path can only be set on Windows.");
-    return aws_raise_error(AWS_ERROR_UNIMPLEMENTED);
+    return aws_raise_error(AWS_ERROR_PLATFORM_NOT_SUPPORTED);
 #endif
 }
 
@@ -289,7 +289,7 @@ int aws_tls_ctx_options_init_client_mtls_pkcs12_from_path(
     (void)pkcs_pwd;
     AWS_ZERO_STRUCT(*options);
     AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: This platform does not support PKCS#12 files.");
-    return aws_raise_error(AWS_ERROR_UNIMPLEMENTED);
+    return aws_raise_error(AWS_ERROR_PLATFORM_NOT_SUPPORTED);
 #endif
 }
 
@@ -318,7 +318,7 @@ int aws_tls_ctx_options_init_client_mtls_pkcs12(
     (void)pkcs_pwd;
     AWS_ZERO_STRUCT(*options);
     AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: This platform does not support PKCS#12 files.");
-    return aws_raise_error(AWS_ERROR_UNIMPLEMENTED);
+    return aws_raise_error(AWS_ERROR_PLATFORM_NOT_SUPPORTED);
 #endif
 }
 
@@ -367,7 +367,7 @@ int aws_tls_ctx_options_init_default_server_from_path(
     (void)pkey_path;
     AWS_ZERO_STRUCT(*options);
     AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: Cannot create a server on this platform.");
-    return aws_raise_error(AWS_ERROR_UNIMPLEMENTED);
+    return aws_raise_error(AWS_ERROR_PLATFORM_NOT_SUPPORTED);
 #endif
 }
 
@@ -390,7 +390,7 @@ int aws_tls_ctx_options_init_default_server(
     (void)pkey;
     AWS_ZERO_STRUCT(*options);
     AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: Cannot create a server on this platform.");
-    return aws_raise_error(AWS_ERROR_UNIMPLEMENTED);
+    return aws_raise_error(AWS_ERROR_PLATFORM_NOT_SUPPORTED);
 #endif
 }
 

--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -49,13 +49,13 @@ void aws_tls_ctx_options_clean_up(struct aws_tls_ctx_options *options) {
     AWS_ZERO_STRUCT(*options);
 }
 
-#if !defined(AWS_OS_IOS)
-
 int aws_tls_ctx_options_init_client_mtls(
     struct aws_tls_ctx_options *options,
     struct aws_allocator *allocator,
     const struct aws_byte_cursor *cert,
     const struct aws_byte_cursor *pkey) {
+
+#if !defined(AWS_OS_IOS)
 
     aws_tls_ctx_options_init_default_client(options, allocator);
 
@@ -81,6 +81,15 @@ int aws_tls_ctx_options_init_client_mtls(
 error:
     aws_tls_ctx_options_clean_up(options);
     return AWS_OP_ERR;
+
+#else
+    (void)allocator;
+    (void)cert;
+    (void)pkey;
+    AWS_ZERO_STRUCT(*options);
+    AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: This platform does not support PEM certificates");
+    return aws_raise_error(AWS_ERROR_UNIMPLEMENTED);
+#endif
 }
 
 int aws_tls_ctx_options_init_client_mtls_from_path(
@@ -89,6 +98,7 @@ int aws_tls_ctx_options_init_client_mtls_from_path(
     const char *cert_path,
     const char *pkey_path) {
 
+#if !defined(AWS_OS_IOS)
     aws_tls_ctx_options_init_default_client(options, allocator);
 
     if (aws_byte_buf_init_from_file(&options->certificate, allocator, cert_path)) {
@@ -113,6 +123,15 @@ int aws_tls_ctx_options_init_client_mtls_from_path(
 error:
     aws_tls_ctx_options_clean_up(options);
     return AWS_OP_ERR;
+
+#else
+    (void)allocator;
+    (void)cert_path;
+    (void)pkey_path;
+    AWS_ZERO_STRUCT(*options);
+    AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: This platform does not support PEM certificates");
+    return aws_raise_error(AWS_ERROR_UNIMPLEMENTED);
+#endif
 }
 
 int aws_tls_ctx_options_init_client_mtls_with_pkcs11(
@@ -120,14 +139,13 @@ int aws_tls_ctx_options_init_client_mtls_with_pkcs11(
     struct aws_allocator *allocator,
     const struct aws_tls_ctx_pkcs11_options *pkcs11_options) {
 
-#    if defined(_WIN32) || defined(__APPLE__)
-    (void)options;
+#if defined(_WIN32) || defined(__APPLE__)
     (void)allocator;
     (void)pkcs11_options;
     AWS_ZERO_STRUCT(*options);
     AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: This platform does not currently support TLS with PKCS#11.");
     return aws_raise_error(AWS_ERROR_UNIMPLEMENTED);
-#    else
+#else
 
     aws_tls_ctx_options_init_default_client(options, allocator);
 
@@ -195,57 +213,65 @@ int aws_tls_ctx_options_init_client_mtls_with_pkcs11(
 error:
     aws_tls_ctx_options_clean_up(options);
     return AWS_OP_ERR;
-#    endif /* PLATFORM-SUPPORTS-PKCS11-TLS */
+#endif /* PLATFORM-SUPPORTS-PKCS11-TLS */
 }
 
-#    if defined(__APPLE__)
 int aws_tls_ctx_options_set_keychain_path(
     struct aws_tls_ctx_options *options,
     struct aws_byte_cursor *keychain_path_cursor) {
+
+#if defined(__APPLE__) && !defined(AWS_OS_IOS)
     options->keychain_path = aws_string_new_from_cursor(options->allocator, keychain_path_cursor);
     if (!options->keychain_path) {
         return AWS_OP_ERR;
     }
 
     return AWS_OP_SUCCESS;
+#else
+    (void)options;
+    (void)keychain_path_cursor;
+    AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: Keychain path can only be set on MacOS.");
+    return aws_raise_error(AWS_ERROR_UNIMPLEMENTED);
+#endif
 }
-#    endif /* __APPLE__ */
 
-#endif /* !AWS_OS_IOS */
+int aws_tls_ctx_options_init_client_mtls_from_system_path(
+    struct aws_tls_ctx_options *options,
+    struct aws_allocator *allocator,
+    const char *cert_reg_path) {
 
 #ifdef _WIN32
-void aws_tls_ctx_options_init_client_mtls_from_system_path(
-    struct aws_tls_ctx_options *options,
-    struct aws_allocator *allocator,
-    const char *cert_reg_path) {
-    AWS_ZERO_STRUCT(*options);
-    options->minimum_tls_version = AWS_IO_TLS_VER_SYS_DEFAULTS;
-    options->verify_peer = true;
-    options->allocator = allocator;
-    options->max_fragment_size = g_aws_channel_max_fragment_size;
+    aws_tls_ctx_options_init_default_client(options, allocator);
     options->system_certificate_path = cert_reg_path;
+    return AWS_OP_SUCCESS;
+#else
+    (void)allocator;
+    (void)cert_reg_path;
+    AWS_ZERO_STRUCT(*options);
+    AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: System certificate path can only be set on Windows.");
+    return aws_raise_error(AWS_ERROR_UNIMPLEMENTED);
+#endif
 }
 
-void aws_tls_ctx_options_init_default_server_from_system_path(
+int aws_tls_ctx_options_init_default_server_from_system_path(
     struct aws_tls_ctx_options *options,
     struct aws_allocator *allocator,
     const char *cert_reg_path) {
-    aws_tls_ctx_options_init_client_mtls_from_system_path(options, allocator, cert_reg_path);
+    if (aws_tls_ctx_options_init_client_mtls_from_system_path(options, allocator, cert_reg_path)) {
+        return AWS_OP_ERR;
+    }
     options->verify_peer = false;
+    return AWS_OP_SUCCESS;
 }
-#endif /* _WIN32 */
 
-#ifdef __APPLE__
 int aws_tls_ctx_options_init_client_mtls_pkcs12_from_path(
     struct aws_tls_ctx_options *options,
     struct aws_allocator *allocator,
     const char *pkcs12_path,
     struct aws_byte_cursor *pkcs_pwd) {
-    AWS_ZERO_STRUCT(*options);
-    options->minimum_tls_version = AWS_IO_TLS_VER_SYS_DEFAULTS;
-    options->verify_peer = true;
-    options->allocator = allocator;
-    options->max_fragment_size = g_aws_channel_max_fragment_size;
+
+#ifdef __APPLE__
+    aws_tls_ctx_options_init_default_client(options, allocator);
 
     if (aws_byte_buf_init_from_file(&options->pkcs12, allocator, pkcs12_path)) {
         return AWS_OP_ERR;
@@ -257,6 +283,14 @@ int aws_tls_ctx_options_init_client_mtls_pkcs12_from_path(
     }
 
     return AWS_OP_SUCCESS;
+#else
+    (void)allocator;
+    (void)pkcs12_path;
+    (void)pkcs_pwd;
+    AWS_ZERO_STRUCT(*options);
+    AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: This platform does not support PKCS#12 files.");
+    return aws_raise_error(AWS_ERROR_UNIMPLEMENTED);
+#endif
 }
 
 int aws_tls_ctx_options_init_client_mtls_pkcs12(
@@ -265,6 +299,7 @@ int aws_tls_ctx_options_init_client_mtls_pkcs12(
     struct aws_byte_cursor *pkcs12,
     struct aws_byte_cursor *pkcs_pwd) {
 
+#ifdef __APPLE__
     aws_tls_ctx_options_init_default_client(options, allocator);
 
     if (aws_byte_buf_init_copy_from_cursor(&options->pkcs12, allocator, *pkcs12)) {
@@ -277,6 +312,14 @@ int aws_tls_ctx_options_init_client_mtls_pkcs12(
     }
 
     return AWS_OP_SUCCESS;
+#else
+    (void)allocator;
+    (void)pkcs12;
+    (void)pkcs_pwd;
+    AWS_ZERO_STRUCT(*options);
+    AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: This platform does not support PKCS#12 files.");
+    return aws_raise_error(AWS_ERROR_UNIMPLEMENTED);
+#endif
 }
 
 int aws_tls_ctx_options_init_server_pkcs12_from_path(
@@ -305,21 +348,27 @@ int aws_tls_ctx_options_init_server_pkcs12(
     return AWS_OP_SUCCESS;
 }
 
-#endif /* __APPLE__ */
-
-#if !defined(AWS_OS_IOS)
-
 int aws_tls_ctx_options_init_default_server_from_path(
     struct aws_tls_ctx_options *options,
     struct aws_allocator *allocator,
     const char *cert_path,
     const char *pkey_path) {
+
+#if !defined(AWS_OS_IOS)
     if (aws_tls_ctx_options_init_client_mtls_from_path(options, allocator, cert_path, pkey_path)) {
         return AWS_OP_ERR;
     }
 
     options->verify_peer = false;
     return AWS_OP_SUCCESS;
+#else
+    (void)allocator;
+    (void)cert_path;
+    (void)pkey_path;
+    AWS_ZERO_STRUCT(*options);
+    AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: Cannot create a server on this platform.");
+    return aws_raise_error(AWS_ERROR_UNIMPLEMENTED);
+#endif
 }
 
 int aws_tls_ctx_options_init_default_server(
@@ -327,15 +376,23 @@ int aws_tls_ctx_options_init_default_server(
     struct aws_allocator *allocator,
     struct aws_byte_cursor *cert,
     struct aws_byte_cursor *pkey) {
+
+#if !defined(AWS_OS_IOS)
     if (aws_tls_ctx_options_init_client_mtls(options, allocator, cert, pkey)) {
         return AWS_OP_ERR;
     }
 
     options->verify_peer = false;
     return AWS_OP_SUCCESS;
+#else
+    (void)allocator;
+    (void)cert;
+    (void)pkey;
+    AWS_ZERO_STRUCT(*options);
+    AWS_LOGF_ERROR(AWS_LS_IO_TLS, "static: Cannot create a server on this platform.");
+    return aws_raise_error(AWS_ERROR_UNIMPLEMENTED);
+#endif
 }
-
-#endif /* AWS_OS_IOS */
 
 int aws_tls_ctx_options_set_alpn_list(struct aws_tls_ctx_options *options, const char *alpn_list) {
     options->alpn_list = aws_string_new_from_c_str(options->allocator, alpn_list);


### PR DESCRIPTION
**Issue**
It was annoying and error prone having to mirror these ifdefs around every function that could call these functions, and every function that could call those functions, etc, etc, etc. There were multiple compilation errors in aws-crt-cpp on iOS because we didn't exactly match the nested pattern of ifdefs previously seen here.

**Description of changes:**
Instead of ifdef-ing out platform-specific functions in the H file, just ifdef in the C file, and raise a runtime error on unsupported platforms.

PS: Merry Christmas @bretambrose 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
