### PR TITLE
Fix some sporadically failing tests

### DIFF
--- a/source/channel.c
+++ b/source/channel.c
@@ -978,7 +978,7 @@ int aws_channel_slot_on_handler_shutdown_complete(
 }
 
 size_t aws_channel_slot_downstream_read_window(struct aws_channel_slot *slot) {
-    AWS_ASSERT(slot->adj_right);
+    AWS_ASSERT(slot->adj_right || !slot->channel->read_back_pressure_enabled);
     return slot->channel->read_back_pressure_enabled ? slot->adj_right->window_size : SIZE_MAX;
 }
 

--- a/source/channel.c
+++ b/source/channel.c
@@ -978,7 +978,7 @@ int aws_channel_slot_on_handler_shutdown_complete(
 }
 
 size_t aws_channel_slot_downstream_read_window(struct aws_channel_slot *slot) {
-    AWS_ASSERT(slot->adj_right || !slot->channel->read_back_pressure_enabled);
+    AWS_ASSERT(slot->adj_right);
     return slot->channel->read_back_pressure_enabled ? slot->adj_right->window_size : SIZE_MAX;
 }
 

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -777,8 +777,8 @@ static int s_verify_negotiation_fails_with_ca_override(
 
     ASSERT_SUCCESS(s_verify_negotiation_fails_helper(allocator, host_name, &client_ctx_options));
 
-    aws_tls_ctx_options_clean_up(&client_ctx_options);
     ASSERT_SUCCESS(s_tls_common_tester_clean_up(&c_tester));
+    aws_tls_ctx_options_clean_up(&client_ctx_options);
 
     return AWS_OP_SUCCESS;
 }


### PR DESCRIPTION
Pinned event loop test was seeing sporadic crashes in the assert because that test only uses/needs a single handler.  Added a dummy handler to address.

Also fixed race condition in shutdown of ca_override test.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
