### PR TITLE
Change windows cert chain processing to act like other platforms

### DIFF
--- a/source/windows/windows_pki_utils.c
+++ b/source/windows/windows_pki_utils.c
@@ -603,7 +603,7 @@ int aws_import_key_pair_to_cert_context(
             aws_raise_error(AWS_ERROR_SYS_CALL_FAILURE);
         }
 
-        if (i != cert_count - 1 || !add_result) {
+        if (i != 0 || !add_result) {
             CertFreeCertificateContext(cert_context);
         } else {
             *certs = cert_context;


### PR DESCRIPTION
Change windows certificate chain processing to work the same way as all other platforms.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
