### PR TITLE
Add option to bind to an interface

### DIFF
--- a/include/aws/io/socket.h
+++ b/include/aws/io/socket.h
@@ -35,7 +35,7 @@ struct aws_socket_options {
     /*
      * If set, socket will bind to this network interface.
      * This should be a valid interface name such-as "eth0" or "en0". */
-    const char *interface;
+    struct aws_byte_cursor interface;
     /* Keepalive properties are TCP only.
      * Set keepalive true to periodically transmit messages for detecting a disconnected peer.
      * If interval or timeout are zero, then default values are used. */

--- a/include/aws/io/socket.h
+++ b/include/aws/io/socket.h
@@ -32,6 +32,10 @@ struct aws_socket_options {
     enum aws_socket_type type;
     enum aws_socket_domain domain;
     uint32_t connect_timeout_ms;
+    /*
+     * If set, socket will bind to this network interface.
+     * This should be a valid interface name such-as "eth0" or "en0". */
+    const char *interface;
     /* Keepalive properties are TCP only.
      * Set keepalive true to periodically transmit messages for detecting a disconnected peer.
      * If interval or timeout are zero, then default values are used. */


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:* Adds optional parameter which specifies a network interface to bind to. Forcing network traffic to use just that single interface.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
