### PR TITLE
Fix memory leak in aws_tls_connection_options_copy

### DIFF
--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -511,6 +511,10 @@ void aws_tls_connection_options_init_from_ctx(
 int aws_tls_connection_options_copy(
     struct aws_tls_connection_options *to,
     const struct aws_tls_connection_options *from) {
+
+    /* clean up the options before copy. */ 
+    aws_tls_connection_options_clean_up(to);
+    
     /* copy everything copyable over, then override the rest with deep copies. */
     *to = *from;
 

--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -512,9 +512,9 @@ int aws_tls_connection_options_copy(
     struct aws_tls_connection_options *to,
     const struct aws_tls_connection_options *from) {
 
-    /* clean up the options before copy. */ 
+    /* clean up the options before copy. */
     aws_tls_connection_options_clean_up(to);
-    
+
     /* copy everything copyable over, then override the rest with deep copies. */
     *to = *from;
 


### PR DESCRIPTION
*Issue #, if available:*
Memory leak in Connection function is reported at  https://github.com/aws/aws-iot-device-sdk-cpp-v2/issues/215
We tracked down the issue and find it is related to aws_tls_connection_options_copy.

*Description of changes:*
Release the tls option data before copy happens in aws_tls_connection_options_copy. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
