### PR TITLE
Deprecate macOS keychain path function

### DIFF
--- a/include/aws/io/tls_channel_handler.h
+++ b/include/aws/io/tls_channel_handler.h
@@ -379,6 +379,8 @@ AWS_IO_API int aws_tls_ctx_options_init_client_mtls_with_pkcs11(
     const struct aws_tls_ctx_pkcs11_options *pkcs11_options);
 
 /**
+ * @Deprecated
+ *
  * Sets a custom keychain path for storing the cert and pkey with mutual tls in client mode.
  *
  * NOTE: This only works on MacOS.

--- a/source/darwin/darwin_pki_utils.c
+++ b/source/darwin/darwin_pki_utils.c
@@ -18,6 +18,12 @@ static struct aws_mutex s_sec_mutex = AWS_MUTEX_INIT;
 
 #if !defined(AWS_OS_IOS)
 
+#    pragma clang diagnostic push
+/* macOS 12.0 starting marking SecKeychainOpen() and SecKeychainUnlock() as deprecated
+ * because "Custom keychain management is no longer supported".
+ * Disable compiler warnings for now, but consider removing support for keychain_path altogether */
+#    pragma clang diagnostic ignored "-Wdeprecated-declarations"
+
 int aws_import_public_and_private_keys_to_identity(
     struct aws_allocator *alloc,
     CFAllocatorRef cf_alloc,
@@ -172,6 +178,7 @@ done:
     return result;
 }
 
+#    pragma clang diagnostic pop
 #endif /* AWS_OS_IOS */
 
 int aws_import_pkcs12_to_identity(

--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -221,6 +221,8 @@ int aws_tls_ctx_options_set_keychain_path(
     struct aws_byte_cursor *keychain_path_cursor) {
 
 #if defined(__APPLE__) && !defined(AWS_OS_IOS)
+    AWS_LOGF_WARN(AWS_LS_IO_TLS, "static: Keychain path is deprecated.");
+
     options->keychain_path = aws_string_new_from_cursor(options->allocator, keychain_path_cursor);
     if (!options->keychain_path) {
         return AWS_OP_ERR;


### PR DESCRIPTION
### Issue

These were causing compiler warnings on macOS 12
```
source/darwin/darwin_pki_utils.c:52:36: warning: 'SecKeychainOpen' is deprecated: first deprecated in macOS 12.0 - Custom keychain management is no longer supported [-Werror,-Wdeprecated-declarations]
```
### Research

These deprecated functions only happen if someone calls `aws_tls_ctx_options_set_keychain_path()`. This function doesn't seem widely used. It's only bound in aws-crt-cpp, no other aws-crt-xyz libraries expose it.

### Description of changes:
- Mark `aws_tls_ctx_options_set_keychain_path()` deprecated
- Disable the compiler warnings so we can still compile with warnings-as-errors


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
