### PR TITLE
Pin s2n version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.15
+  BUILDER_VERSION: v0.9.16
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-io

--- a/builder.json
+++ b/builder.json
@@ -2,12 +2,12 @@
     "name": "aws-c-io",
     "upstream": [
         { "name": "aws-c-common" },
+        { "name": "aws-c-cal" },
         {
             "name": "s2n",
             "revision": "v1.3.11",
             "targets": ["linux", "android"]
-        },
-        { "name": "aws-c-cal" }
+        }
     ],
     "downstream": [
         { "name": "aws-c-mqtt" },

--- a/builder.json
+++ b/builder.json
@@ -4,6 +4,7 @@
         { "name": "aws-c-common" },
         {
             "name": "s2n",
+            "revision": "v1.3.11",
             "targets": ["linux", "android"]
         },
         { "name": "aws-c-cal" }

--- a/codebuild/linux-integration-tests.yml
+++ b/codebuild/linux-integration-tests.yml
@@ -10,7 +10,7 @@ phases:
   pre_build:
     commands:
       - export CC=gcc-7
-      - export BUILDER_VERSION=v0.9.12
+      - export BUILDER_VERSION=v0.9.16
       - export BUILDER_SOURCE=releases
       - export BUILDER_HOST=https://d19elf31gohf1l.cloudfront.net
   build:
@@ -19,7 +19,7 @@ phases:
       - aws s3 cp s3://aws-crt-test-stuff/setup_proxy_test_env.sh /tmp/setup_proxy_test_env.sh
       - chmod a+xr /tmp/setup_proxy_test_env.sh
       - python3 -c "from urllib.request import urlretrieve; urlretrieve('$BUILDER_HOST/$BUILDER_SOURCE/$BUILDER_VERSION/builder.pyz', 'builder.pyz')"
-      - python3 builder.pyz build downstream -p aws-c-io --cmake-extra=-DENABLE_PROXY_INTEGRATION_TESTS=ON
+      - python3 builder.pyz build -p aws-c-io --cmake-extra=-DENABLE_PROXY_INTEGRATION_TESTS=ON
   post_build:
     commands:
       - echo Build completed on `date`


### PR DESCRIPTION
s2n and aws-lc recently made changes, and now symbols from `libcrypto` are public in our builds, breaking some of our tests.

Until we figure out how to deal with this, use a specific version of s2n in our tests instead of whatever's in `main`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
