### PR TITLE
Shutdown started callback support for event loop group

### DIFF
--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -22,7 +22,7 @@ struct aws_event_loop *aws_event_loop_new_default(struct aws_allocator *alloc, a
 static void s_event_loop_group_thread_exit(void *user_data) {
     struct aws_event_loop_group *el_group = user_data;
 
-    aws_simple_completion_callback *completion_callback = el_group->shutdown_options.shutdown_callback_fn;
+    aws_simple_completion_callback *completion_callback = el_group->shutdown_options.shutdown_completed_callback_fn;
     void *completion_user_data = el_group->shutdown_options.shutdown_callback_user_data;
 
     aws_mem_release(el_group->allocator, el_group);
@@ -33,6 +33,11 @@ static void s_event_loop_group_thread_exit(void *user_data) {
 }
 
 static void s_aws_event_loop_group_shutdown_sync(struct aws_event_loop_group *el_group) {
+    aws_simple_completion_callback *started_callback = el_group->shutdown_options.shutdown_started_callback_fn;
+    if (started_callback != NULL) {
+        started_callback(el_group->shutdown_options.shutdown_callback_user_data);
+    }
+
     while (aws_array_list_length(&el_group->event_loops) > 0) {
         struct aws_event_loop *loop = NULL;
 

--- a/source/host_resolver.c
+++ b/source/host_resolver.c
@@ -317,7 +317,7 @@ static void s_cleanup_default_resolver(struct aws_host_resolver *resolver) {
 
     aws_mutex_clean_up(&default_host_resolver->resolver_lock);
 
-    aws_simple_completion_callback *shutdown_callback = resolver->shutdown_options.shutdown_callback_fn;
+    aws_simple_completion_callback *shutdown_callback = resolver->shutdown_options.shutdown_completed_callback_fn;
     void *shutdown_completion_user_data = resolver->shutdown_options.shutdown_callback_user_data;
 
     aws_mem_release(resolver->allocator, resolver);

--- a/tests/event_loop_test.c
+++ b/tests/event_loop_test.c
@@ -1152,7 +1152,7 @@ static int test_event_loop_group_setup_and_shutdown_async(struct aws_allocator *
     struct aws_shutdown_callback_options async_shutdown_options;
     AWS_ZERO_STRUCT(async_shutdown_options);
     async_shutdown_options.shutdown_callback_user_data = &task_args;
-    async_shutdown_options.shutdown_callback_fn = s_async_shutdown_complete_callback;
+    async_shutdown_options.shutdown_completed_callback_fn = s_async_shutdown_complete_callback;
 
     struct aws_event_loop_group *event_loop_group =
         aws_event_loop_group_new_default(allocator, 0, &async_shutdown_options);

--- a/tests/standard_retry_test.c
+++ b/tests/standard_retry_test.c
@@ -45,7 +45,7 @@ static int s_fixture_setup(struct aws_allocator *allocator, void *ctx) {
     aws_io_library_init(allocator);
     struct exponential_backoff_test_data *test_data = ctx;
     struct aws_shutdown_callback_options shutdown_options = {
-        .shutdown_callback_fn = s_el_group_completion_callback,
+        .shutdown_completed_callback_fn = s_el_group_completion_callback,
         .shutdown_callback_user_data = ctx,
     };
 


### PR DESCRIPTION
* Add shutdown started callback support for event loop group shutdown to address JVM thread detachment race condition in aws-crt-java

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
