### PR TITLE
ALPN availability check function now properly checks for Windows 8.1 and above

### DIFF
--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -136,8 +136,8 @@ bool aws_tls_is_alpn_available(void) {
     VER_SET_CONDITION(condition_mask, VER_SERVICEPACKMINOR, VER_GREATER_EQUAL);
 
     AWS_ZERO_STRUCT(os_version);
-    os_version.dwMajorVersion = HIBYTE(_WIN32_WINNT_WIN8);
-    os_version.dwMinorVersion = LOBYTE(_WIN32_WINNT_WIN8);
+    os_version.dwMajorVersion = HIBYTE(_WIN32_WINNT_WINBLUE);
+    os_version.dwMinorVersion = LOBYTE(_WIN32_WINNT_WINBLUE);
     os_version.wServicePackMajor = 0;
     os_version.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
 


### PR DESCRIPTION
*Description of changes:*
Currently on Windows 8 and (probably) Windows Server 2012 aws_tls_is_alpn_available() function returns true, leading to the failure of tls negotiation step. As the logs surrounding this code and other web sources state, ALPN is only available from Windows 8.1 and above. This change raises the minimum Windows version from Win8 to Win8.1.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
