### PR TITLE
Fix building with clang

### DIFF
--- a/source/windows/iocp/socket.c
+++ b/source/windows/iocp/socket.c
@@ -27,6 +27,7 @@ below, clang-format doesn't work (at least on my version) with the c-style comme
 #include <aws/io/pipe.h>
 
 #include <aws/io/io.h>
+#include <errno.h>
 #include <fcntl.h>
 #include <signal.h>
 #include <stdio.h>
@@ -1216,8 +1217,9 @@ static int s_local_connect(
         return AWS_OP_SUCCESS;
     }
 
+    int win_error = ERROR_SUCCESS;
 error:
-    int win_error = GetLastError(); /* logging may reset error, so cache it */
+    win_error = GetLastError(); /* logging may reset error, so cache it */
     AWS_LOGF_ERROR(
         AWS_LS_IO_SOCKET,
         "id=%p handle=%p: failed to connect to named pipe %s.",


### PR DESCRIPTION
This fixes two errors.
1. error: use of undeclared identifier 'EPIPE'.
   This is fixed by including errno.h file.
2. error: use of undeclared identifier 'win_error'.
   This is fixed by declaring win_error variable before goto label.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
