### PR TITLE
VerifyVersionInfo doesn't behave like you'd expect

### DIFF
--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -136,8 +136,8 @@ bool aws_tls_is_alpn_available(void) {
     VER_SET_CONDITION(condition_mask, VER_SERVICEPACKMINOR, VER_GREATER_EQUAL);
 
     AWS_ZERO_STRUCT(os_version);
-    os_version.dwMajorVersion = HIBYTE(_WIN32_WINNT_WINBLUE);
-    os_version.dwMinorVersion = LOBYTE(_WIN32_WINNT_WINBLUE);
+    os_version.dwMajorVersion = HIBYTE(_WIN32_WINNT_WIN8);
+    os_version.dwMinorVersion = LOBYTE(_WIN32_WINNT_WIN8);
     os_version.wServicePackMajor = 0;
     os_version.dwOSVersionInfoSize = sizeof(OSVERSIONINFOEX);
 


### PR DESCRIPTION
Reverts the alpn check update in https://github.com/awslabs/aws-c-io/pull/502

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
