### PR TITLE
Disable test due to expired cert on badssl.com

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -201,7 +201,7 @@ if (NOT BYO_CRYPTO)
     add_net_test_case(tls_client_channel_negotiation_success_rsa2048)
     add_net_test_case(tls_client_channel_negotiation_success_ecc256)
     add_net_test_case(tls_client_channel_negotiation_success_ecc384)
-    add_net_test_case(tls_client_channel_negotiation_success_extended_validation)
+    # add_net_test_case(tls_client_channel_negotiation_success_extended_validation) test disabled until badssl updates cert (expired 2022.08.10)
     add_net_test_case(tls_client_channel_negotiation_success_mozilla_modern)
 
     # Misc non-badssl tls tests


### PR DESCRIPTION
**ISSUE:**
The `tls_client_channel_negotiation_success_extended_validation` test is always failing. It contacts https://extended-validation.badssl.com/ but their cert expired on 2022.08.10

**DESCRIPTION OF CHANGES:**
Disable test for now

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
