### PR TITLE
Int types

### DIFF
--- a/source/posix/socket.c
+++ b/source/posix/socket.c
@@ -17,6 +17,7 @@
 #include <aws/io/io.h>
 #include <errno.h>
 #include <fcntl.h>
+#include <inttypes.h>
 #include <netinet/tcp.h>
 #include <sys/socket.h>
 #include <sys/types.h>


### PR DESCRIPTION
Mirror of https://github.com/awslabs/aws-c-io/pull/506

Fixes a missing include that may cause build failures depending on linux distribution.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
