### PR TITLE
Use const in aws_host_resolver_new_default

### DIFF
--- a/include/aws/io/host_resolver.h
+++ b/include/aws/io/host_resolver.h
@@ -183,7 +183,7 @@ AWS_IO_API int aws_default_dns_resolve(
  */
 AWS_IO_API struct aws_host_resolver *aws_host_resolver_new_default(
     struct aws_allocator *allocator,
-    struct aws_host_resolver_default_options *options);
+    const struct aws_host_resolver_default_options *options);
 
 /**
  * Increments the reference count on the host resolver, allowing the caller to take a reference to it.

--- a/source/host_resolver.c
+++ b/source/host_resolver.c
@@ -1553,7 +1553,7 @@ static void s_aws_host_resolver_destroy(struct aws_host_resolver *resolver) {
 
 struct aws_host_resolver *aws_host_resolver_new_default(
     struct aws_allocator *allocator,
-    struct aws_host_resolver_default_options *options) {
+    const struct aws_host_resolver_default_options *options) {
     AWS_FATAL_ASSERT(options != NULL);
 
     /* NOTE: we don't use el_group yet, but we will in the future. Also, we


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Use const for aws_host_resolver_default_options in aws_host_resolver_new_default. This makes it easier to bind this in crt-Swift.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
