### PR TITLE
sprintf() -> snprintf()

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         python .\aws-c-io\build\deps\aws-c-common\scripts\appverifier_ctest.py --build_directory .\aws-c-io\build\aws-c-io
 
   osx:
-    runs-on: macos-11 # latest
+    runs-on: macos-12 # latest
     steps:
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -129,7 +129,7 @@ jobs:
         python .\aws-c-io\build\deps\aws-c-common\scripts\appverifier_ctest.py --build_directory .\aws-c-io\build\aws-c-io
 
   osx:
-    runs-on: macos-12 # latest
+    runs-on: macos-11 # latest
     steps:
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       run: |

--- a/tests/socket_test.c
+++ b/tests/socket_test.c
@@ -20,10 +20,6 @@
 #    define LOCAL_SOCK_TEST_PATTERN "testsock%llu.sock"
 #endif
 
-#if _MSC_VER
-#    pragma warning(disable : 4996) /* sprintf */
-#endif
-
 #if USE_VSOCK
 #    include <linux/vm_sockets.h>
 #endif
@@ -590,7 +586,7 @@ static int s_test_connect_timeout(struct aws_allocator *allocator, void *ctx) {
     ASSERT_TRUE(host_callback_data.has_a_address);
 
     struct aws_socket_endpoint endpoint = {.port = 81};
-    sprintf(endpoint.address, "%s", aws_string_bytes(host_callback_data.a_address.address));
+    snprintf(endpoint.address, sizeof(endpoint.address), "%s", aws_string_bytes(host_callback_data.a_address.address));
 
     aws_string_destroy((void *)host_name);
     aws_host_address_clean_up(&host_callback_data.a_address);
@@ -670,7 +666,7 @@ static int s_test_connect_timeout_cancelation(struct aws_allocator *allocator, v
     ASSERT_TRUE(host_callback_data.has_a_address);
 
     struct aws_socket_endpoint endpoint = {.port = 81};
-    sprintf(endpoint.address, "%s", aws_string_bytes(host_callback_data.a_address.address));
+    snprintf(endpoint.address, sizeof(endpoint.address), "%s", aws_string_bytes(host_callback_data.a_address.address));
 
     aws_string_destroy((void *)host_name);
     aws_host_address_clean_up(&host_callback_data.a_address);
@@ -1088,7 +1084,7 @@ static int s_cleanup_before_connect_or_timeout_doesnt_explode(struct aws_allocat
     ASSERT_TRUE(host_callback_data.has_a_address);
 
     struct aws_socket_endpoint endpoint = {.port = 81};
-    sprintf(endpoint.address, "%s", aws_string_bytes(host_callback_data.a_address.address));
+    snprintf(endpoint.address, sizeof(endpoint.address), "%s", aws_string_bytes(host_callback_data.a_address.address));
 
     aws_string_destroy((void *)host_name);
     aws_host_address_clean_up(&host_callback_data.a_address);

--- a/tests/socket_test.c
+++ b/tests/socket_test.c
@@ -20,6 +20,10 @@
 #    define LOCAL_SOCK_TEST_PATTERN "testsock%llu.sock"
 #endif
 
+#if _MSC_VER
+#    pragma warning(disable : 4996) /* strncpy */
+#endif
+
 #if USE_VSOCK
 #    include <linux/vm_sockets.h>
 #endif

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -23,10 +23,6 @@
 #    include <read_write_test_handler.h>
 #    include <statistics_handler_test.h>
 
-#    if _MSC_VER
-#        pragma warning(disable : 4996) /* sprintf */
-#    endif
-
 #    ifdef _WIN32
 #        define LOCAL_SOCK_TEST_PATTERN "\\\\.\\pipe\\testsock%llu_%d"
 #    else
@@ -400,7 +396,12 @@ static int s_tls_local_server_tester_init(
     tester->socket_options.type = AWS_SOCKET_STREAM;
     tester->socket_options.domain = AWS_SOCKET_LOCAL;
     ASSERT_SUCCESS(aws_sys_clock_get_ticks(&tester->timestamp));
-    sprintf(tester->endpoint.address, LOCAL_SOCK_TEST_PATTERN, (long long unsigned)tester->timestamp, server_index);
+    snprintf(
+        tester->endpoint.address,
+        sizeof(tester->endpoint.address),
+        LOCAL_SOCK_TEST_PATTERN,
+        (long long unsigned)tester->timestamp,
+        server_index);
     tester->server_bootstrap = aws_server_bootstrap_new(allocator, tls_c_tester->el_group);
     ASSERT_NOT_NULL(tester->server_bootstrap);
 
@@ -2137,10 +2138,10 @@ static int s_test_concurrent_cert_import(struct aws_allocator *allocator, void *
         import->allocator = allocator;
 
         char filename[1024];
-        sprintf(filename, "testcert%u.pem", (uint32_t)idx);
+        snprintf(filename, sizeof(filename), "testcert%u.pem", (uint32_t)idx);
         ASSERT_SUCCESS(aws_byte_buf_init_from_file(&import->cert_buf, import->allocator, filename));
 
-        sprintf(filename, "testkey.pem");
+        snprintf(filename, sizeof(filename), "testkey.pem");
         ASSERT_SUCCESS(aws_byte_buf_init_from_file(&import->key_buf, import->allocator, filename));
 
         struct aws_thread *thread = &import->thread;


### PR DESCRIPTION
Issue: Today my Mac started issuing warnings about sprintf().
Changes: Use snprintf() instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
