### PR TITLE
fix the crash from log

### DIFF
--- a/source/bsd/kqueue_event_loop.c
+++ b/source/bsd/kqueue_event_loop.c
@@ -521,8 +521,6 @@ static void s_subscribe_task(struct aws_task *task, void *user_data, enum aws_ta
     if (status == AWS_TASK_STATUS_CANCELED) {
         return;
     }
-    AWS_LOGF_TRACE(
-        AWS_LS_IO_EVENT_LOOP, "id=%p: subscribing to events on fd %d", (void *)event_loop, handle_data->owner->data.fd);
 
     /* If handle was unsubscribed before this task could execute, nothing to do */
     if (handle_data->state == HANDLE_STATE_UNSUBSCRIBED) {
@@ -530,6 +528,8 @@ static void s_subscribe_task(struct aws_task *task, void *user_data, enum aws_ta
     }
 
     AWS_ASSERT(handle_data->state == HANDLE_STATE_SUBSCRIBING);
+    AWS_LOGF_TRACE(
+        AWS_LS_IO_EVENT_LOOP, "id=%p: subscribing to events on fd %d", (void *)event_loop, handle_data->owner->data.fd);
 
     /* In order to monitor both reads and writes, kqueue requires you to add two separate kevents.
      * If we're adding two separate kevents, but one of those fails, we need to remove the other kevent.


### PR DESCRIPTION
*Issue #, if available:*

- The crash happens when the `aws_socket_assign_to_event_loop` called, it will invoke `aws_event_loop_subscribe_to_io_events` on Mac, and leads to a async task to run from [here](https://github.com/awslabs/aws-c-io/blob/main/source/bsd/kqueue_event_loop.c#L652)
- However, before the task runs, there could be a case the socket closed and released the memory [here](https://github.com/awslabs/aws-c-io/blob/main/source/channel_bootstrap.c#L491-L500)
- When the task runs, [here](https://github.com/awslabs/aws-c-io/blob/main/source/bsd/kqueue_event_loop.c#L524-L525), it tries to access the owner, which is the socket that could be released already.

*Description of changes:*
- Log the owner after checking the state.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
