### PR TITLE
Create setter for TLS Cipher Preference 

### DIFF
--- a/include/aws/io/tls_channel_handler.h
+++ b/include/aws/io/tls_channel_handler.h
@@ -622,6 +622,13 @@ AWS_IO_API int aws_tls_ctx_options_set_alpn_list(struct aws_tls_ctx_options *opt
 AWS_IO_API void aws_tls_ctx_options_set_verify_peer(struct aws_tls_ctx_options *options, bool verify_peer);
 
 /**
+ * Sets preferred TLS Cipher List
+ */
+AWS_IO_API void aws_tls_ctx_options_set_tls_cipher_preference(
+    struct aws_tls_ctx_options *options,
+    enum aws_tls_cipher_pref cipher_pref);
+
+/**
  * Sets the minimum TLS version to allow.
  */
 AWS_IO_API void aws_tls_ctx_options_set_minimum_tls_version(

--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -459,6 +459,12 @@ void aws_tls_ctx_options_set_minimum_tls_version(
     options->minimum_tls_version = minimum_tls_version;
 }
 
+void aws_tls_ctx_options_set_tls_cipher_preference(
+    struct aws_tls_ctx_options *options,
+    enum aws_tls_cipher_pref cipher_pref) {
+    options->cipher_pref = cipher_pref;
+}
+
 int aws_tls_ctx_options_override_default_trust_store_from_path(
     struct aws_tls_ctx_options *options,
     const char *ca_path,


### PR DESCRIPTION
*Issue #, if available:*
N/A

*Description of changes:*
Creates a `aws_tls_ctx_options_set_tls_cipher_preference()` method that can be used by the C++ CRT SDK to [match it's use of setter methods](https://github.com/awslabs/aws-crt-cpp/blob/main/source/io/TlsOptions.cpp#L146-L162). Currently the Java CRT SDK is [manually writing the enum](https://github.com/awslabs/aws-crt-java/blob/5390cb9981d176f21e7d4c4960627e72cd91c599/src/native/tls_context_options.c#L302) into the `aws_tls_ctx_options` struct instead of using a setter method. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
