### PR TITLE
Fix bug with increment read window

### DIFF
--- a/source/channel.c
+++ b/source/channel.c
@@ -80,7 +80,7 @@ struct aws_channel {
     size_t window_update_batch_emit_threshold;
     struct aws_channel_task window_update_task;
     bool read_back_pressure_enabled;
-    bool window_update_in_progress;
+    bool window_update_scheduled;
 };
 
 struct channel_setup_args {
@@ -833,6 +833,8 @@ static void s_window_update_task(struct aws_channel_task *channel_task, void *ar
     (void)channel_task;
     struct aws_channel *channel = arg;
 
+    channel->window_update_scheduled = false;
+
     if (status == AWS_TASK_STATUS_RUN_READY && channel->channel_state < AWS_CHANNEL_SHUTTING_DOWN) {
         /* get the right-most slot to start the updates. */
         struct aws_channel_slot *slot = channel->first;
@@ -852,7 +854,6 @@ static void s_window_update_task(struct aws_channel_task *channel_task, void *ar
                         "channel %p: channel update task failed with status %d",
                         (void *)slot->channel,
                         aws_last_error());
-                    slot->channel->window_update_in_progress = false;
                     aws_channel_shutdown(channel, aws_last_error());
                     return;
                 }
@@ -860,7 +861,6 @@ static void s_window_update_task(struct aws_channel_task *channel_task, void *ar
             slot = slot->adj_left;
         }
     }
-    channel->window_update_in_progress = false;
 }
 
 int aws_channel_slot_increment_read_window(struct aws_channel_slot *slot, size_t window) {
@@ -869,9 +869,9 @@ int aws_channel_slot_increment_read_window(struct aws_channel_slot *slot, size_t
         slot->current_window_update_batch_size =
             aws_add_size_saturating(slot->current_window_update_batch_size, window);
 
-        if (!slot->channel->window_update_in_progress &&
+        if (!slot->channel->window_update_scheduled &&
             slot->window_size <= slot->channel->window_update_batch_emit_threshold) {
-            slot->channel->window_update_in_progress = true;
+            slot->channel->window_update_scheduled = true;
             aws_channel_task_init(
                 &slot->channel->window_update_task, s_window_update_task, slot->channel, "window update task");
             aws_channel_schedule_task_now(slot->channel, &slot->channel->window_update_task);


### PR DESCRIPTION
**Issue:**
Turns out, if `aws_channel_slot_increment_read_window()` was called while the "window update task" was running, the "window update task" would not get rescheduled to run again.

I was writing read-window-update tests for the python WebSocket bindings, and the test was failing as the read window approached 0. Here's how it played out:
- the WebSocket started with a read window of 500 bytes
- a 1000 byte payload (total frame size 1004) was sent to the WebSocket
- the HTTP handler sent along the first 500/1004 bytes
- the WebSocket processes this, but since the first 4 bytes were frame metadata that it doesn't count against the read window, it increments its read window by 4 bytes
- but due to this bug, the "window update task" DOES NOT get rescheduled
- and my test would fail because it received 4 less bytes than it expected

**Description of changes:**
Fix rescheduling logic for "window update task"

**Rant about tests:**
I lost a few hours trying to add a regression test here in aws-c-io. First, I tried adding to the existing `socket_handler_echo_and_backpressure` test to reproduce my issue, but it didn't fail! Turns out, the bug can only occur when you have 3+ handlers in the channel. Then I started modifying the `read_write_test_handler` so that it could serve as a proper "midchannel" handler that buffers up frames if necessary before sending them downstream. Then realized this would be more work complex than making a new type of test-handler that solely functions as a midchannel handler. Then realized at this point we'd be better off adding true integration tests for websocket that exercise the REAL stack of handlers, instead of a bunch of test handlers. Then realized this would take days, and I already had the new python tests I was working on that exercise the real stack of handlers... so yeah. I'll just rely on the [tests I'm adding in aws-crt-python](https://github.com/awslabs/aws-crt-python/pull/429) for now, but we should probably add integration tests in aws-c-http someday.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
