### PR TITLE
stop checking errno after failed aws_fopen()

### DIFF
--- a/source/stream.c
+++ b/source/stream.c
@@ -289,7 +289,6 @@ struct aws_input_stream *aws_input_stream_new_from_file(struct aws_allocator *al
 
     impl->file = aws_fopen(file_name, "r+b");
     if (impl->file == NULL) {
-        aws_translate_and_raise_io_error(errno);
         goto on_error;
     }
 


### PR DESCRIPTION
related: https://github.com/awslabs/aws-c-common/pull/970

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
