### PR TITLE
Fix possible crash when host resolver returns two addresses.

### DIFF
--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -144,7 +144,6 @@ struct client_connection_args {
 
 static struct client_connection_args *s_client_connection_args_acquire(struct client_connection_args *args) {
     if (args != NULL) {
-        AWS_LOGF_ERROR(AWS_LS_IO_CHANNEL_BOOTSTRAP, "id=%p: s_client_connection_args_acquire", (void *)args);
         aws_ref_count_acquire(&args->ref_count);
     }
 
@@ -153,7 +152,6 @@ static struct client_connection_args *s_client_connection_args_acquire(struct cl
 
 static void s_client_connection_args_destroy(struct client_connection_args *args) {
     AWS_ASSERT(args);
-    AWS_LOGF_ERROR(AWS_LS_IO_CHANNEL_BOOTSTRAP, "id=%p: client_connection_args_destroy", (void *)args);
 
     struct aws_allocator *allocator = args->bootstrap->allocator;
     aws_client_bootstrap_release(args->bootstrap);
@@ -170,7 +168,6 @@ static void s_client_connection_args_destroy(struct client_connection_args *args
 
 static void s_client_connection_args_release(struct client_connection_args *args) {
     if (args != NULL) {
-        AWS_LOGF_ERROR(AWS_LS_IO_CHANNEL_BOOTSTRAP, "id=%p: s_client_connection_args_release", (void *)args);
         aws_ref_count_release(&args->ref_count);
     }
 }

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -144,6 +144,7 @@ struct client_connection_args {
 
 static struct client_connection_args *s_client_connection_args_acquire(struct client_connection_args *args) {
     if (args != NULL) {
+        AWS_LOGF_ERROR(AWS_LS_IO_CHANNEL_BOOTSTRAP, "id=%p: s_client_connection_args_acquire", (void *)args);
         aws_ref_count_acquire(&args->ref_count);
     }
 
@@ -152,6 +153,7 @@ static struct client_connection_args *s_client_connection_args_acquire(struct cl
 
 static void s_client_connection_args_destroy(struct client_connection_args *args) {
     AWS_ASSERT(args);
+    AWS_LOGF_ERROR(AWS_LS_IO_CHANNEL_BOOTSTRAP, "id=%p: client_connection_args_destroy", (void *)args);
 
     struct aws_allocator *allocator = args->bootstrap->allocator;
     aws_client_bootstrap_release(args->bootstrap);
@@ -168,6 +170,7 @@ static void s_client_connection_args_destroy(struct client_connection_args *args
 
 static void s_client_connection_args_release(struct client_connection_args *args) {
     if (args != NULL) {
+        AWS_LOGF_ERROR(AWS_LS_IO_CHANNEL_BOOTSTRAP, "id=%p: s_client_connection_args_release", (void *)args);
         aws_ref_count_release(&args->ref_count);
     }
 }

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -25,7 +25,7 @@
 
 static void s_client_bootstrap_destroy_impl(struct aws_client_bootstrap *bootstrap) {
     AWS_ASSERT(bootstrap);
-    AWS_LOGF_DEBUG(AWS_LS_IO_CHANNEL_BOOTSTRAP, "id=%p: destroying", (void *)bootstrap);
+    AWS_LOGF_DEBUG(AWS_LS_IO_CHANNEL_BOOTSTRAP, "id=%p: bootstrap destroying", (void *)bootstrap);
     aws_client_bootstrap_shutdown_complete_fn *on_shutdown_complete = bootstrap->on_shutdown_complete;
     void *user_data = bootstrap->user_data;
 
@@ -41,6 +41,7 @@ static void s_client_bootstrap_destroy_impl(struct aws_client_bootstrap *bootstr
 
 struct aws_client_bootstrap *aws_client_bootstrap_acquire(struct aws_client_bootstrap *bootstrap) {
     if (bootstrap != NULL) {
+        AWS_LOGF_DEBUG(AWS_LS_IO_CHANNEL_BOOTSTRAP, "id=%p: acquiring bootstrap reference", (void *)bootstrap);
         aws_ref_count_acquire(&bootstrap->ref_count);
     }
 
@@ -48,8 +49,8 @@ struct aws_client_bootstrap *aws_client_bootstrap_acquire(struct aws_client_boot
 }
 
 void aws_client_bootstrap_release(struct aws_client_bootstrap *bootstrap) {
-    AWS_LOGF_DEBUG(AWS_LS_IO_CHANNEL_BOOTSTRAP, "id=%p: releasing bootstrap reference", (void *)bootstrap);
     if (bootstrap != NULL) {
+        AWS_LOGF_DEBUG(AWS_LS_IO_CHANNEL_BOOTSTRAP, "id=%p: releasing bootstrap reference", (void *)bootstrap);
         aws_ref_count_release(&bootstrap->ref_count);
     }
 }
@@ -144,6 +145,7 @@ struct client_connection_args {
 
 static struct client_connection_args *s_client_connection_args_acquire(struct client_connection_args *args) {
     if (args != NULL) {
+        AWS_LOGF_TRACE(AWS_LS_IO_CHANNEL_BOOTSTRAP, "acquiring client connection args, args=%p", (void *)args);
         aws_ref_count_acquire(&args->ref_count);
     }
 
@@ -152,6 +154,7 @@ static struct client_connection_args *s_client_connection_args_acquire(struct cl
 
 static void s_client_connection_args_destroy(struct client_connection_args *args) {
     AWS_ASSERT(args);
+    AWS_LOGF_TRACE(AWS_LS_IO_CHANNEL_BOOTSTRAP, "destroying client connection args, args=%p", (void *)args);
 
     struct aws_allocator *allocator = args->bootstrap->allocator;
     aws_client_bootstrap_release(args->bootstrap);
@@ -168,6 +171,7 @@ static void s_client_connection_args_destroy(struct client_connection_args *args
 
 static void s_client_connection_args_release(struct client_connection_args *args) {
     if (args != NULL) {
+        AWS_LOGF_TRACE(AWS_LS_IO_CHANNEL_BOOTSTRAP, "releasing client connection args, args=%p", (void *)args);
         aws_ref_count_release(&args->ref_count);
     }
 }

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -192,18 +192,17 @@ static void s_connection_args_setup_callback(
     int error_code,
     struct aws_channel *channel) {
     /* setup_callback is always called exactly once */
-    AWS_ASSERT(!args->setup_called);
-    if (!args->setup_called) {
-        AWS_ASSERT((error_code == AWS_OP_SUCCESS) == (channel != NULL));
-        aws_client_bootstrap_on_channel_event_fn *setup_callback = args->setup_callback;
-        setup_callback(args->bootstrap, error_code, channel, args->user_data);
-        args->setup_called = true;
-        /* if setup_callback is called with an error, we will not call shutdown_callback */
-        if (error_code) {
-            args->shutdown_callback = NULL;
-        }
-        s_client_connection_args_release(args);
+    AWS_FATAL_ASSERT(!args->setup_called);
+
+    AWS_ASSERT((error_code == AWS_OP_SUCCESS) == (channel != NULL));
+    aws_client_bootstrap_on_channel_event_fn *setup_callback = args->setup_callback;
+    setup_callback(args->bootstrap, error_code, channel, args->user_data);
+    args->setup_called = true;
+    /* if setup_callback is called with an error, we will not call shutdown_callback */
+    if (error_code) {
+        args->shutdown_callback = NULL;
     }
+    s_client_connection_args_release(args);
 }
 
 static void s_connection_args_creation_callback(struct client_connection_args *args, struct aws_channel *channel) {
@@ -699,9 +698,19 @@ static void s_on_host_resolved(
     /* ...then schedule all the tasks, which cannot fail */
     for (size_t i = 0; i < host_addresses_len; ++i) {
         struct connection_task_data *task_data = tasks[i];
-        /* each task needs to hold a ref to the args until completed */
+        /**
+         * Acquire on the connection args to make sure connection args outlive the tasks to attempt connection.
+         *
+         * Once upon a time, the connection attempt tasks were scheduled right after acquiring the connection args,
+         * which lead to a crash that when the attempt connection tasks run and the attempt connection succeed and
+         * closed before the other tasks can acquire on the connection args, the connection args had be destroyed before
+         * acquire and lead to a crash.
+         */
         s_client_connection_args_acquire(task_data->args);
+    }
 
+    for (size_t i = 0; i < host_addresses_len; ++i) {
+        struct connection_task_data *task_data = tasks[i];
         aws_task_init(&task_data->task, s_attempt_connection, task_data, "attempt_connection");
         aws_event_loop_schedule_task_now(connect_loop, &task_data->task);
     }


### PR DESCRIPTION
- When host resolver returns two addresses and one `s_attempt_connection` can happen before the second one ever acquire on `client_connection_args`
- If the attempt on connection succeed and **SHUTDOWN** successful before the second address try to acquire on `client_connection_args`. The `client_connection_args` has already destroyed and lead to a crash.

Related log:
```
[2023-01-18T19:57:50Z] [00001550] [channel-bootstrap] - id=0000016B8C15B3E0: dns resolution completed. Kicking off connections on 2 addresses. First one back wins.
[2023-01-18T19:57:50Z] [00001550] [channel-bootstrap] - id=0000016B8CD57F90: s_client_connection_args_acquire
[2023-01-18T19:57:50Z] [00001550] [event-loop] - id=0000016B8C15C040: Scheduling task 0000016B8C1E5960 cross-thread for timestamp 0
[2023-01-18T19:57:50Z] [00001550] [event-loop] - id=0000016B8C15C040: Waking up event-loop thread
[2023-01-18T19:57:50Z] [00001550] [event-loop] - id=0000016B8C15C040: notified of cross-thread tasks to schedule
[2023-01-18T19:57:50Z] [00001028] [event-loop] - id=0000016B8C15C040: wake up with 1 events to process.
[2023-01-18T19:57:50Z] [00001028] [event-loop] - id=0000016B8C15C040: notified of cross-thread tasks to schedule
[2023-01-18T19:57:50Z] [00001028] [task-scheduler] - id=0000016B8C1E5960: Scheduling attempt_connection task for immediate execution
[2023-01-18T19:57:50Z] [00001028] [event-loop] - id=0000016B8C15C040: running scheduled tasks.
[2023-01-18T19:57:50Z] [00001028] [task-scheduler] - id=0000016B8C1E5960: Running attempt_connection task with <Running> status

***

[2023-01-18T19:57:50Z] [00001028] [task-scheduler] - id=0000016B8C1E1E98: Scheduling http1_connection_cross_thread_work task for immediate execution
[2023-01-18T19:57:50Z] [00001028] [channel-bootstrap] - id=0000016B8CD57F90: s_client_connection_args_release

***

[2023-01-18T19:57:50Z] [00001028] [socket] - id=0000016B8C1C03E0, handle=FFFFFFFFFFFFFFFF: cleaning up socket.
[2023-01-18T19:57:50Z] [00001028] [socket] - id=0000016B8C1C03E0 handle=FFFFFFFFFFFFFFFF: closing
[2023-01-18T19:57:50Z] [00001028] [channel-bootstrap] - id=0000016B8CD57F90: s_client_connection_args_release
[2023-01-18T19:57:50Z] [00001028] [channel-bootstrap] - id=0000016B8CD57F90: client_connection_args_destroy

***

[2023-01-18T19:57:50Z] [00001550] [channel-bootstrap] - id=0000016B8CD57F90: s_client_connection_args_acquire

```


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
