### PR TITLE
Use const in record_connection_failure

### DIFF
--- a/include/aws/io/host_resolver.h
+++ b/include/aws/io/host_resolver.h
@@ -91,7 +91,7 @@ struct aws_host_resolver_vtable {
     /** gives your implementation a hint that an address has some failed connections occuring. Do whatever you want (or
      * nothing) about it.
      */
-    int (*record_connection_failure)(struct aws_host_resolver *resolver, struct aws_host_address *address);
+    int (*record_connection_failure)(struct aws_host_resolver *resolver, const struct aws_host_address *address);
     /** wipe out anything you have cached. */
     int (*purge_cache)(struct aws_host_resolver *resolver);
     /** get number of addresses for a given host. */
@@ -212,7 +212,7 @@ AWS_IO_API int aws_host_resolver_resolve_host(
  */
 AWS_IO_API int aws_host_resolver_record_connection_failure(
     struct aws_host_resolver *resolver,
-    struct aws_host_address *address);
+    const struct aws_host_address *address);
 
 /**
  * calls purge_cache on the vtable.

--- a/source/host_resolver.c
+++ b/source/host_resolver.c
@@ -80,7 +80,9 @@ int aws_host_resolver_purge_cache(struct aws_host_resolver *resolver) {
     return resolver->vtable->purge_cache(resolver);
 }
 
-int aws_host_resolver_record_connection_failure(struct aws_host_resolver *resolver, struct aws_host_address *address) {
+int aws_host_resolver_record_connection_failure(
+    struct aws_host_resolver *resolver,
+    const struct aws_host_address *address) {
     AWS_ASSERT(resolver->vtable && resolver->vtable->record_connection_failure);
     return resolver->vtable->record_connection_failure(resolver, address);
 }
@@ -547,7 +549,9 @@ static inline void process_records(
     }
 }
 
-static int resolver_record_connection_failure(struct aws_host_resolver *resolver, struct aws_host_address *address) {
+static int resolver_record_connection_failure(
+    struct aws_host_resolver *resolver,
+    const struct aws_host_address *address) {
     struct default_host_resolver *default_host_resolver = resolver->impl;
 
     AWS_LOGF_INFO(


### PR DESCRIPTION
*Description of changes:*
- Adds const for `aws_host_address` in `record_connection_failure` to make it easier to bind in Swift.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
