### PR TITLE
Teach c-io where to find the PKI trust store on OpenBSD

### DIFF
--- a/include/aws/io/private/pki_utils.h
+++ b/include/aws/io/private/pki_utils.h
@@ -39,6 +39,13 @@ AWS_IO_API int aws_decode_pem_to_buffer_list(
     struct aws_array_list *cert_chain_or_key);
 
 /**
+ * Returns the path to the directory and file, respectively, which holds the
+ * SSL certificate trust store on the system.
+ */
+AWS_IO_API const char *aws_determine_default_pki_dir(void);
+AWS_IO_API const char *aws_determine_default_pki_ca_file(void);
+
+/**
  * Decodes a PEM file at 'filename' and adds the results to 'cert_chain_or_key' if successful.
  * Otherwise, 'cert_chain_or_key' will be empty.
  * The passed-in parameter 'cert_chain_or_key' should be empty and dynamically initialized array_list

--- a/include/aws/io/tls_channel_handler.h
+++ b/include/aws/io/tls_channel_handler.h
@@ -13,9 +13,6 @@ struct aws_channel_handler;
 struct aws_pkcs11_session;
 struct aws_string;
 
-const char *s_determine_default_pki_dir(void);
-const char *s_determine_default_pki_ca_file(void);
-
 enum aws_tls_versions {
     AWS_IO_SSLv3,
     AWS_IO_TLSv1,

--- a/include/aws/io/tls_channel_handler.h
+++ b/include/aws/io/tls_channel_handler.h
@@ -13,6 +13,9 @@ struct aws_channel_handler;
 struct aws_pkcs11_session;
 struct aws_string;
 
+const char *s_determine_default_pki_dir(void);
+const char *s_determine_default_pki_ca_file(void);
+
 enum aws_tls_versions {
     AWS_IO_SSLv3,
     AWS_IO_TLSv1,

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -120,12 +120,12 @@ static const char *s_determine_default_pki_dir(void) {
         return aws_string_c_str(s_android_path);
     }
 
-    /* Free BSD */
+    /* FreeBSD */
     if (aws_path_exists(s_free_bsd_path)) {
         return aws_string_c_str(s_free_bsd_path);
     }
 
-    /* Net BSD */
+    /* NetBSD */
     if (aws_path_exists(s_net_bsd_path)) {
         return aws_string_c_str(s_net_bsd_path);
     }
@@ -138,6 +138,7 @@ AWS_STATIC_STRING_FROM_LITERAL(s_old_rhel_ca_file_path, "/etc/pki/tls/certs/ca-b
 AWS_STATIC_STRING_FROM_LITERAL(s_open_suse_ca_file_path, "/etc/ssl/ca-bundle.pem");
 AWS_STATIC_STRING_FROM_LITERAL(s_open_elec_ca_file_path, "/etc/pki/tls/cacert.pem");
 AWS_STATIC_STRING_FROM_LITERAL(s_modern_rhel_ca_file_path, "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem");
+AWS_STATIC_STRING_FROM_LITERAL(s_openbsd_ca_file_path, "/etc/ssl/cert.pem");
 
 static const char *s_determine_default_pki_ca_file(void) {
     /* debian variants */
@@ -163,6 +164,11 @@ static const char *s_determine_default_pki_ca_file(void) {
     /* Modern RHEL variants */
     if (aws_path_exists(s_modern_rhel_ca_file_path)) {
         return aws_string_c_str(s_modern_rhel_ca_file_path);
+    }
+
+    /* OpenBSD */
+    if (aws_path_exists(s_openbsd_ca_file_path)) {
+        return aws_string_c_str(s_openbsd_ca_file_path);
     }
 
     return NULL;

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -104,7 +104,7 @@ AWS_STATIC_STRING_FROM_LITERAL(s_android_path, "/system/etc/security/cacerts");
 AWS_STATIC_STRING_FROM_LITERAL(s_free_bsd_path, "/usr/local/share/certs");
 AWS_STATIC_STRING_FROM_LITERAL(s_net_bsd_path, "/etc/openssl/certs");
 
-static const char *s_determine_default_pki_dir(void) {
+const char *s_determine_default_pki_dir(void) {
     /* debian variants */
     if (aws_path_exists(s_debian_path)) {
         return aws_string_c_str(s_debian_path);
@@ -140,7 +140,7 @@ AWS_STATIC_STRING_FROM_LITERAL(s_open_elec_ca_file_path, "/etc/pki/tls/cacert.pe
 AWS_STATIC_STRING_FROM_LITERAL(s_modern_rhel_ca_file_path, "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem");
 AWS_STATIC_STRING_FROM_LITERAL(s_openbsd_ca_file_path, "/etc/ssl/cert.pem");
 
-static const char *s_determine_default_pki_ca_file(void) {
+const char *s_determine_default_pki_ca_file(void) {
     /* debian variants */
     if (aws_path_exists(s_debian_ca_file_path)) {
         return aws_string_c_str(s_debian_ca_file_path);

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -105,7 +105,7 @@ AWS_STATIC_STRING_FROM_LITERAL(s_free_bsd_path, "/usr/local/share/certs");
 AWS_STATIC_STRING_FROM_LITERAL(s_net_bsd_path, "/etc/openssl/certs");
 
 AWS_IO_API const char *aws_determine_default_pki_dir(void) {
-    /* debian variants */
+    /* debian variants; OpenBSD (although the directory doesn't exist by default) */
     if (aws_path_exists(s_debian_path)) {
         return aws_string_c_str(s_debian_path);
     }

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -104,7 +104,7 @@ AWS_STATIC_STRING_FROM_LITERAL(s_android_path, "/system/etc/security/cacerts");
 AWS_STATIC_STRING_FROM_LITERAL(s_free_bsd_path, "/usr/local/share/certs");
 AWS_STATIC_STRING_FROM_LITERAL(s_net_bsd_path, "/etc/openssl/certs");
 
-const char *s_determine_default_pki_dir(void) {
+AWS_IO_API const char *aws_determine_default_pki_dir(void) {
     /* debian variants */
     if (aws_path_exists(s_debian_path)) {
         return aws_string_c_str(s_debian_path);
@@ -140,7 +140,7 @@ AWS_STATIC_STRING_FROM_LITERAL(s_open_elec_ca_file_path, "/etc/pki/tls/cacert.pe
 AWS_STATIC_STRING_FROM_LITERAL(s_modern_rhel_ca_file_path, "/etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem");
 AWS_STATIC_STRING_FROM_LITERAL(s_openbsd_ca_file_path, "/etc/ssl/cert.pem");
 
-const char *s_determine_default_pki_ca_file(void) {
+AWS_IO_API const char *aws_determine_default_pki_ca_file(void) {
     /* debian variants */
     if (aws_path_exists(s_debian_ca_file_path)) {
         return aws_string_c_str(s_debian_ca_file_path);
@@ -204,8 +204,8 @@ void aws_tls_init_static_state(struct aws_allocator *alloc) {
         }
     }
 
-    s_default_ca_dir = s_determine_default_pki_dir();
-    s_default_ca_file = s_determine_default_pki_ca_file();
+    s_default_ca_dir = aws_determine_default_pki_dir();
+    s_default_ca_file = aws_determine_default_pki_ca_file();
     if (s_default_ca_dir || s_default_ca_file) {
         AWS_LOGF_DEBUG(
             AWS_LS_IO_TLS,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -300,6 +300,10 @@ endif()
 set(TEST_BINARY_NAME ${PROJECT_NAME}-tests)
 generate_test_driver(${TEST_BINARY_NAME})
 
+if (USE_S2N)
+    target_compile_definitions(${PROJECT_NAME}-tests PRIVATE "-DUSE_S2N")
+endif()
+
 #SSL certificates to use for testing.
 add_custom_command(TARGET ${TEST_BINARY_NAME} PRE_BUILD
         COMMAND ${CMAKE_COMMAND} -E copy_directory

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -145,6 +145,7 @@ if (NOT BYO_CRYPTO)
 
     # Badssl - Certificate Validation endpoint suite
     # For each failure case, we also include a positive test that verifies success when peer verification is disabled
+    add_test_case(default_pki_path_exists)
     add_net_test_case(tls_client_channel_negotiation_error_expired)
     add_net_test_case(tls_client_channel_negotiation_error_wrong_host)
     add_net_test_case(tls_client_channel_negotiation_error_wrong_host_with_ca_override)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -145,7 +145,9 @@ if (NOT BYO_CRYPTO)
 
     # Badssl - Certificate Validation endpoint suite
     # For each failure case, we also include a positive test that verifies success when peer verification is disabled
-    add_test_case(default_pki_path_exists)
+    if (USE_S2N)
+        add_test_case(default_pki_path_exists)
+    endif()
     add_net_test_case(tls_client_channel_negotiation_error_expired)
     add_net_test_case(tls_client_channel_negotiation_error_wrong_host)
     add_net_test_case(tls_client_channel_negotiation_error_wrong_host_with_ca_override)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -131,6 +131,10 @@ add_test_case(socket_handler_close)
 add_test_case(socket_pinned_event_loop)
 
 if (NOT BYO_CRYPTO)
+    if (USE_S2N)
+        add_net_test_case(default_pki_path_exists)
+    endif()
+
     # Badssl-based tests (https://badssl.com/dashboard/) - use remote endpoints for now, later transition to
     # internal hosting using the bad ssl container/server setup and dns redirects per
     # https://github.com/chromium/badssl.com
@@ -145,9 +149,6 @@ if (NOT BYO_CRYPTO)
 
     # Badssl - Certificate Validation endpoint suite
     # For each failure case, we also include a positive test that verifies success when peer verification is disabled
-    if (USE_S2N)
-        add_test_case(default_pki_path_exists)
-    endif()
     add_net_test_case(tls_client_channel_negotiation_error_expired)
     add_net_test_case(tls_client_channel_negotiation_error_wrong_host)
     add_net_test_case(tls_client_channel_negotiation_error_wrong_host_with_ca_override)

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -23,6 +23,8 @@
 #    include <read_write_test_handler.h>
 #    include <statistics_handler_test.h>
 
+#    include <aws/io/private/pki_utils.h>
+
 #    ifdef _WIN32
 #        define LOCAL_SOCK_TEST_PATTERN "\\\\.\\pipe\\testsock%llu_%d"
 #    else

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -810,6 +810,9 @@ static int s_verify_negotiation_fails_with_ca_override(
 }
 
 static int s_default_pki_path_exists_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+    (void)allocator;
+
     const char *dir = s_determine_default_pki_dir();
     const char *file = s_determine_default_pki_ca_file();
 

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -809,7 +809,7 @@ static int s_verify_negotiation_fails_with_ca_override(
     return AWS_OP_SUCCESS;
 }
 
-#if defined(USE_S2N)
+#   if defined(USE_S2N)
 static int s_default_pki_path_exists_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
     (void)allocator;
@@ -823,7 +823,7 @@ static int s_default_pki_path_exists_fn(struct aws_allocator *allocator, void *c
 }
 
 AWS_TEST_CASE(default_pki_path_exists, s_default_pki_path_exists_fn)
-#endif /* defined(USE_S2N) */
+#   endif /* defined(USE_S2N) */
 
 AWS_STATIC_STRING_FROM_LITERAL(s_expired_host_name, "expired.badssl.com");
 

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -809,7 +809,7 @@ static int s_verify_negotiation_fails_with_ca_override(
     return AWS_OP_SUCCESS;
 }
 
-#   if defined(USE_S2N)
+#    if defined(USE_S2N)
 static int s_default_pki_path_exists_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
     (void)allocator;
@@ -823,7 +823,7 @@ static int s_default_pki_path_exists_fn(struct aws_allocator *allocator, void *c
 }
 
 AWS_TEST_CASE(default_pki_path_exists, s_default_pki_path_exists_fn)
-#   endif /* defined(USE_S2N) */
+#    endif /* defined(USE_S2N) */
 
 AWS_STATIC_STRING_FROM_LITERAL(s_expired_host_name, "expired.badssl.com");
 

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -814,8 +814,8 @@ static int s_default_pki_path_exists_fn(struct aws_allocator *allocator, void *c
     (void)ctx;
     (void)allocator;
 
-    const char *dir = s_determine_default_pki_dir();
-    const char *file = s_determine_default_pki_ca_file();
+    const char *dir = aws_determine_default_pki_dir();
+    const char *file = aws_determine_default_pki_ca_file();
 
     ASSERT_TRUE(dir != NULL || file != NULL);
 

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -809,6 +809,7 @@ static int s_verify_negotiation_fails_with_ca_override(
     return AWS_OP_SUCCESS;
 }
 
+#if defined(USE_S2N)
 static int s_default_pki_path_exists_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
     (void)allocator;
@@ -822,6 +823,7 @@ static int s_default_pki_path_exists_fn(struct aws_allocator *allocator, void *c
 }
 
 AWS_TEST_CASE(default_pki_path_exists, s_default_pki_path_exists_fn)
+#endif /* defined(USE_S2N) */
 
 AWS_STATIC_STRING_FROM_LITERAL(s_expired_host_name, "expired.badssl.com");
 

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -809,7 +809,7 @@ static int s_verify_negotiation_fails_with_ca_override(
     return AWS_OP_SUCCESS;
 }
 
-static int s_default_pki_path_exists_fn() {
+static int s_default_pki_path_exists_fn(struct aws_allocator *allocator, void *ctx) {
     const char *dir = s_determine_default_pki_dir();
     const char *file = s_determine_default_pki_ca_file();
 

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -816,10 +816,14 @@ static int s_default_pki_path_exists_fn(struct aws_allocator *allocator, void *c
     (void)ctx;
     (void)allocator;
 
-    const char *dir = aws_determine_default_pki_dir();
-    const char *file = aws_determine_default_pki_ca_file();
-
-    ASSERT_TRUE(dir != NULL || file != NULL);
+#        if !defined(__OpenBSD__)
+    /*
+     * OpenBSD's standard PKI directory doesn't exist on fresh installs which means this
+     * test will normally fail.
+     */
+    ASSERT_NOT_NULL(aws_determine_default_pki_dir());
+#        endif /* __OpenBSD__ */
+    ASSERT_NOT_NULL(aws_determine_default_pki_ca_file());
 
     return AWS_OP_SUCCESS;
 }

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -809,6 +809,17 @@ static int s_verify_negotiation_fails_with_ca_override(
     return AWS_OP_SUCCESS;
 }
 
+static int s_default_pki_path_exists_fn() {
+    const char *dir = s_determine_default_pki_dir();
+    const char *file = s_determine_default_pki_ca_file();
+
+    ASSERT_TRUE(dir != NULL || file != NULL);
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(default_pki_path_exists, s_default_pki_path_exists_fn)
+
 AWS_STATIC_STRING_FROM_LITERAL(s_expired_host_name, "expired.badssl.com");
 
 static int s_tls_client_channel_negotiation_error_expired_fn(struct aws_allocator *allocator, void *ctx) {


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

This PR teaches c-io where to find the PKI trust store on OpenBSD systems. It also includes a new test case to make identifying failures to find the trust store easier to pick out.

Prior to the changes in this PR, most (all?) of the tls_* unit tests were segfaulting on OpenBSD and I wasn't able to root cause it. It was a crt-python unit test which gave me a clue where to look because it threw a `AWS_IO_TLS_ERROR_DEFAULT_TRUST_STORE_NOT_FOUND` error. Having a test case for the PKI trust store location would've saved me an awful lot of head scratching.

With this PR, all unit tests in c-io pass on OpenBSD.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
