### PR TITLE
Fix DNS starvation case

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -100,6 +100,7 @@ add_net_test_case(test_default_with_ipv4_only_lookup)
 add_test_case(test_resolver_ttls)
 add_test_case(test_resolver_connect_failure_recording)
 add_test_case(test_resolver_ttl_refreshes_on_resolve)
+add_test_case(test_resolver_low_frequency_starvation)
 
 add_test_case(test_pem_single_cert_parse)
 add_test_case(test_pem_private_key_parse)


### PR DESCRIPTION
Fix a starvation problem in DNS resolution when resolution frequency is very low.  Uncovered by the JS CRT testing suite because the JS CRT uses a global host resolver and connection failures against localhost were locking out resolution for later tests.

Problem summary:

Failed connection attempts cause the host resolver to classify an address as temporarily "bad."  While a "bad" address may later be promoted to "good", only "good" addresses are considered when resolution requests arrive while the host resolver is asleep between resolution attempts.  This leads to a situation where an initial failed connection can lock out followup connection attempts if the resolve frequency is very low.

Solution:

Allow resolution requests where no good addresses are present to interrupt the resolver thread's (potentially long) wait between resolution attempts.

Additional Note:

Test was verified to fail (badly) against the old behavior

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
