### PR TITLE
Relax the default_pki_path_exists test.

### DIFF
--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -816,15 +816,9 @@ static int s_default_pki_path_exists_fn(struct aws_allocator *allocator, void *c
     (void)ctx;
     (void)allocator;
 
-#        if !defined(__OpenBSD__)
-    /*
-     * OpenBSD's standard PKI directory doesn't exist on fresh installs which means this
-     * test will normally fail.
-     */
-    ASSERT_NOT_NULL(aws_determine_default_pki_dir());
-#        endif /* __OpenBSD__ */
-    ASSERT_NOT_NULL(aws_determine_default_pki_ca_file());
-
+    ASSERT_TRUE(
+        aws_determine_default_pki_dir() != NULL || aws_determine_default_pki_ca_file() != NULL,
+        "Default TLS trust store not found on this system.");
     return AWS_OP_SUCCESS;
 }
 


### PR DESCRIPTION
**Issue:**
https://github.com/awslabs/aws-c-io/issues/565#issuecomment-1517531311

**Description of changes:**
Change test so it only requires 1 trust store location to exist, instead of requiring both.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
