### PR TITLE
Use UUID for socket endpoints

### DIFF
--- a/include/aws/io/socket.h
+++ b/include/aws/io/socket.h
@@ -302,6 +302,12 @@ AWS_IO_API int aws_socket_get_error(struct aws_socket *socket);
  */
 AWS_IO_API bool aws_socket_is_open(struct aws_socket *socket);
 
+/**
+ * Assigns a random address (UUID) for use with AWS_SOCKET_LOCAL (Unix Domain Sockets).
+ * For use in internal tests only.
+ */
+AWS_IO_API void aws_socket_endpoint_init_local_address_for_test(struct aws_socket_endpoint *endpoint);
+
 AWS_EXTERN_C_END
 AWS_POP_SANE_WARNING_LEVEL
 

--- a/source/posix/socket.c
+++ b/source/posix/socket.c
@@ -1911,11 +1911,11 @@ bool aws_socket_is_open(struct aws_socket *socket) {
 
 void aws_socket_endpoint_init_local_address_for_test(struct aws_socket_endpoint *endpoint) {
     struct aws_uuid uuid;
-    AWS_FATAL_ASSERT(aws_uuid_init(&uuid));
+    AWS_FATAL_ASSERT(aws_uuid_init(&uuid) == AWS_OP_SUCCESS);
     char uuid_str[AWS_UUID_STR_LEN] = {0};
     struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
     uuid_buf.len = 0;
-    AWS_FATAL_ASSERT(aws_uuid_to_str(&uuid, &uuid_buf));
+    AWS_FATAL_ASSERT(aws_uuid_to_str(&uuid, &uuid_buf) == AWS_OP_SUCCESS);
     snprintf(
-        endpoint->address, sizeof(endpoint->address), "testsock" PRInSTR ".sock" PRInSTR, AWS_BYTE_BUF_PRI(uuid_buf));
+        endpoint->address, sizeof(endpoint->address), "testsock" PRInSTR ".sock", AWS_BYTE_BUF_PRI(uuid_buf));
 }

--- a/source/posix/socket.c
+++ b/source/posix/socket.c
@@ -1913,8 +1913,7 @@ void aws_socket_endpoint_init_local_address_for_test(struct aws_socket_endpoint 
     struct aws_uuid uuid;
     AWS_FATAL_ASSERT(aws_uuid_init(&uuid) == AWS_OP_SUCCESS);
     char uuid_str[AWS_UUID_STR_LEN] = {0};
-    struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
-    uuid_buf.len = 0;
+    struct aws_byte_buf uuid_buf = aws_byte_buf_from_empty_array(uuid_str, sizeof(uuid_str));
     AWS_FATAL_ASSERT(aws_uuid_to_str(&uuid, &uuid_buf) == AWS_OP_SUCCESS);
     snprintf(endpoint->address, sizeof(endpoint->address), "testsock" PRInSTR ".sock", AWS_BYTE_BUF_PRI(uuid_buf));
 }

--- a/source/posix/socket.c
+++ b/source/posix/socket.c
@@ -1916,6 +1916,5 @@ void aws_socket_endpoint_init_local_address_for_test(struct aws_socket_endpoint 
     struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
     uuid_buf.len = 0;
     AWS_FATAL_ASSERT(aws_uuid_to_str(&uuid, &uuid_buf) == AWS_OP_SUCCESS);
-    snprintf(
-        endpoint->address, sizeof(endpoint->address), "testsock" PRInSTR ".sock", AWS_BYTE_BUF_PRI(uuid_buf));
+    snprintf(endpoint->address, sizeof(endpoint->address), "testsock" PRInSTR ".sock", AWS_BYTE_BUF_PRI(uuid_buf));
 }

--- a/source/posix/socket.c
+++ b/source/posix/socket.c
@@ -9,6 +9,7 @@
 #include <aws/common/condition_variable.h>
 #include <aws/common/mutex.h>
 #include <aws/common/string.h>
+#include <aws/common/uuid.h>
 
 #include <aws/io/event_loop.h>
 #include <aws/io/logging.h>
@@ -1906,4 +1907,15 @@ int aws_socket_get_error(struct aws_socket *socket) {
 
 bool aws_socket_is_open(struct aws_socket *socket) {
     return socket->io_handle.data.fd >= 0;
+}
+
+void aws_socket_endpoint_init_local_address_for_test(struct aws_socket_endpoint *endpoint) {
+    struct aws_uuid uuid;
+    AWS_FATAL_ASSERT(aws_uuid_init(&uuid));
+    char uuid_str[AWS_UUID_STR_LEN] = {0};
+    struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
+    uuid_buf.len = 0;
+    AWS_FATAL_ASSERT(aws_uuid_to_str(&uuid, &uuid_buf));
+    snprintf(
+        endpoint->address, sizeof(endpoint->address), "testsock" PRInSTR ".sock" PRInSTR, AWS_BYTE_BUF_PRI(uuid_buf));
 }

--- a/source/windows/iocp/socket.c
+++ b/source/windows/iocp/socket.c
@@ -21,6 +21,7 @@ below, clang-format doesn't work (at least on my version) with the c-style comme
 #include <aws/common/condition_variable.h>
 #include <aws/common/mutex.h>
 #include <aws/common/task_scheduler.h>
+#include <aws/common/uuid.h>
 
 #include <aws/io/event_loop.h>
 #include <aws/io/logging.h>
@@ -3231,4 +3232,14 @@ int aws_socket_get_error(struct aws_socket *socket) {
 
 bool aws_socket_is_open(struct aws_socket *socket) {
     return socket->io_handle.data.handle != INVALID_HANDLE_VALUE;
+}
+
+void aws_socket_endpoint_init_local_address_for_test(struct aws_socket_endpoint *endpoint) {
+    struct aws_uuid uuid;
+    AWS_FATAL_ASSERT(aws_uuid_init(&uuid));
+    char uuid_str[AWS_UUID_STR_LEN] = {0};
+    struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
+    uuid_buf.len = 0;
+    AWS_FATAL_ASSERT(aws_uuid_to_str(&uuid, &uuid_buf));
+    snprintf(endpoint->address, sizeof(endpoint->address), "\\\\.\\pipe\\testsock" PRInSTR, AWS_BYTE_BUF_PRI(uuid_buf));
 }

--- a/source/windows/iocp/socket.c
+++ b/source/windows/iocp/socket.c
@@ -3238,8 +3238,7 @@ void aws_socket_endpoint_init_local_address_for_test(struct aws_socket_endpoint 
     struct aws_uuid uuid;
     AWS_FATAL_ASSERT(aws_uuid_init(&uuid) == AWS_OP_SUCCESS);
     char uuid_str[AWS_UUID_STR_LEN] = {0};
-    struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
-    uuid_buf.len = 0;
+    struct aws_byte_buf uuid_buf = aws_byte_buf_from_empty_array(uuid_str, sizeof(uuid_str));
     AWS_FATAL_ASSERT(aws_uuid_to_str(&uuid, &uuid_buf) == AWS_OP_SUCCESS);
     snprintf(endpoint->address, sizeof(endpoint->address), "\\\\.\\pipe\\testsock" PRInSTR, AWS_BYTE_BUF_PRI(uuid_buf));
 }

--- a/source/windows/iocp/socket.c
+++ b/source/windows/iocp/socket.c
@@ -3236,10 +3236,10 @@ bool aws_socket_is_open(struct aws_socket *socket) {
 
 void aws_socket_endpoint_init_local_address_for_test(struct aws_socket_endpoint *endpoint) {
     struct aws_uuid uuid;
-    AWS_FATAL_ASSERT(aws_uuid_init(&uuid));
+    AWS_FATAL_ASSERT(aws_uuid_init(&uuid) == AWS_OP_SUCCESS);
     char uuid_str[AWS_UUID_STR_LEN] = {0};
     struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
     uuid_buf.len = 0;
-    AWS_FATAL_ASSERT(aws_uuid_to_str(&uuid, &uuid_buf));
+    AWS_FATAL_ASSERT(aws_uuid_to_str(&uuid, &uuid_buf) == AWS_OP_SUCCESS);
     snprintf(endpoint->address, sizeof(endpoint->address), "\\\\.\\pipe\\testsock" PRInSTR, AWS_BYTE_BUF_PRI(uuid_buf));
 }

--- a/tests/byo_crypto_test.c
+++ b/tests/byo_crypto_test.c
@@ -20,17 +20,12 @@
 #    include <aws/common/atomics.h>
 #    include <aws/common/clock.h>
 #    include <aws/common/condition_variable.h>
+#    include <aws/common/uuid.h>
 
 #    include <aws/testing/aws_test_harness.h>
 
 #    include "statistics_handler_test.h"
 #    include <read_write_test_handler.h>
-
-#    ifdef _WIN32
-#        define LOCAL_SOCK_TEST_PATTERN "\\\\.\\pipe\\testsock%llu"
-#    else
-#        define LOCAL_SOCK_TEST_PATTERN "testsock%llu.sock"
-#    endif
 
 struct byo_crypto_test_args {
     struct aws_allocator *allocator;
@@ -84,7 +79,6 @@ struct local_server_tester {
     struct aws_socket_endpoint endpoint;
     struct aws_server_bootstrap *server_bootstrap;
     struct aws_socket *listener;
-    uint64_t timestamp;
 };
 
 static bool s_channel_setup_predicate(void *user_data) {
@@ -276,12 +270,23 @@ static int s_local_server_tester_init(
     tester->socket_options.type = AWS_SOCKET_STREAM;
     tester->socket_options.domain = AWS_SOCKET_LOCAL;
 
-    ASSERT_SUCCESS(aws_sys_clock_get_ticks(&tester->timestamp));
-    snprintf(
-        tester->endpoint.address,
-        sizeof(tester->endpoint.address),
-        LOCAL_SOCK_TEST_PATTERN,
-        (long long unsigned)tester->timestamp);
+    struct aws_byte_buf endpoint_buf =
+        aws_byte_buf_from_empty_array(tester->endpoint.address, sizeof(tester->endpoint.address));
+#    ifdef _WIN32
+    AWS_FATAL_ASSERT(
+        aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str("\\\\.\\pipe\\testsock")));
+#    else
+    AWS_FATAL_ASSERT(aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str("testsock")));
+#    endif
+    /* Use UUID to generate a random endpoint for the socket */
+    struct aws_uuid uuid;
+    ASSERT_SUCCESS(aws_uuid_init(&uuid));
+    ASSERT_SUCCESS(aws_uuid_to_str(&uuid, &endpoint_buf));
+
+#    ifndef _WIN32
+    AWS_FATAL_ASSERT(aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str(".sock")));
+#    endif
+
     tester->server_bootstrap = aws_server_bootstrap_new(allocator, s_c_tester->el_group);
     ASSERT_NOT_NULL(tester->server_bootstrap);
 

--- a/tests/byo_crypto_test.c
+++ b/tests/byo_crypto_test.c
@@ -27,6 +27,12 @@
 #    include "statistics_handler_test.h"
 #    include <read_write_test_handler.h>
 
+#    ifdef _WIN32
+#        define LOCAL_SOCK_TEST_PATTERN "\\\\.\\pipe\\testsock" PRInSTR
+#    else
+#        define LOCAL_SOCK_TEST_PATTERN "testsock" PRInSTR ".sock"
+#    endif
+
 struct byo_crypto_test_args {
     struct aws_allocator *allocator;
     struct aws_mutex *mutex;
@@ -270,22 +276,17 @@ static int s_local_server_tester_init(
     tester->socket_options.type = AWS_SOCKET_STREAM;
     tester->socket_options.domain = AWS_SOCKET_LOCAL;
 
-    struct aws_byte_buf endpoint_buf =
-        aws_byte_buf_from_empty_array(tester->endpoint.address, sizeof(tester->endpoint.address));
-#    ifdef _WIN32
-    AWS_FATAL_ASSERT(
-        aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str("\\\\.\\pipe\\testsock")));
-#    else
-    AWS_FATAL_ASSERT(aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str("testsock")));
-#    endif
-    /* Use UUID to generate a random endpoint for the socket */
     struct aws_uuid uuid;
     ASSERT_SUCCESS(aws_uuid_init(&uuid));
-    ASSERT_SUCCESS(aws_uuid_to_str(&uuid, &endpoint_buf));
-
-#    ifndef _WIN32
-    AWS_FATAL_ASSERT(aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str(".sock")));
-#    endif
+    char uuid_str[AWS_UUID_STR_LEN] = {0};
+    struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
+    uuid_buf.len = 0;
+    aws_uuid_to_str(&uuid, &uuid_buf);
+    snprintf(
+        state_test_data->endpoint.address,
+        sizeof(state_test_data->endpoint.address),
+        LOCAL_SOCK_TEST_PATTERN,
+        AWS_BYTE_BUF_PRI(uuid_buf));
 
     tester->server_bootstrap = aws_server_bootstrap_new(allocator, s_c_tester->el_group);
     ASSERT_NOT_NULL(tester->server_bootstrap);

--- a/tests/byo_crypto_test.c
+++ b/tests/byo_crypto_test.c
@@ -283,8 +283,8 @@ static int s_local_server_tester_init(
     uuid_buf.len = 0;
     aws_uuid_to_str(&uuid, &uuid_buf);
     snprintf(
-        state_test_data->endpoint.address,
-        sizeof(state_test_data->endpoint.address),
+        tester->endpoint.address,
+        sizeof(tester->endpoint.address),
         LOCAL_SOCK_TEST_PATTERN,
         AWS_BYTE_BUF_PRI(uuid_buf));
 

--- a/tests/byo_crypto_test.c
+++ b/tests/byo_crypto_test.c
@@ -18,9 +18,7 @@
 #    include <aws/io/tls_channel_handler.h>
 
 #    include <aws/common/atomics.h>
-#    include <aws/common/clock.h>
 #    include <aws/common/condition_variable.h>
-#    include <aws/common/uuid.h>
 
 #    include <aws/testing/aws_test_harness.h>
 

--- a/tests/byo_crypto_test.c
+++ b/tests/byo_crypto_test.c
@@ -27,12 +27,6 @@
 #    include "statistics_handler_test.h"
 #    include <read_write_test_handler.h>
 
-#    ifdef _WIN32
-#        define LOCAL_SOCK_TEST_PATTERN "\\\\.\\pipe\\testsock" PRInSTR
-#    else
-#        define LOCAL_SOCK_TEST_PATTERN "testsock" PRInSTR ".sock"
-#    endif
-
 struct byo_crypto_test_args {
     struct aws_allocator *allocator;
     struct aws_mutex *mutex;
@@ -276,17 +270,7 @@ static int s_local_server_tester_init(
     tester->socket_options.type = AWS_SOCKET_STREAM;
     tester->socket_options.domain = AWS_SOCKET_LOCAL;
 
-    struct aws_uuid uuid;
-    ASSERT_SUCCESS(aws_uuid_init(&uuid));
-    char uuid_str[AWS_UUID_STR_LEN] = {0};
-    struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
-    uuid_buf.len = 0;
-    aws_uuid_to_str(&uuid, &uuid_buf);
-    snprintf(
-        tester->endpoint.address,
-        sizeof(tester->endpoint.address),
-        LOCAL_SOCK_TEST_PATTERN,
-        AWS_BYTE_BUF_PRI(uuid_buf));
+    aws_socket_endpoint_init_local_address_for_test(&tester->endpoint);
 
     tester->server_bootstrap = aws_server_bootstrap_new(allocator, s_c_tester->el_group);
     ASSERT_NOT_NULL(tester->server_bootstrap);

--- a/tests/socket_handler_test.c
+++ b/tests/socket_handler_test.c
@@ -18,12 +18,6 @@
 #include "statistics_handler_test.h"
 #include <read_write_test_handler.h>
 
-#ifdef _WIN32
-#    define LOCAL_SOCK_TEST_PATTERN "\\\\.\\pipe\\testsock" PRInSTR
-#else
-#    define LOCAL_SOCK_TEST_PATTERN "testsock" PRInSTR ".sock"
-#endif
-
 struct socket_test_args {
     struct aws_allocator *allocator;
     struct aws_mutex *mutex;
@@ -300,17 +294,7 @@ static int s_local_server_tester_init(
     tester->socket_options.type = AWS_SOCKET_STREAM;
     tester->socket_options.domain = AWS_SOCKET_LOCAL;
 
-    struct aws_uuid uuid;
-    ASSERT_SUCCESS(aws_uuid_init(&uuid));
-    char uuid_str[AWS_UUID_STR_LEN] = {0};
-    struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
-    uuid_buf.len = 0;
-    aws_uuid_to_str(&uuid, &uuid_buf);
-    snprintf(
-        tester->endpoint.address,
-        sizeof(tester->endpoint.address),
-        LOCAL_SOCK_TEST_PATTERN,
-        AWS_BYTE_BUF_PRI(uuid_buf));
+    aws_socket_endpoint_init_local_address_for_test(&tester->endpoint);
 
     tester->server_bootstrap = aws_server_bootstrap_new(allocator, s_c_tester->el_group);
     ASSERT_NOT_NULL(tester->server_bootstrap);

--- a/tests/socket_handler_test.c
+++ b/tests/socket_handler_test.c
@@ -11,17 +11,12 @@
 #include <aws/common/atomics.h>
 #include <aws/common/clock.h>
 #include <aws/common/condition_variable.h>
+#include <aws/common/uuid.h>
 
 #include <aws/testing/aws_test_harness.h>
 
 #include "statistics_handler_test.h"
 #include <read_write_test_handler.h>
-
-#ifdef _WIN32
-#    define LOCAL_SOCK_TEST_PATTERN "\\\\.\\pipe\\testsock%llu"
-#else
-#    define LOCAL_SOCK_TEST_PATTERN "testsock%llu.sock"
-#endif
 
 struct socket_test_args {
     struct aws_allocator *allocator;
@@ -80,7 +75,6 @@ struct local_server_tester {
     struct aws_socket_endpoint endpoint;
     struct aws_server_bootstrap *server_bootstrap;
     struct aws_socket *listener;
-    uint64_t timestamp;
 };
 
 static bool s_pinned_channel_setup_predicate(void *user_data) {
@@ -300,12 +294,23 @@ static int s_local_server_tester_init(
     tester->socket_options.type = AWS_SOCKET_STREAM;
     tester->socket_options.domain = AWS_SOCKET_LOCAL;
 
-    ASSERT_SUCCESS(aws_sys_clock_get_ticks(&tester->timestamp));
-    snprintf(
-        tester->endpoint.address,
-        sizeof(tester->endpoint.address),
-        LOCAL_SOCK_TEST_PATTERN,
-        (long long unsigned)tester->timestamp);
+    struct aws_byte_buf endpoint_buf =
+        aws_byte_buf_from_empty_array(tester->endpoint.address, sizeof(tester->endpoint.address));
+#ifdef _WIN32
+    AWS_FATAL_ASSERT(
+        aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str("\\\\.\\pipe\\testsock")));
+#else
+    AWS_FATAL_ASSERT(aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str("testsock")));
+#endif
+    /* Use UUID to generate a random endpoint for the socket */
+    struct aws_uuid uuid;
+    ASSERT_SUCCESS(aws_uuid_init(&uuid));
+    ASSERT_SUCCESS(aws_uuid_to_str(&uuid, &endpoint_buf));
+
+#ifndef _WIN32
+    AWS_FATAL_ASSERT(aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str(".sock")));
+#endif
+
     tester->server_bootstrap = aws_server_bootstrap_new(allocator, s_c_tester->el_group);
     ASSERT_NOT_NULL(tester->server_bootstrap);
 

--- a/tests/socket_handler_test.c
+++ b/tests/socket_handler_test.c
@@ -9,6 +9,7 @@
 #include <aws/io/statistics.h>
 
 #include <aws/common/atomics.h>
+#include <aws/common/clock.h>
 #include <aws/common/condition_variable.h>
 
 #include <aws/testing/aws_test_harness.h>

--- a/tests/socket_handler_test.c
+++ b/tests/socket_handler_test.c
@@ -9,9 +9,7 @@
 #include <aws/io/statistics.h>
 
 #include <aws/common/atomics.h>
-#include <aws/common/clock.h>
 #include <aws/common/condition_variable.h>
-#include <aws/common/uuid.h>
 
 #include <aws/testing/aws_test_harness.h>
 

--- a/tests/socket_test.c
+++ b/tests/socket_test.c
@@ -23,6 +23,12 @@
 #    include <linux/vm_sockets.h>
 #endif
 
+#ifdef _WIN32
+#    define LOCAL_SOCK_TEST_PATTERN "\\\\.\\pipe\\testsock" PRInSTR
+#else
+#    define LOCAL_SOCK_TEST_PATTERN "testsock" PRInSTR ".sock"
+#endif
+
 struct local_listener_args {
     struct aws_socket *incoming;
     struct aws_mutex *mutex;
@@ -408,21 +414,13 @@ static int s_test_local_socket_communication(struct aws_allocator *allocator, vo
     struct aws_socket_endpoint endpoint;
     AWS_ZERO_STRUCT(endpoint);
 
-    struct aws_byte_buf endpoint_buf = aws_byte_buf_from_empty_array(endpoint.address, sizeof(endpoint.address));
-#ifdef _WIN32
-    AWS_FATAL_ASSERT(
-        aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str("\\\\.\\pipe\\testsock")));
-#else
-    AWS_FATAL_ASSERT(aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str("testsock")));
-#endif
-    /* Use UUID to generate a random endpoint for the socket */
     struct aws_uuid uuid;
     ASSERT_SUCCESS(aws_uuid_init(&uuid));
-    ASSERT_SUCCESS(aws_uuid_to_str(&uuid, &endpoint_buf));
-
-#ifndef _WIN32
-    AWS_FATAL_ASSERT(aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str(".sock")));
-#endif
+    char uuid_str[AWS_UUID_STR_LEN] = {0};
+    struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
+    uuid_buf.len = 0;
+    aws_uuid_to_str(&uuid, &uuid_buf);
+    snprintf(endpoint.address, sizeof(endpoint.address), LOCAL_SOCK_TEST_PATTERN, AWS_BYTE_BUF_PRI(uuid_buf));
 
     return s_test_socket(allocator, &options, &endpoint);
 }
@@ -1587,21 +1585,13 @@ static int s_sock_write_cb_is_async(struct aws_allocator *allocator, void *ctx) 
     struct aws_socket_endpoint endpoint;
     AWS_ZERO_STRUCT(endpoint);
 
-    struct aws_byte_buf endpoint_buf = aws_byte_buf_from_empty_array(endpoint.address, sizeof(endpoint.address));
-#ifdef _WIN32
-    AWS_FATAL_ASSERT(
-        aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str("\\\\.\\pipe\\testsock")));
-#else
-    AWS_FATAL_ASSERT(aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str("testsock")));
-#endif
-    /* Use UUID to generate a random endpoint for the socket */
     struct aws_uuid uuid;
     ASSERT_SUCCESS(aws_uuid_init(&uuid));
-    ASSERT_SUCCESS(aws_uuid_to_str(&uuid, &endpoint_buf));
-
-#ifndef _WIN32
-    AWS_FATAL_ASSERT(aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str(".sock")));
-#endif
+    char uuid_str[AWS_UUID_STR_LEN] = {0};
+    struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
+    uuid_buf.len = 0;
+    aws_uuid_to_str(&uuid, &uuid_buf);
+    snprintf(endpoint.address, sizeof(endpoint.address), LOCAL_SOCK_TEST_PATTERN, AWS_BYTE_BUF_PRI(uuid_buf));
 
     struct aws_socket listener;
     ASSERT_SUCCESS(aws_socket_init(&listener, allocator, &options));
@@ -1693,21 +1683,13 @@ static int s_local_socket_pipe_connected_race(struct aws_allocator *allocator, v
     struct aws_socket_endpoint endpoint;
     AWS_ZERO_STRUCT(endpoint);
 
-    struct aws_byte_buf endpoint_buf = aws_byte_buf_from_empty_array(endpoint.address, sizeof(endpoint.address));
-#    ifdef _WIN32
-    AWS_FATAL_ASSERT(
-        aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str("\\\\.\\pipe\\testsock")));
-#    else
-    AWS_FATAL_ASSERT(aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str("testsock")));
-#    endif
-    /* Use UUID to generate a random endpoint for the socket */
     struct aws_uuid uuid;
     ASSERT_SUCCESS(aws_uuid_init(&uuid));
-    ASSERT_SUCCESS(aws_uuid_to_str(&uuid, &endpoint_buf));
-
-#    ifndef _WIN32
-    AWS_FATAL_ASSERT(aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str(".sock")));
-#    endif
+    char uuid_str[AWS_UUID_STR_LEN] = {0};
+    struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
+    uuid_buf.len = 0;
+    aws_uuid_to_str(&uuid, &uuid_buf);
+    snprintf(endpoint.address, sizeof(endpoint.address), LOCAL_SOCK_TEST_PATTERN, AWS_BYTE_BUF_PRI(uuid_buf));
 
     struct aws_socket listener;
     ASSERT_SUCCESS(aws_socket_init(&listener, allocator, &options));

--- a/tests/socket_test.c
+++ b/tests/socket_test.c
@@ -23,12 +23,6 @@
 #    include <linux/vm_sockets.h>
 #endif
 
-#ifdef _WIN32
-#    define LOCAL_SOCK_TEST_PATTERN "\\\\.\\pipe\\testsock" PRInSTR
-#else
-#    define LOCAL_SOCK_TEST_PATTERN "testsock" PRInSTR ".sock"
-#endif
-
 struct local_listener_args {
     struct aws_socket *incoming;
     struct aws_mutex *mutex;
@@ -413,14 +407,7 @@ static int s_test_local_socket_communication(struct aws_allocator *allocator, vo
     options.domain = AWS_SOCKET_LOCAL;
     struct aws_socket_endpoint endpoint;
     AWS_ZERO_STRUCT(endpoint);
-
-    struct aws_uuid uuid;
-    ASSERT_SUCCESS(aws_uuid_init(&uuid));
-    char uuid_str[AWS_UUID_STR_LEN] = {0};
-    struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
-    uuid_buf.len = 0;
-    aws_uuid_to_str(&uuid, &uuid_buf);
-    snprintf(endpoint.address, sizeof(endpoint.address), LOCAL_SOCK_TEST_PATTERN, AWS_BYTE_BUF_PRI(uuid_buf));
+    aws_socket_endpoint_init_local_address_for_test(&endpoint);
 
     return s_test_socket(allocator, &options, &endpoint);
 }
@@ -1584,14 +1571,7 @@ static int s_sock_write_cb_is_async(struct aws_allocator *allocator, void *ctx) 
     options.domain = AWS_SOCKET_LOCAL;
     struct aws_socket_endpoint endpoint;
     AWS_ZERO_STRUCT(endpoint);
-
-    struct aws_uuid uuid;
-    ASSERT_SUCCESS(aws_uuid_init(&uuid));
-    char uuid_str[AWS_UUID_STR_LEN] = {0};
-    struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
-    uuid_buf.len = 0;
-    aws_uuid_to_str(&uuid, &uuid_buf);
-    snprintf(endpoint.address, sizeof(endpoint.address), LOCAL_SOCK_TEST_PATTERN, AWS_BYTE_BUF_PRI(uuid_buf));
+    aws_socket_endpoint_init_local_address_for_test(&endpoint);
 
     struct aws_socket listener;
     ASSERT_SUCCESS(aws_socket_init(&listener, allocator, &options));
@@ -1682,14 +1662,7 @@ static int s_local_socket_pipe_connected_race(struct aws_allocator *allocator, v
 
     struct aws_socket_endpoint endpoint;
     AWS_ZERO_STRUCT(endpoint);
-
-    struct aws_uuid uuid;
-    ASSERT_SUCCESS(aws_uuid_init(&uuid));
-    char uuid_str[AWS_UUID_STR_LEN] = {0};
-    struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
-    uuid_buf.len = 0;
-    aws_uuid_to_str(&uuid, &uuid_buf);
-    snprintf(endpoint.address, sizeof(endpoint.address), LOCAL_SOCK_TEST_PATTERN, AWS_BYTE_BUF_PRI(uuid_buf));
+    aws_socket_endpoint_init_local_address_for_test(&endpoint);
 
     struct aws_socket listener;
     ASSERT_SUCCESS(aws_socket_init(&listener, allocator, &options));

--- a/tests/socket_test.c
+++ b/tests/socket_test.c
@@ -5,6 +5,7 @@
 
 #include <aws/testing/aws_test_harness.h>
 
+#include <aws/common/clock.h>
 #include <aws/common/condition_variable.h>
 #include <aws/common/string.h>
 #include <aws/common/task_scheduler.h>

--- a/tests/socket_test.c
+++ b/tests/socket_test.c
@@ -5,11 +5,9 @@
 
 #include <aws/testing/aws_test_harness.h>
 
-#include <aws/common/clock.h>
 #include <aws/common/condition_variable.h>
 #include <aws/common/string.h>
 #include <aws/common/task_scheduler.h>
-#include <aws/common/uuid.h>
 
 #include <aws/io/event_loop.h>
 #include <aws/io/host_resolver.h>

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -385,6 +385,7 @@ static int s_tls_local_server_tester_init(
     int server_index,
     const char *cert_path,
     const char *pkey_path) {
+    (void)server_index;
     AWS_ZERO_STRUCT(*tester);
     ASSERT_SUCCESS(s_tls_server_opt_tester_init(allocator, &tester->server_tls_opt_tester, cert_path, pkey_path));
     aws_tls_connection_options_set_callbacks(&tester->server_tls_opt_tester.opt, s_tls_on_negotiated, NULL, NULL, args);

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -13,10 +13,8 @@
 #    include <aws/io/socket.h>
 #    include <aws/io/tls_channel_handler.h>
 
-#    include <aws/common/clock.h>
 #    include <aws/common/condition_variable.h>
 #    include <aws/common/thread.h>
-#    include <aws/common/uuid.h>
 
 #    include <aws/testing/aws_test_harness.h>
 
@@ -382,10 +380,8 @@ static int s_tls_local_server_tester_init(
     struct tls_test_args *args,
     struct tls_common_tester *tls_c_tester,
     bool enable_back_pressure,
-    int server_index,
     const char *cert_path,
     const char *pkey_path) {
-    (void)server_index;
     AWS_ZERO_STRUCT(*tester);
     ASSERT_SUCCESS(s_tls_server_opt_tester_init(allocator, &tester->server_tls_opt_tester, cert_path, pkey_path));
     aws_tls_connection_options_set_callbacks(&tester->server_tls_opt_tester.opt, s_tls_on_negotiated, NULL, NULL, args);
@@ -515,7 +511,7 @@ static int s_tls_channel_echo_and_backpressure_test_fn(struct aws_allocator *all
 
     struct tls_local_server_tester local_server_tester;
     ASSERT_SUCCESS(s_tls_local_server_tester_init(
-        allocator, &local_server_tester, &incoming_args, &c_tester, true, 1, "server.crt", "server.key"));
+        allocator, &local_server_tester, &incoming_args, &c_tester, true, "server.crt", "server.key"));
     /* make the windows small to make sure back pressure is honored. */
     struct aws_channel_handler *outgoing_rw_handler = rw_handler_new(
         allocator, s_tls_test_handle_read, s_tls_test_handle_write, true, write_tag.len / 2, &outgoing_rw_args);
@@ -1422,7 +1418,7 @@ static int s_tls_server_multiple_connections_fn(struct aws_allocator *allocator,
 
     struct tls_local_server_tester local_server_tester;
     ASSERT_SUCCESS(s_tls_local_server_tester_init(
-        allocator, &local_server_tester, &incoming_args, &c_tester, false, 1, "server.crt", "server.key"));
+        allocator, &local_server_tester, &incoming_args, &c_tester, false, "server.crt", "server.key"));
 
     struct tls_opt_tester client_tls_opt_tester;
     struct aws_byte_cursor server_name = aws_byte_cursor_from_c_str("localhost");
@@ -1571,7 +1567,7 @@ static int s_tls_server_hangup_during_negotiation_fn(struct aws_allocator *alloc
 
     struct tls_local_server_tester local_server_tester;
     ASSERT_SUCCESS(s_tls_local_server_tester_init(
-        allocator, &local_server_tester, &incoming_args, &c_tester, false, 1, "server.crt", "server.key"));
+        allocator, &local_server_tester, &incoming_args, &c_tester, false, "server.crt", "server.key"));
 
     ASSERT_SUCCESS(aws_mutex_lock(&c_tester.mutex));
 
@@ -1716,7 +1712,7 @@ static int s_tls_channel_statistics_test(struct aws_allocator *allocator, void *
 
     struct tls_local_server_tester local_server_tester;
     ASSERT_SUCCESS(s_tls_local_server_tester_init(
-        allocator, &local_server_tester, &incoming_args, &c_tester, false, 1, "server.crt", "server.key"));
+        allocator, &local_server_tester, &incoming_args, &c_tester, false, "server.crt", "server.key"));
 
     struct aws_channel_handler *outgoing_rw_handler =
         rw_handler_new(allocator, s_tls_test_handle_read, s_tls_test_handle_write, true, 10000, &outgoing_rw_args);
@@ -1837,7 +1833,7 @@ static int s_tls_certificate_chain_test(struct aws_allocator *allocator, void *c
 
     struct tls_local_server_tester local_server_tester;
     ASSERT_SUCCESS(s_tls_local_server_tester_init(
-        allocator, &local_server_tester, &incoming_args, &c_tester, false, 1, "server_chain.crt", "server.key"));
+        allocator, &local_server_tester, &incoming_args, &c_tester, false, "server_chain.crt", "server.key"));
 
     struct tls_opt_tester client_tls_opt_tester;
     struct aws_byte_cursor server_name = aws_byte_cursor_from_c_str("localhost");

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -26,6 +26,12 @@
 
 #    include <aws/io/private/pki_utils.h>
 
+#    ifdef _WIN32
+#        define LOCAL_SOCK_TEST_PATTERN "\\\\.\\pipe\\testsock" PRInSTR
+#    else
+#        define LOCAL_SOCK_TEST_PATTERN "testsock" PRInSTR ".sock"
+#    endif
+
 struct tls_test_args {
     struct aws_allocator *allocator;
     struct aws_mutex *mutex;
@@ -393,22 +399,17 @@ static int s_tls_local_server_tester_init(
     tester->socket_options.type = AWS_SOCKET_STREAM;
     tester->socket_options.domain = AWS_SOCKET_LOCAL;
 
-    struct aws_byte_buf endpoint_buf =
-        aws_byte_buf_from_empty_array(tester->endpoint.address, sizeof(tester->endpoint.address));
-#    ifdef _WIN32
-    AWS_FATAL_ASSERT(
-        aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str("\\\\.\\pipe\\testsock")));
-#    else
-    AWS_FATAL_ASSERT(aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str("testsock")));
-#    endif
-    /* Use UUID to generate a random endpoint for the socket */
     struct aws_uuid uuid;
     ASSERT_SUCCESS(aws_uuid_init(&uuid));
-    ASSERT_SUCCESS(aws_uuid_to_str(&uuid, &endpoint_buf));
-
-#    ifndef _WIN32
-    AWS_FATAL_ASSERT(aws_byte_buf_write_from_whole_cursor(&endpoint_buf, aws_byte_cursor_from_c_str(".sock")));
-#    endif
+    char uuid_str[AWS_UUID_STR_LEN] = {0};
+    struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
+    uuid_buf.len = 0;
+    aws_uuid_to_str(&uuid, &uuid_buf);
+    snprintf(
+        tester->endpoint.address,
+        sizeof(tester->endpoint.address),
+        LOCAL_SOCK_TEST_PATTERN,
+        AWS_BYTE_BUF_PRI(uuid_buf));
 
     tester->server_bootstrap = aws_server_bootstrap_new(allocator, tls_c_tester->el_group);
     ASSERT_NOT_NULL(tester->server_bootstrap);

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -26,12 +26,6 @@
 
 #    include <aws/io/private/pki_utils.h>
 
-#    ifdef _WIN32
-#        define LOCAL_SOCK_TEST_PATTERN "\\\\.\\pipe\\testsock" PRInSTR
-#    else
-#        define LOCAL_SOCK_TEST_PATTERN "testsock" PRInSTR ".sock"
-#    endif
-
 struct tls_test_args {
     struct aws_allocator *allocator;
     struct aws_mutex *mutex;
@@ -399,17 +393,7 @@ static int s_tls_local_server_tester_init(
     tester->socket_options.type = AWS_SOCKET_STREAM;
     tester->socket_options.domain = AWS_SOCKET_LOCAL;
 
-    struct aws_uuid uuid;
-    ASSERT_SUCCESS(aws_uuid_init(&uuid));
-    char uuid_str[AWS_UUID_STR_LEN] = {0};
-    struct aws_byte_buf uuid_buf = aws_byte_buf_from_array(uuid_str, sizeof(uuid_str));
-    uuid_buf.len = 0;
-    aws_uuid_to_str(&uuid, &uuid_buf);
-    snprintf(
-        tester->endpoint.address,
-        sizeof(tester->endpoint.address),
-        LOCAL_SOCK_TEST_PATTERN,
-        AWS_BYTE_BUF_PRI(uuid_buf));
+    aws_socket_endpoint_init_local_address_for_test(&tester->endpoint);
 
     tester->server_bootstrap = aws_server_bootstrap_new(allocator, tls_c_tester->el_group);
     ASSERT_NOT_NULL(tester->server_bootstrap);

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -13,6 +13,7 @@
 #    include <aws/io/socket.h>
 #    include <aws/io/tls_channel_handler.h>
 
+#    include <aws/common/clock.h>
 #    include <aws/common/condition_variable.h>
 #    include <aws/common/thread.h>
 


### PR DESCRIPTION
*Description of changes:*

Adjust tests to use UUID instead of timestamps for socket endpoints, preventing any overlap if two tests run in parallel or at the exact same timestamp clock sample.

__________

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
