### PR TITLE
aws_future functions no longer inline

### DIFF
--- a/source/future.c
+++ b/source/future.c
@@ -467,3 +467,76 @@ bool aws_future_impl_wait(const struct aws_future_impl *future, uint64_t timeout
 
     return is_done;
 }
+
+// AWS_FUTURE_T_BY_VALUE_IMPLEMENTATION(aws_future_bool, bool)
+struct aws_future_bool *aws_future_bool_new(struct aws_allocator *alloc) {
+    return (struct aws_future_bool *)aws_future_impl_new_by_value(alloc, sizeof(_Bool));
+}
+void aws_future_bool_set_result(struct aws_future_bool *future, _Bool result) {
+    aws_future_impl_set_result_by_move((struct aws_future_impl *)future, &result);
+}
+_Bool aws_future_bool_get_result(const struct aws_future_bool *future) {
+    return *(_Bool *)aws_future_impl_get_result_address((const struct aws_future_impl *)future);
+}
+struct aws_future_bool *aws_future_bool_acquire(struct aws_future_bool *future) {
+    return (struct aws_future_bool *)aws_future_impl_acquire((struct aws_future_impl *)future);
+}
+struct aws_future_bool *aws_future_bool_release(struct aws_future_bool *future) {
+    return (struct aws_future_bool *)aws_future_impl_release((struct aws_future_impl *)future);
+}
+void aws_future_bool_set_error(struct aws_future_bool *future, int error_code) {
+    aws_future_impl_set_error((struct aws_future_impl *)future, error_code);
+}
+_Bool aws_future_bool_is_done(const struct aws_future_bool *future) {
+    return aws_future_impl_is_done((const struct aws_future_impl *)future);
+}
+int aws_future_bool_get_error(const struct aws_future_bool *future) {
+    return aws_future_impl_get_error((const struct aws_future_impl *)future);
+}
+void aws_future_bool_register_callback(
+    struct aws_future_bool *future,
+    aws_future_callback_fn *on_done,
+    void *user_data) {
+    aws_future_impl_register_callback((struct aws_future_impl *)future, on_done, user_data);
+}
+_Bool aws_future_bool_register_callback_if_not_done(
+    struct aws_future_bool *future,
+    aws_future_callback_fn *on_done,
+    void *user_data) {
+    return aws_future_impl_register_callback_if_not_done((struct aws_future_impl *)future, on_done, user_data);
+}
+void aws_future_bool_register_event_loop_callback(
+    struct aws_future_bool *future,
+    struct aws_event_loop *event_loop,
+    aws_future_callback_fn *on_done,
+    void *user_data) {
+    aws_future_impl_register_event_loop_callback((struct aws_future_impl *)future, event_loop, on_done, user_data);
+}
+void aws_future_bool_register_channel_callback(
+    struct aws_future_bool *future,
+    struct aws_channel *channel,
+    aws_future_callback_fn *on_done,
+    void *user_data) {
+    aws_future_impl_register_channel_callback((struct aws_future_impl *)future, channel, on_done, user_data);
+}
+_Bool aws_future_bool_wait(struct aws_future_bool *future, uint64_t timeout_ns) {
+    return aws_future_impl_wait((struct aws_future_impl *)future, timeout_ns);
+}
+
+AWS_FUTURE_T_BY_VALUE_IMPLEMENTATION(aws_future_size, size_t)
+
+/**
+ * aws_future<void>
+ */
+AWS_FUTURE_T_IMPLEMENTATION_BEGIN(aws_future_void)
+
+struct aws_future_void *aws_future_void_new(struct aws_allocator *alloc) {
+    /* Use aws_future<bool> under the hood, to avoid edge-cases with 0-sized result */
+    return (struct aws_future_void *)aws_future_bool_new(alloc);
+}
+
+void aws_future_void_set_result(struct aws_future_void *future) {
+    aws_future_bool_set_result((struct aws_future_bool *)future, false);
+}
+
+AWS_FUTURE_T_IMPLEMENTATION_END(aws_future_void)

--- a/tests/future_test.c
+++ b/tests/future_test.c
@@ -17,6 +17,9 @@
 #define ONE_SEC_IN_NS ((uint64_t)AWS_TIMESTAMP_NANOS)
 #define MAX_TIMEOUT_NS (10 * ONE_SEC_IN_NS)
 
+AWS_FUTURE_T_POINTER_WITH_DESTROY_IMPLEMENTATION(aws_future_destroyme, struct aws_destroyme, aws_destroyme_destroy);
+AWS_FUTURE_T_POINTER_WITH_RELEASE_IMPLEMENTATION(aws_future_refcountme, struct aws_refcountme, aws_refcountme_release);
+
 /* Run through the basics of an AWS_FUTURE_T_BY_VALUE */
 static int s_test_future_by_value(struct aws_allocator *alloc, void *ctx) {
     (void)ctx;

--- a/tests/future_test.h
+++ b/tests/future_test.h
@@ -12,11 +12,11 @@ struct aws_destroyme *aws_destroyme_new(struct aws_allocator *alloc, bool *set_t
 void aws_destroyme_destroy(struct aws_destroyme *destroyme);
 
 /* We get unused-function warnings if this macro is used in a .c file, so put it in a header */
-AWS_DECLARE_FUTURE_T_POINTER_WITH_DESTROY(aws_future_destroyme, struct aws_destroyme, aws_destroyme_destroy);
+AWS_FUTURE_T_POINTER_WITH_DESTROY_DECLARATION(aws_future_destroyme, struct aws_destroyme, AWS_IO_API);
 
 struct aws_refcountme *aws_refcountme_new(struct aws_allocator *alloc, bool *set_true_on_death);
 struct aws_refcountme *aws_refcountme_acquire(struct aws_refcountme *refcountme);
 struct aws_refcountme *aws_refcountme_release(struct aws_refcountme *refcountme);
-AWS_DECLARE_FUTURE_T_POINTER_WITH_RELEASE(aws_future_refcountme, struct aws_refcountme, aws_refcountme_release);
+AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_refcountme, struct aws_refcountme, AWS_IO_API);
 
 #endif /* AWS_FUTURE_TEST_H */

--- a/tests/future_test.h
+++ b/tests/future_test.h
@@ -12,11 +12,11 @@ struct aws_destroyme *aws_destroyme_new(struct aws_allocator *alloc, bool *set_t
 void aws_destroyme_destroy(struct aws_destroyme *destroyme);
 
 /* We get unused-function warnings if this macro is used in a .c file, so put it in a header */
-AWS_FUTURE_T_POINTER_WITH_DESTROY_DECLARATION(aws_future_destroyme, struct aws_destroyme, AWS_IO_API);
+AWS_FUTURE_T_POINTER_WITH_DESTROY_DECLARATION(aws_future_destroyme, struct aws_destroyme, /*private API*/);
 
 struct aws_refcountme *aws_refcountme_new(struct aws_allocator *alloc, bool *set_true_on_death);
 struct aws_refcountme *aws_refcountme_acquire(struct aws_refcountme *refcountme);
 struct aws_refcountme *aws_refcountme_release(struct aws_refcountme *refcountme);
-AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_refcountme, struct aws_refcountme, AWS_IO_API);
+AWS_FUTURE_T_POINTER_WITH_RELEASE_DECLARATION(aws_future_refcountme, struct aws_refcountme, /*private API*/);
 
 #endif /* AWS_FUTURE_TEST_H */


### PR DESCRIPTION
Rust was having trouble calling `aws_future_bool` functions, due to them only being available as inline.

These functions were inline so that the we'd only need 1 declaration macro in a header. It wasn't a performance thing.

Fix is to have the macros generate normal non-inline functions, with a DECLARATION macro that goes in a header, and an IMPLEMENTATION macro that goes in a C file.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
