### PR TITLE
fix compiler warning

### DIFF
--- a/source/future.c
+++ b/source/future.c
@@ -295,6 +295,7 @@ static void s_future_impl_set_done(struct aws_future_impl *future, void *src_add
             future->error_code = error_code;
         } else {
             future->owns_result = true;
+            AWS_FATAL_ASSERT(src_address != NULL);
             memcpy(aws_future_impl_get_result_address(future), src_address, future->sizeof_result);
         }
 


### PR DESCRIPTION
in Armv7, with GNU 11.3.0, https://github.com/awslabs/aws-crt-java/actions/runs/5224906579/jobs/9433692863
```
In function 's_future_impl_set_done',
    inlined from 'aws_future_impl_set_error' at /work/crt/aws-c-io/source/future.c:327:5:
/work/crt/aws-c-io/source/future.c:298:13: error: argument 2 null where non-null expected [-Werror=nonnull]
  298 |             memcpy(aws_future_impl_get_result_address(future), src_address, future->sizeof_result);
      |             ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
In file included from /work/crt/aws-c-common/include/aws/common/zero.h:12,
                 from /work/crt/aws-c-common/include/aws/common/common.h:20,
                 from /work/crt/aws-c-common/include/aws/common/array_list.h:8,
                 from /work/crt/aws-c-common/include/aws/common/byte_buf.h:8,
                 from /work/crt/aws-c-io/include/aws/io/io.h:8,
                 from /work/crt/aws-c-io/include/aws/io/future.h:185,
                 from /work/crt/aws-c-io/source/future.c:5:
/work/crt/aws-c-io/source/future.c: In function 'aws_future_impl_set_error':
/usr/xcc/armv7-unknown-linux-gnueabi/armv7-unknown-linux-gnueabi/sysroot/usr/include/string.h:43:14: note: in a call to function 'memcpy' declared 'nonnull'
   43 | extern void *memcpy (void *__restrict __dest, const void *__restrict __src,
      |              ^~~~~~
cc1: all warnings being treated as errors
```

After the hint before the `memcpy`, it compiled successfully. https://github.com/awslabs/aws-crt-java/actions/runs/5225002585/jobs/9433913366?pr=637

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
