### PR TITLE
Fix build issues with stream-tester files

### DIFF
--- a/include/aws/testing/async_stream_tester.h
+++ b/include/aws/testing/async_stream_tester.h
@@ -65,8 +65,7 @@ struct aws_async_input_stream_tester {
     struct aws_atomic_var num_outstanding_reads;
 };
 
-AWS_STATIC_IMPL
-void s_async_input_stream_tester_do_actual_read(
+static inline void s_async_input_stream_tester_do_actual_read(
     struct aws_async_input_stream_tester *impl,
     struct aws_byte_buf *dest,
     struct aws_future_bool *read_future) {
@@ -109,8 +108,7 @@ done:
     aws_future_bool_release(read_future);
 }
 
-AWS_STATIC_IMPL
-struct aws_future_bool *s_async_input_stream_tester_read(
+static inline struct aws_future_bool *s_async_input_stream_tester_read(
     struct aws_async_input_stream *stream,
     struct aws_byte_buf *dest) {
 
@@ -151,8 +149,7 @@ struct aws_future_bool *s_async_input_stream_tester_read(
     return read_future;
 }
 
-AWS_STATIC_IMPL
-void s_async_input_stream_tester_do_actual_destroy(struct aws_async_input_stream_tester *impl) {
+static inline void s_async_input_stream_tester_do_actual_destroy(struct aws_async_input_stream_tester *impl) {
     if (impl->options.completion_strategy != AWS_ASYNC_READ_COMPLETES_IMMEDIATELY) {
         aws_condition_variable_clean_up(&impl->synced_data.cvar);
         aws_mutex_clean_up(&impl->synced_data.lock);
@@ -163,8 +160,7 @@ void s_async_input_stream_tester_do_actual_destroy(struct aws_async_input_stream
 }
 
 /* refcount has reached zero */
-AWS_STATIC_IMPL
-void s_async_input_stream_tester_destroy(struct aws_async_input_stream *async_stream) {
+static inline void s_async_input_stream_tester_destroy(struct aws_async_input_stream *async_stream) {
     struct aws_async_input_stream_tester *impl = async_stream->impl;
 
     if (impl->options.completion_strategy == AWS_ASYNC_READ_COMPLETES_IMMEDIATELY) {
@@ -181,14 +177,12 @@ void s_async_input_stream_tester_destroy(struct aws_async_input_stream *async_st
     }
 }
 
-AWS_STATIC_IMPL
-bool s_async_input_stream_tester_thread_pred(void *arg) {
+static inline bool s_async_input_stream_tester_thread_pred(void *arg) {
     struct aws_async_input_stream_tester *impl = arg;
     return impl->synced_data.do_shutdown || (impl->synced_data.read_dest != NULL);
 }
 
-AWS_STATIC_IMPL
-void s_async_input_stream_tester_thread(void *arg) {
+static inline void s_async_input_stream_tester_thread(void *arg) {
     struct aws_async_input_stream_tester *impl = arg;
     bool do_shutdown = false;
     struct aws_byte_buf *read_dest = NULL;
@@ -220,8 +214,8 @@ void s_async_input_stream_tester_thread(void *arg) {
     s_async_input_stream_tester_do_actual_destroy(impl);
 }
 
-AWS_STATIC_IMPL
-uint64_t aws_async_input_stream_tester_total_bytes_read(const struct aws_async_input_stream *async_stream) {
+static inline uint64_t aws_async_input_stream_tester_total_bytes_read(
+    const struct aws_async_input_stream *async_stream) {
     const struct aws_async_input_stream_tester *async_impl = async_stream->impl;
     const struct aws_input_stream_tester *synchronous_impl = async_impl->source_stream->impl;
     return synchronous_impl->total_bytes_read;
@@ -232,8 +226,7 @@ static struct aws_async_input_stream_vtable s_async_input_stream_tester_vtable =
     .read = s_async_input_stream_tester_read,
 };
 
-AWS_STATIC_IMPL
-struct aws_async_input_stream *aws_async_input_stream_new_tester(
+static inline struct aws_async_input_stream *aws_async_input_stream_new_tester(
     struct aws_allocator *alloc,
     const struct aws_async_input_stream_tester_options *options) {
 

--- a/include/aws/testing/stream_tester.h
+++ b/include/aws/testing/stream_tester.h
@@ -23,6 +23,12 @@ To enable use of this code, set the AWS_UNSTABLE_TESTING_API compiler flag.
  * - autogen_length: autogen streaming content N bytes in length.
  */
 
+enum aws_autogen_style {
+    AWS_AUTOGEN_LOREM_IPSUM,
+    AWS_AUTOGEN_ALPHABET,
+    AWS_AUTOGEN_NUMBERS,
+};
+
 struct aws_input_stream_tester_options {
     /* bytes to be streamed.
      * the stream copies these to its own internal buffer.
@@ -36,11 +42,7 @@ struct aws_input_stream_tester_options {
     size_t autogen_length;
 
     /* style of contents (if using autogen) */
-    enum aws_autogen_style {
-        AWS_AUTOGEN_LOREM_IPSUM,
-        AWS_AUTOGEN_ALPHABET,
-        AWS_AUTOGEN_NUMBERS,
-    } autogen_style;
+    enum aws_autogen_style autogen_style;
 
     /* if non-zero, read at most N bytes per read() */
     size_t max_bytes_per_read;
@@ -76,12 +78,12 @@ static inline int s_input_stream_tester_seek(
     int64_t offset,
     enum aws_stream_seek_basis basis) {
 
-    struct aws_input_stream_tester *impl = AWS_CONTAINER_OF(stream, struct aws_input_stream_tester, base);
+    struct aws_input_stream_tester *impl = (struct aws_input_stream_tester *)stream->impl;
     return aws_input_stream_seek(impl->source_stream, offset, basis);
 }
 
 static inline int s_input_stream_tester_read(struct aws_input_stream *stream, struct aws_byte_buf *original_dest) {
-    struct aws_input_stream_tester *impl = AWS_CONTAINER_OF(stream, struct aws_input_stream_tester, base);
+    struct aws_input_stream_tester *impl = (struct aws_input_stream_tester *)stream->impl;
 
     impl->read_count++;
 
@@ -118,7 +120,7 @@ static inline int s_input_stream_tester_read(struct aws_input_stream *stream, st
 }
 
 static inline int s_input_stream_tester_get_status(struct aws_input_stream *stream, struct aws_stream_status *status) {
-    struct aws_input_stream_tester *impl = AWS_CONTAINER_OF(stream, struct aws_input_stream_tester, base);
+    struct aws_input_stream_tester *impl = (struct aws_input_stream_tester *)stream->impl;
     if (aws_input_stream_get_status(impl->source_stream, status)) {
         return AWS_OP_ERR;
     }
@@ -134,7 +136,7 @@ static inline int s_input_stream_tester_get_status(struct aws_input_stream *stre
 }
 
 static inline int s_input_stream_tester_get_length(struct aws_input_stream *stream, int64_t *out_length) {
-    struct aws_input_stream_tester *impl = AWS_CONTAINER_OF(stream, struct aws_input_stream_tester, base);
+    struct aws_input_stream_tester *impl = (struct aws_input_stream_tester *)stream->impl;
     return aws_input_stream_get_length(impl->source_stream, out_length);
 }
 
@@ -181,12 +183,12 @@ static inline void s_byte_buf_init_autogenned(
 }
 
 static inline uint64_t aws_input_stream_tester_total_bytes_read(const struct aws_input_stream *stream) {
-    struct aws_input_stream_tester *impl = stream->impl;
+    const struct aws_input_stream_tester *impl = (const struct aws_input_stream_tester *)stream->impl;
     return impl->total_bytes_read;
 }
 
 static inline void s_input_stream_tester_destroy(void *user_data) {
-    struct aws_input_stream_tester *impl = user_data;
+    struct aws_input_stream_tester *impl = (struct aws_input_stream_tester *)user_data;
     aws_input_stream_release(impl->source_stream);
     aws_byte_buf_clean_up(&impl->source_buf);
     aws_mem_release(impl->alloc, impl);
@@ -196,7 +198,8 @@ static inline struct aws_input_stream *aws_input_stream_new_tester(
     struct aws_allocator *alloc,
     const struct aws_input_stream_tester_options *options) {
 
-    struct aws_input_stream_tester *impl = aws_mem_calloc(alloc, 1, sizeof(struct aws_input_stream_tester));
+    struct aws_input_stream_tester *impl =
+        (struct aws_input_stream_tester *)aws_mem_calloc(alloc, 1, sizeof(struct aws_input_stream_tester));
     impl->base.impl = impl;
     impl->base.vtable = &s_input_stream_tester_vtable;
     aws_ref_count_init(&impl->base.ref_count, impl, s_input_stream_tester_destroy);

--- a/include/aws/testing/stream_tester.h
+++ b/include/aws/testing/stream_tester.h
@@ -71,14 +71,16 @@ struct aws_input_stream_tester {
     uint64_t total_bytes_read;
 };
 
-AWS_STATIC_IMPL
-int s_input_stream_tester_seek(struct aws_input_stream *stream, int64_t offset, enum aws_stream_seek_basis basis) {
+static inline int s_input_stream_tester_seek(
+    struct aws_input_stream *stream,
+    int64_t offset,
+    enum aws_stream_seek_basis basis) {
+
     struct aws_input_stream_tester *impl = AWS_CONTAINER_OF(stream, struct aws_input_stream_tester, base);
     return aws_input_stream_seek(impl->source_stream, offset, basis);
 }
 
-AWS_STATIC_IMPL
-int s_input_stream_tester_read(struct aws_input_stream *stream, struct aws_byte_buf *original_dest) {
+static inline int s_input_stream_tester_read(struct aws_input_stream *stream, struct aws_byte_buf *original_dest) {
     struct aws_input_stream_tester *impl = AWS_CONTAINER_OF(stream, struct aws_input_stream_tester, base);
 
     impl->read_count++;
@@ -115,8 +117,7 @@ int s_input_stream_tester_read(struct aws_input_stream *stream, struct aws_byte_
     return AWS_OP_SUCCESS;
 }
 
-AWS_STATIC_IMPL
-int s_input_stream_tester_get_status(struct aws_input_stream *stream, struct aws_stream_status *status) {
+static inline int s_input_stream_tester_get_status(struct aws_input_stream *stream, struct aws_stream_status *status) {
     struct aws_input_stream_tester *impl = AWS_CONTAINER_OF(stream, struct aws_input_stream_tester, base);
     if (aws_input_stream_get_status(impl->source_stream, status)) {
         return AWS_OP_ERR;
@@ -132,8 +133,7 @@ int s_input_stream_tester_get_status(struct aws_input_stream *stream, struct aws
     return AWS_OP_SUCCESS;
 }
 
-AWS_STATIC_IMPL
-int s_input_stream_tester_get_length(struct aws_input_stream *stream, int64_t *out_length) {
+static inline int s_input_stream_tester_get_length(struct aws_input_stream *stream, int64_t *out_length) {
     struct aws_input_stream_tester *impl = AWS_CONTAINER_OF(stream, struct aws_input_stream_tester, base);
     return aws_input_stream_get_length(impl->source_stream, out_length);
 }
@@ -146,8 +146,7 @@ static struct aws_input_stream_vtable s_input_stream_tester_vtable = {
 };
 
 /* init byte-buf and fill it autogenned content */
-AWS_STATIC_IMPL
-void s_byte_buf_init_autogenned(
+static inline void s_byte_buf_init_autogenned(
     struct aws_byte_buf *buf,
     struct aws_allocator *alloc,
     size_t length,
@@ -181,22 +180,19 @@ void s_byte_buf_init_autogenned(
     }
 }
 
-AWS_STATIC_IMPL
-uint64_t aws_input_stream_tester_total_bytes_read(const struct aws_input_stream *stream) {
+static inline uint64_t aws_input_stream_tester_total_bytes_read(const struct aws_input_stream *stream) {
     struct aws_input_stream_tester *impl = stream->impl;
     return impl->total_bytes_read;
 }
 
-AWS_STATIC_IMPL
-void s_input_stream_tester_destroy(void *user_data) {
+static inline void s_input_stream_tester_destroy(void *user_data) {
     struct aws_input_stream_tester *impl = user_data;
     aws_input_stream_release(impl->source_stream);
     aws_byte_buf_clean_up(&impl->source_buf);
     aws_mem_release(impl->alloc, impl);
 }
 
-AWS_STATIC_IMPL
-struct aws_input_stream *aws_input_stream_new_tester(
+static inline struct aws_input_stream *aws_input_stream_new_tester(
     struct aws_allocator *alloc,
     const struct aws_input_stream_tester_options *options) {
 


### PR DESCRIPTION
Fix the following build issues with the stream_tester.h files:
- Issues when compiled with `-DAWS_NO_STATIC_IMPL=1` CFLAG
- Issues when included from .cpp files

**Description of changes:**
- use `static inline` instead of `AWS_STATIC_IMPL` (which does nothing if `-DAWS_NO_STATIC_IMPL=1` is defined)
- move enum definition outside of struct definition
- add explicit casts where c++ demands


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
