### PR TITLE
Cleanup aws-lc thread locals in event loop threads

### DIFF
--- a/.github/workflows/proof-alarm.yml
+++ b/.github/workflows/proof-alarm.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Check
       run: |
         TMPFILE=$(mktemp)
-        echo "8391c38acd85cca2a2892d02ebfd4ceb  source/linux/epoll_event_loop.c" > $TMPFILE
+        echo "59be2f2fbbd5ff4a374589cfe408609f  source/linux/epoll_event_loop.c" > $TMPFILE
         md5sum --check $TMPFILE
 
     # No further steps if successful

--- a/source/bsd/kqueue_event_loop.c
+++ b/source/bsd/kqueue_event_loop.c
@@ -824,8 +824,9 @@ static int aws_event_loop_listen_for_io_events(int kq_fd, struct kevent kevents[
 
 static void s_aws_kqueue_cleanup_aws_lc_thread_local_state(void *user_data) {
     (void)user_data;
-
+#ifndef BYO_CRYPTO
     aws_cal_thread_clean_up();
+#endif
 }
 
 static void aws_event_loop_thread(void *user_data) {

--- a/source/bsd/kqueue_event_loop.c
+++ b/source/bsd/kqueue_event_loop.c
@@ -824,9 +824,8 @@ static int aws_event_loop_listen_for_io_events(int kq_fd, struct kevent kevents[
 
 static void s_aws_kqueue_cleanup_aws_lc_thread_local_state(void *user_data) {
     (void)user_data;
-#ifndef BYO_CRYPTO
+
     aws_cal_thread_clean_up();
-#endif
 }
 
 static void aws_event_loop_thread(void *user_data) {

--- a/source/bsd/kqueue_event_loop.c
+++ b/source/bsd/kqueue_event_loop.c
@@ -7,6 +7,7 @@
 
 #include <aws/io/logging.h>
 
+#include <aws/cal/cal.h>
 #include <aws/common/atomics.h>
 #include <aws/common/clock.h>
 #include <aws/common/mutex.h>
@@ -15,7 +16,6 @@
 
 #if defined(__FreeBSD__) || defined(__NetBSD__)
 #    define __BSD_VISIBLE 1
-#    include <openssl/thread.h>
 #    include <sys/types.h>
 #endif
 
@@ -825,9 +825,7 @@ static int aws_event_loop_listen_for_io_events(int kq_fd, struct kevent kevents[
 static void s_aws_kqueue_cleanup_aws_lc_thread_local_state(void *user_data) {
     (void)user_data;
 
-#if defined(OPENSSL_IS_AWSLC)
-    AWSLC_thread_local_clear();
-#endif
+    aws_cal_thread_clean_up();
 }
 
 static void aws_event_loop_thread(void *user_data) {

--- a/source/linux/epoll_event_loop.c
+++ b/source/linux/epoll_event_loop.c
@@ -16,8 +16,6 @@
 
 #include <sys/epoll.h>
 
-#include <openssl/thread.h>
-
 #include <errno.h>
 #include <limits.h>
 #include <unistd.h>

--- a/source/linux/epoll_event_loop.c
+++ b/source/linux/epoll_event_loop.c
@@ -15,6 +15,8 @@
 
 #include <sys/epoll.h>
 
+#include <openssl/thread.h>
+
 #include <errno.h>
 #include <limits.h>
 #include <unistd.h>
@@ -562,7 +564,7 @@ static int aws_event_loop_listen_for_io_events(int epoll_fd, struct epoll_event 
     return epoll_wait(epoll_fd, events, MAX_EVENTS, timeout);
 }
 
-static void s_aws_cleanup_aws_lc_thread_local_state(void *user_data) {
+static void s_aws_epoll_cleanup_aws_lc_thread_local_state(void *user_data) {
     (void)user_data;
 
 #if defined(OPENSSL_IS_AWSLC)
@@ -584,7 +586,7 @@ static void aws_event_loop_thread(void *args) {
         return;
     }
 
-    aws_thread_current_at_exit(s_aws_cleanup_aws_lc_thread_local_state, NULL);
+    aws_thread_current_at_exit(s_aws_epoll_cleanup_aws_lc_thread_local_state, NULL);
 
     int timeout = DEFAULT_TIMEOUT;
 

--- a/source/linux/epoll_event_loop.c
+++ b/source/linux/epoll_event_loop.c
@@ -5,6 +5,7 @@
 
 #include <aws/io/event_loop.h>
 
+#include <aws/cal/cal.h>
 #include <aws/common/atomics.h>
 #include <aws/common/clock.h>
 #include <aws/common/mutex.h>
@@ -567,9 +568,7 @@ static int aws_event_loop_listen_for_io_events(int epoll_fd, struct epoll_event 
 static void s_aws_epoll_cleanup_aws_lc_thread_local_state(void *user_data) {
     (void)user_data;
 
-#if defined(OPENSSL_IS_AWSLC)
-    AWSLC_thread_local_clear();
-#endif
+    aws_cal_thread_clean_up();
 }
 
 static void aws_event_loop_thread(void *args) {

--- a/source/linux/epoll_event_loop.c
+++ b/source/linux/epoll_event_loop.c
@@ -566,9 +566,7 @@ static int aws_event_loop_listen_for_io_events(int epoll_fd, struct epoll_event 
 static void s_aws_epoll_cleanup_aws_lc_thread_local_state(void *user_data) {
     (void)user_data;
 
-#ifndef BYO_CRYPTO
     aws_cal_thread_clean_up();
-#endif
 }
 
 static void aws_event_loop_thread(void *args) {

--- a/source/linux/epoll_event_loop.c
+++ b/source/linux/epoll_event_loop.c
@@ -566,7 +566,9 @@ static int aws_event_loop_listen_for_io_events(int epoll_fd, struct epoll_event 
 static void s_aws_epoll_cleanup_aws_lc_thread_local_state(void *user_data) {
     (void)user_data;
 
+#ifndef BYO_CRYPTO
     aws_cal_thread_clean_up();
+#endif
 }
 
 static void aws_event_loop_thread(void *args) {


### PR DESCRIPTION
Requires >= v1.11.0 of aws-lc

Part of the fix for https://github.com/awslabs/aws-crt-nodejs/issues/452

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
