### PR TITLE
Readonly file

### DIFF
--- a/source/future.c
+++ b/source/future.c
@@ -295,6 +295,7 @@ static void s_future_impl_set_done(struct aws_future_impl *future, void *src_add
             future->error_code = error_code;
         } else {
             future->owns_result = true;
+            AWS_FATAL_ASSERT(src_address != NULL);
             memcpy(aws_future_impl_get_result_address(future), src_address, future->sizeof_result);
         }
 

--- a/source/stream.c
+++ b/source/stream.c
@@ -287,7 +287,7 @@ struct aws_input_stream *aws_input_stream_new_from_file(struct aws_allocator *al
 
     struct aws_input_stream_file_impl *impl = aws_mem_calloc(allocator, 1, sizeof(struct aws_input_stream_file_impl));
 
-    impl->file = aws_fopen(file_name, "r+b");
+    impl->file = aws_fopen(file_name, "rb");
     if (impl->file == NULL) {
         goto on_error;
     }

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -32,9 +32,10 @@ add_pipe_test_case(pipe_clean_up_cancels_pending_writes)
 
 add_test_case(event_loop_xthread_scheduled_tasks_execute)
 add_test_case(event_loop_canceled_tasks_run_in_el_thread)
-if (USE_IO_COMPLETION_PORTS)
+
+if(USE_IO_COMPLETION_PORTS)
     add_test_case(event_loop_completion_events)
-else ()
+else()
     add_test_case(event_loop_subscribe_unsubscribe)
     add_test_case(event_loop_writable_event_on_subscribe)
     add_test_case(event_loop_no_readable_event_before_write)
@@ -42,7 +43,7 @@ else ()
     add_test_case(event_loop_readable_event_on_subscribe_if_data_present)
     add_test_case(event_loop_readable_event_on_2nd_time_readable)
     add_test_case(event_loop_no_events_after_unsubscribe)
-endif ()
+endif()
 
 add_test_case(event_loop_stop_then_restart)
 add_test_case(event_loop_multiple_stops)
@@ -58,9 +59,10 @@ add_net_test_case(udp_socket_communication)
 add_test_case(udp_bind_connect_communication)
 add_net_test_case(connect_timeout)
 add_net_test_case(connect_timeout_cancelation)
-if (USE_VSOCK)
-	add_test_case(vsock_loopback_socket_communication)
-endif ()
+
+if(USE_VSOCK)
+    add_test_case(vsock_loopback_socket_communication)
+endif()
 
 add_test_case(outgoing_local_sock_errors)
 add_test_case(outgoing_tcp_sock_error)
@@ -75,7 +77,7 @@ add_test_case(cleanup_in_accept_doesnt_explode)
 add_test_case(cleanup_in_write_cb_doesnt_explode)
 add_test_case(sock_write_cb_is_async)
 
-if (WIN32)
+if(WIN32)
     add_test_case(local_socket_pipe_connected_race)
 endif()
 
@@ -120,8 +122,8 @@ add_test_case(socket_handler_echo_and_backpressure)
 add_test_case(socket_handler_close)
 add_test_case(socket_pinned_event_loop)
 
-if (NOT BYO_CRYPTO)
-    if (USE_S2N)
+if(NOT BYO_CRYPTO)
+    if(USE_S2N)
         add_net_test_case(default_pki_path_exists)
     endif()
 
@@ -131,11 +133,11 @@ if (NOT BYO_CRYPTO)
     #
     # We don't use the interception suite since that's a host configuration issue
     # We also don't check the domain security policy suite:
-    #  1. s2n does not support revocation checks and we do not currently enable any revocation checks
-    #    in windows or osx, although we may add configurable support to those platforms(off-by-default) at a
-    #    later date
-    #  2. s2n does not support public key pinning and, given its deprecated and http-centric position, there are no
-    #    plans to add support nor investigate osx/windows support as well.
+    # 1. s2n does not support revocation checks and we do not currently enable any revocation checks
+    # in windows or osx, although we may add configurable support to those platforms(off-by-default) at a
+    # later date
+    # 2. s2n does not support public key pinning and, given its deprecated and http-centric position, there are no
+    # plans to add support nor investigate osx/windows support as well.
 
     # Badssl - Certificate Validation endpoint suite
     # For each failure case, we also include a positive test that verifies success when peer verification is disabled
@@ -161,13 +163,13 @@ if (NOT BYO_CRYPTO)
 
     # Badssl - Legacy crypto suite, includes both negative and positive tests, with override checks where appropriate
     # Our current baseline/default is platform-specific, whereas badssl expects a baseline of 1.2
-    #   Linux - tls1.1
-    #   Windows - system default (1.0 is the only thing we could reasonable fixate to given win7 support)
-    #   Mac - system default
+    # Linux - tls1.1
+    # Windows - system default (1.0 is the only thing we could reasonable fixate to given win7 support)
+    # Mac - system default
     # We skip the cbc and 3des checks, as a positive connection result there does not yet represent a security risk
     # We don't include dh2048 as it succeeds on the windows baseline configuration and there does not seem
     # to be a way to disable it
-    if(NOT (WIN32 AND NOT CMAKE_SYSTEM_VERSION MATCHES "10\.0\.1.*"))
+    if(NOT(WIN32 AND NOT CMAKE_SYSTEM_VERSION MATCHES "10\.0\.1.*"))
         # Skip TLS 1.0 and TLS 1.1 test for windows later than windows server 2022, as they droped old TLS
         add_net_test_case(tls_client_channel_negotiation_error_legacy_crypto_tls10)
         add_net_test_case(tls_client_channel_negotiation_override_legacy_crypto_tls10)
@@ -197,6 +199,7 @@ if (NOT BYO_CRYPTO)
     add_net_test_case(tls_client_channel_negotiation_success_rsa2048)
     add_net_test_case(tls_client_channel_negotiation_success_ecc256)
     add_net_test_case(tls_client_channel_negotiation_success_ecc384)
+
     # add_net_test_case(tls_client_channel_negotiation_success_extended_validation) test disabled until badssl updates cert (expired 2022.08.10)
     add_net_test_case(tls_client_channel_negotiation_success_mozilla_modern)
 
@@ -253,6 +256,7 @@ add_test_case(test_input_stream_file_seek_end)
 add_test_case(test_input_stream_memory_length)
 add_test_case(test_input_stream_file_length)
 add_test_case(test_input_stream_binary)
+add_test_case(test_input_stream_read_only)
 
 add_test_case(async_input_stream_fill_completes_on_thread)
 add_test_case(async_input_stream_fill_completes_immediately)
@@ -264,7 +268,7 @@ add_test_case(open_channel_statistics_test)
 
 add_test_case(shared_library_open_failure)
 
-if (BUILD_SHARED_LIBS)
+if(BUILD_SHARED_LIBS)
     add_test_case(shared_library_open_success)
     add_test_case(shared_library_find_function_failure)
     add_test_case(shared_library_find_function_success)
@@ -283,7 +287,7 @@ add_test_case(test_standard_retry_strategy_failure_exhausts_bucket)
 add_test_case(test_standard_retry_strategy_failure_recovers)
 
 # See PKCS11.md for instructions on running these tests
-if (ENABLE_PKCS11_TESTS)
+if(ENABLE_PKCS11_TESTS)
     add_test_case(pkcs11_lib_sanity_check)
     add_test_case(pkcs11_lib_behavior_default)
     add_test_case(pkcs11_lib_behavior_omit_initialize)
@@ -306,7 +310,7 @@ if (ENABLE_PKCS11_TESTS)
     add_test_case(pkcs11_login_tests)
 
     # TLS with PKCS#11 not currently supported on every platform
-    if (USE_S2N)
+    if(USE_S2N)
         add_test_case(pkcs11_tls_rsa_negotiation_succeeds)
         add_test_case(pkcs11_tls_ec_negotiation_succeeds)
     endif()
@@ -315,11 +319,11 @@ endif()
 set(TEST_BINARY_NAME ${PROJECT_NAME}-tests)
 generate_test_driver(${TEST_BINARY_NAME})
 
-if (USE_S2N)
+if(USE_S2N)
     target_compile_definitions(${PROJECT_NAME}-tests PRIVATE "-DUSE_S2N")
 endif()
 
-#SSL certificates to use for testing.
+# SSL certificates to use for testing.
 add_custom_command(TARGET ${TEST_BINARY_NAME} PRE_BUILD
-        COMMAND ${CMAKE_COMMAND} -E copy_directory
-        ${CMAKE_CURRENT_SOURCE_DIR}/resources $<TARGET_FILE_DIR:${TEST_BINARY_NAME}>)
+    COMMAND ${CMAKE_COMMAND} -E copy_directory
+    ${CMAKE_CURRENT_SOURCE_DIR}/resources $<TARGET_FILE_DIR:${TEST_BINARY_NAME}>)

--- a/tests/stream_test.c
+++ b/tests/stream_test.c
@@ -54,9 +54,15 @@ static struct aws_input_stream *s_create_read_only_file_stream(struct aws_alloca
     FILE *file = aws_fopen(s_test_file_name, "w+b");
     fwrite(s_simple_binary_test, sizeof(uint8_t), sizeof(s_simple_binary_test), file);
     fclose(file);
+#ifdef _WIN32
+    if (_chmod(s_test_file_name, 0444)) {
+        return NULL;
+    }
+#else
     if (chmod(s_test_file_name, 0444)) {
         return NULL;
     }
+#endif
     return aws_input_stream_new_from_file(allocator, s_test_file_name);
 }
 

--- a/tests/stream_test.c
+++ b/tests/stream_test.c
@@ -11,14 +11,14 @@
 
 #include <sys/stat.h>
 
-#ifdef _wIN32
+#ifdef _WIN32
 #    include <io.h>
 #endif
 
-AwS_STATIC_STRING_FROM_LITERAL(s_simple_test, "SimpleTest");
+AWS_STATIC_STRING_FROM_LITERAL(s_simple_test, "SimpleTest");
 
-/* 0x1A represents the windows end-of-file character. Having this in the test data set allows us to verify that file
- * stream reads on binary files do not terminate early on windows.*/
+/* 0x1A represents the Windows end-of-file character. Having this in the test data set allows us to verify that file
+ * stream reads on binary files do not terminate early on Windows.*/
 const uint8_t s_simple_binary_test[] = {'a', 'b', 'c', 'd', 'e', 'f', 0x1A, 'g', 'h', 'i', 'j', 'k'};
 
 const char *s_test_file_name = "stream.dat";
@@ -60,12 +60,12 @@ static struct aws_input_stream *s_create_read_only_file_stream(struct aws_alloca
     FILE *file = aws_fopen(s_test_read_only_file_name, "wb");
     fwrite(s_simple_binary_test, sizeof(uint8_t), sizeof(s_simple_binary_test), file);
     fclose(file);
-#ifdef _wIN32
-    if (_chmod(s_test_read_only_file_name, 0444)) {
+#ifdef _WIN32
+    if (_chmod(s_test_read_only_file_name, _S_IREAD)) {
         return NULL;
     }
 #else
-    if (chmod(s_test_read_only_file_name, 0444)) {
+    if (chmod(s_test_read_only_file_name, 0x0444)) {
         return NULL;
     }
 #endif
@@ -92,7 +92,7 @@ static int s_do_simple_input_stream_test(
     aws_byte_buf_init(&result_buf, allocator, 1024);
 
     struct aws_stream_status status;
-    AwS_ZERO_STRUCT(status);
+    AWS_ZERO_STRUCT(status);
 
     ASSERT_TRUE(aws_input_stream_get_status(stream, &status) == 0);
     ASSERT_TRUE(status.is_end_of_stream == false);
@@ -117,7 +117,7 @@ static int s_do_simple_input_stream_test(
     aws_byte_buf_clean_up(&read_buf);
     aws_byte_buf_clean_up(&result_buf);
 
-    return AwS_OP_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 static int s_test_input_stream_memory_simple(struct aws_allocator *allocator, void *ctx) {
@@ -126,14 +126,14 @@ static int s_test_input_stream_memory_simple(struct aws_allocator *allocator, vo
     struct aws_input_stream *stream = s_create_memory_stream(allocator);
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_string(s_simple_test);
-    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AwS_OP_SUCCESS);
+    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AWS_OP_SUCCESS);
 
     s_destroy_memory_stream(stream);
 
-    return AwS_OP_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
-AwS_TEST_CASE(test_input_stream_memory_simple, s_test_input_stream_memory_simple);
+AWS_TEST_CASE(test_input_stream_memory_simple, s_test_input_stream_memory_simple);
 
 static int s_test_input_stream_memory_iterate(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -141,14 +141,14 @@ static int s_test_input_stream_memory_iterate(struct aws_allocator *allocator, v
     struct aws_input_stream *stream = s_create_memory_stream(allocator);
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_string(s_simple_test);
-    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 2, &test_cursor) == AwS_OP_SUCCESS);
+    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 2, &test_cursor) == AWS_OP_SUCCESS);
 
     s_destroy_memory_stream(stream);
 
-    return AwS_OP_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
-AwS_TEST_CASE(test_input_stream_memory_iterate, s_test_input_stream_memory_iterate);
+AWS_TEST_CASE(test_input_stream_memory_iterate, s_test_input_stream_memory_iterate);
 
 static int s_test_input_stream_file_simple(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -156,14 +156,14 @@ static int s_test_input_stream_file_simple(struct aws_allocator *allocator, void
     struct aws_input_stream *stream = s_create_file_stream(allocator);
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_string(s_simple_test);
-    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AwS_OP_SUCCESS);
+    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AWS_OP_SUCCESS);
 
     s_destroy_file_stream(stream);
 
-    return AwS_OP_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
-AwS_TEST_CASE(test_input_stream_file_simple, s_test_input_stream_file_simple);
+AWS_TEST_CASE(test_input_stream_file_simple, s_test_input_stream_file_simple);
 
 static int s_test_input_stream_file_iterate(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -171,14 +171,14 @@ static int s_test_input_stream_file_iterate(struct aws_allocator *allocator, voi
     struct aws_input_stream *stream = s_create_file_stream(allocator);
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_string(s_simple_test);
-    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 2, &test_cursor) == AwS_OP_SUCCESS);
+    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 2, &test_cursor) == AWS_OP_SUCCESS);
 
     s_destroy_file_stream(stream);
 
-    return AwS_OP_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
-AwS_TEST_CASE(test_input_stream_file_iterate, s_test_input_stream_file_iterate);
+AWS_TEST_CASE(test_input_stream_file_iterate, s_test_input_stream_file_iterate);
 
 static int s_do_input_stream_seek_test(
     struct aws_input_stream *stream,
@@ -198,7 +198,7 @@ static int s_do_input_stream_seek_test(
 
     aws_byte_buf_clean_up(&read_buf);
 
-    return AwS_OP_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
 #define SEEK_BEGINNING_OFFSET 5
@@ -211,15 +211,15 @@ static int s_test_input_stream_memory_seek_beginning(struct aws_allocator *alloc
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_string(s_simple_test);
     aws_byte_cursor_advance(&test_cursor, SEEK_BEGINNING_OFFSET);
     ASSERT_TRUE(
-        s_do_input_stream_seek_test(stream, allocator, SEEK_BEGINNING_OFFSET, AwS_SSB_BEGIN, &test_cursor) ==
-        AwS_OP_SUCCESS);
+        s_do_input_stream_seek_test(stream, allocator, SEEK_BEGINNING_OFFSET, AWS_SSB_BEGIN, &test_cursor) ==
+        AWS_OP_SUCCESS);
 
     s_destroy_memory_stream(stream);
 
-    return AwS_OP_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
-AwS_TEST_CASE(test_input_stream_memory_seek_beginning, s_test_input_stream_memory_seek_beginning);
+AWS_TEST_CASE(test_input_stream_memory_seek_beginning, s_test_input_stream_memory_seek_beginning);
 
 static int s_test_input_stream_file_seek_beginning(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -229,15 +229,15 @@ static int s_test_input_stream_file_seek_beginning(struct aws_allocator *allocat
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_string(s_simple_test);
     aws_byte_cursor_advance(&test_cursor, SEEK_BEGINNING_OFFSET);
     ASSERT_TRUE(
-        s_do_input_stream_seek_test(stream, allocator, SEEK_BEGINNING_OFFSET, AwS_SSB_BEGIN, &test_cursor) ==
-        AwS_OP_SUCCESS);
+        s_do_input_stream_seek_test(stream, allocator, SEEK_BEGINNING_OFFSET, AWS_SSB_BEGIN, &test_cursor) ==
+        AWS_OP_SUCCESS);
 
     s_destroy_file_stream(stream);
 
-    return AwS_OP_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
-AwS_TEST_CASE(test_input_stream_file_seek_beginning, s_test_input_stream_file_seek_beginning);
+AWS_TEST_CASE(test_input_stream_file_seek_beginning, s_test_input_stream_file_seek_beginning);
 
 #define SEEK_END_OFFSET (-3)
 
@@ -249,14 +249,14 @@ static int s_test_input_stream_memory_seek_end(struct aws_allocator *allocator, 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_string(s_simple_test);
     aws_byte_cursor_advance(&test_cursor, (size_t)((int64_t)s_simple_test->len + SEEK_END_OFFSET));
     ASSERT_TRUE(
-        s_do_input_stream_seek_test(stream, allocator, SEEK_END_OFFSET, AwS_SSB_END, &test_cursor) == AwS_OP_SUCCESS);
+        s_do_input_stream_seek_test(stream, allocator, SEEK_END_OFFSET, AWS_SSB_END, &test_cursor) == AWS_OP_SUCCESS);
 
     s_destroy_memory_stream(stream);
 
-    return AwS_OP_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
-AwS_TEST_CASE(test_input_stream_memory_seek_end, s_test_input_stream_memory_seek_end);
+AWS_TEST_CASE(test_input_stream_memory_seek_end, s_test_input_stream_memory_seek_end);
 
 static int s_test_input_stream_memory_seek_multiple_times(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -269,40 +269,40 @@ static int s_test_input_stream_memory_seek_multiple_times(struct aws_allocator *
     struct aws_byte_buf read_buf = aws_byte_buf_from_empty_array(&read_byte, 1);
 
     /* Seek to BEGIN + 2. Read "2" */
-    ASSERT_SUCCESS(aws_input_stream_seek(stream, 2, AwS_SSB_BEGIN));
+    ASSERT_SUCCESS(aws_input_stream_seek(stream, 2, AWS_SSB_BEGIN));
     read_buf.len = 0;
     ASSERT_SUCCESS(aws_input_stream_read(stream, &read_buf));
     ASSERT_INT_EQUALS('2', read_byte);
 
     /* Seek to BEGIN + 4. Read "4" */
-    ASSERT_SUCCESS(aws_input_stream_seek(stream, 4, AwS_SSB_BEGIN));
+    ASSERT_SUCCESS(aws_input_stream_seek(stream, 4, AWS_SSB_BEGIN));
     read_buf.len = 0;
     ASSERT_SUCCESS(aws_input_stream_read(stream, &read_buf));
     ASSERT_INT_EQUALS('4', read_byte);
 
     /* Seek to END - 1. Read "9" */
-    ASSERT_SUCCESS(aws_input_stream_seek(stream, -1, AwS_SSB_END));
+    ASSERT_SUCCESS(aws_input_stream_seek(stream, -1, AWS_SSB_END));
     read_buf.len = 0;
     ASSERT_SUCCESS(aws_input_stream_read(stream, &read_buf));
     ASSERT_INT_EQUALS('9', read_byte);
 
     /* Seek to END - 5. Read "5" */
-    ASSERT_SUCCESS(aws_input_stream_seek(stream, -1, AwS_SSB_END));
+    ASSERT_SUCCESS(aws_input_stream_seek(stream, -1, AWS_SSB_END));
     read_buf.len = 0;
     ASSERT_SUCCESS(aws_input_stream_read(stream, &read_buf));
     ASSERT_INT_EQUALS('9', read_byte);
 
     /* Seek to BEGIN + 0. Read "0" */
-    ASSERT_SUCCESS(aws_input_stream_seek(stream, 4, AwS_SSB_BEGIN));
+    ASSERT_SUCCESS(aws_input_stream_seek(stream, 4, AWS_SSB_BEGIN));
     read_buf.len = 0;
     ASSERT_SUCCESS(aws_input_stream_read(stream, &read_buf));
     ASSERT_INT_EQUALS('4', read_byte);
 
     aws_input_stream_destroy(stream);
-    return AwS_OP_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
-AwS_TEST_CASE(test_input_stream_memory_seek_multiple_times, s_test_input_stream_memory_seek_multiple_times);
+AWS_TEST_CASE(test_input_stream_memory_seek_multiple_times, s_test_input_stream_memory_seek_multiple_times);
 
 static int s_test_input_stream_file_seek_end(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -312,54 +312,54 @@ static int s_test_input_stream_file_seek_end(struct aws_allocator *allocator, vo
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_string(s_simple_test);
     aws_byte_cursor_advance(&test_cursor, (size_t)((int64_t)s_simple_test->len + SEEK_END_OFFSET));
     ASSERT_TRUE(
-        s_do_input_stream_seek_test(stream, allocator, SEEK_END_OFFSET, AwS_SSB_END, &test_cursor) == AwS_OP_SUCCESS);
+        s_do_input_stream_seek_test(stream, allocator, SEEK_END_OFFSET, AWS_SSB_END, &test_cursor) == AWS_OP_SUCCESS);
 
     s_destroy_file_stream(stream);
 
-    return AwS_OP_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
-AwS_TEST_CASE(test_input_stream_file_seek_end, s_test_input_stream_file_seek_end);
+AWS_TEST_CASE(test_input_stream_file_seek_end, s_test_input_stream_file_seek_end);
 
 static int s_test_input_stream_memory_seek_past_end(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
     struct aws_input_stream *stream = s_create_memory_stream(allocator);
 
-    ASSERT_TRUE(aws_input_stream_seek(stream, 13, AwS_SSB_BEGIN) == AwS_OP_ERR);
-    ASSERT_TRUE(aws_last_error() == AwS_IO_STREAM_INVALID_SEEK_POSITION);
+    ASSERT_TRUE(aws_input_stream_seek(stream, 13, AWS_SSB_BEGIN) == AWS_OP_ERR);
+    ASSERT_TRUE(aws_last_error() == AWS_IO_STREAM_INVALID_SEEK_POSITION);
 
     aws_reset_error();
 
-    ASSERT_TRUE(aws_input_stream_seek(stream, 1, AwS_SSB_END) == AwS_OP_ERR);
-    ASSERT_TRUE(aws_last_error() == AwS_IO_STREAM_INVALID_SEEK_POSITION);
+    ASSERT_TRUE(aws_input_stream_seek(stream, 1, AWS_SSB_END) == AWS_OP_ERR);
+    ASSERT_TRUE(aws_last_error() == AWS_IO_STREAM_INVALID_SEEK_POSITION);
 
     s_destroy_memory_stream(stream);
 
-    return AwS_OP_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
-AwS_TEST_CASE(test_input_stream_memory_seek_past_end, s_test_input_stream_memory_seek_past_end);
+AWS_TEST_CASE(test_input_stream_memory_seek_past_end, s_test_input_stream_memory_seek_past_end);
 
 static int s_test_input_stream_memory_seek_before_start(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
     struct aws_input_stream *stream = s_create_memory_stream(allocator);
 
-    ASSERT_TRUE(aws_input_stream_seek(stream, -13, AwS_SSB_END) == AwS_OP_ERR);
-    ASSERT_TRUE(aws_last_error() == AwS_IO_STREAM_INVALID_SEEK_POSITION);
+    ASSERT_TRUE(aws_input_stream_seek(stream, -13, AWS_SSB_END) == AWS_OP_ERR);
+    ASSERT_TRUE(aws_last_error() == AWS_IO_STREAM_INVALID_SEEK_POSITION);
 
     aws_reset_error();
 
-    ASSERT_TRUE(aws_input_stream_seek(stream, -1, AwS_SSB_BEGIN) == AwS_OP_ERR);
-    ASSERT_TRUE(aws_last_error() == AwS_IO_STREAM_INVALID_SEEK_POSITION);
+    ASSERT_TRUE(aws_input_stream_seek(stream, -1, AWS_SSB_BEGIN) == AWS_OP_ERR);
+    ASSERT_TRUE(aws_last_error() == AWS_IO_STREAM_INVALID_SEEK_POSITION);
 
     s_destroy_memory_stream(stream);
 
-    return AwS_OP_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
-AwS_TEST_CASE(test_input_stream_memory_seek_before_start, s_test_input_stream_memory_seek_before_start);
+AWS_TEST_CASE(test_input_stream_memory_seek_before_start, s_test_input_stream_memory_seek_before_start);
 
 #define LENGTH_SEEK_OFFSET 3
 
@@ -369,21 +369,21 @@ static int s_test_input_stream_memory_length(struct aws_allocator *allocator, vo
     struct aws_input_stream *stream = s_create_memory_stream(allocator);
 
     int64_t length = 0;
-    ASSERT_TRUE(aws_input_stream_get_length(stream, &length) == AwS_OP_SUCCESS);
+    ASSERT_TRUE(aws_input_stream_get_length(stream, &length) == AWS_OP_SUCCESS);
     ASSERT_TRUE(length == (int64_t)s_simple_test->len);
 
     /* invariant under seeking */
-    aws_input_stream_seek(stream, LENGTH_SEEK_OFFSET, AwS_SSB_BEGIN);
+    aws_input_stream_seek(stream, LENGTH_SEEK_OFFSET, AWS_SSB_BEGIN);
 
-    ASSERT_TRUE(aws_input_stream_get_length(stream, &length) == AwS_OP_SUCCESS);
+    ASSERT_TRUE(aws_input_stream_get_length(stream, &length) == AWS_OP_SUCCESS);
     ASSERT_TRUE(length == (int64_t)s_simple_test->len);
 
     s_destroy_memory_stream(stream);
 
-    return AwS_OP_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
-AwS_TEST_CASE(test_input_stream_memory_length, s_test_input_stream_memory_length);
+AWS_TEST_CASE(test_input_stream_memory_length, s_test_input_stream_memory_length);
 
 static int s_test_input_stream_file_length(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -391,21 +391,21 @@ static int s_test_input_stream_file_length(struct aws_allocator *allocator, void
     struct aws_input_stream *stream = s_create_file_stream(allocator);
 
     int64_t length = 0;
-    ASSERT_TRUE(aws_input_stream_get_length(stream, &length) == AwS_OP_SUCCESS);
+    ASSERT_TRUE(aws_input_stream_get_length(stream, &length) == AWS_OP_SUCCESS);
     ASSERT_TRUE(length == (int64_t)s_simple_test->len);
 
     /* invariant under seeking */
-    aws_input_stream_seek(stream, LENGTH_SEEK_OFFSET, AwS_SSB_BEGIN);
+    aws_input_stream_seek(stream, LENGTH_SEEK_OFFSET, AWS_SSB_BEGIN);
 
-    ASSERT_TRUE(aws_input_stream_get_length(stream, &length) == AwS_OP_SUCCESS);
+    ASSERT_TRUE(aws_input_stream_get_length(stream, &length) == AWS_OP_SUCCESS);
     ASSERT_TRUE(length == (int64_t)s_simple_test->len);
 
     s_destroy_file_stream(stream);
 
-    return AwS_OP_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
-AwS_TEST_CASE(test_input_stream_file_length, s_test_input_stream_file_length);
+AWS_TEST_CASE(test_input_stream_file_length, s_test_input_stream_file_length);
 
 static int s_test_input_stream_binary(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -417,14 +417,14 @@ static int s_test_input_stream_binary(struct aws_allocator *allocator, void *ctx
         .len = sizeof(s_simple_binary_test),
     };
 
-    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AwS_OP_SUCCESS);
+    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AWS_OP_SUCCESS);
 
     s_destroy_file_stream(stream);
 
-    return AwS_OP_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
-AwS_TEST_CASE(test_input_stream_binary, s_test_input_stream_binary);
+AWS_TEST_CASE(test_input_stream_binary, s_test_input_stream_binary);
 
 static int s_test_input_stream_read_only(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -437,11 +437,11 @@ static int s_test_input_stream_read_only(struct aws_allocator *allocator, void *
         .len = sizeof(s_simple_binary_test),
     };
 
-    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AwS_OP_SUCCESS);
+    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AWS_OP_SUCCESS);
 
     s_destroy_file_stream(stream);
 
-    return AwS_OP_SUCCESS;
+    return AWS_OP_SUCCESS;
 }
 
-AwS_TEST_CASE(test_input_stream_read_only, s_test_input_stream_read_only);
+AWS_TEST_CASE(test_input_stream_read_only, s_test_input_stream_read_only);

--- a/tests/stream_test.c
+++ b/tests/stream_test.c
@@ -417,7 +417,7 @@ static int s_test_input_stream_binary(struct aws_allocator *allocator, void *ctx
 
     ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AWS_OP_SUCCESS);
 
-    s_destroy_file_stream(stream, s_simple_binary_test);
+    s_destroy_file_stream(stream, s_test_binary_file_name);
 
     return AWS_OP_SUCCESS;
 }

--- a/tests/stream_test.c
+++ b/tests/stream_test.c
@@ -11,6 +11,10 @@
 
 #include <sys/stat.h>
 
+#ifdef _WIN32
+#    include <io.h>
+#endif
+
 AWS_STATIC_STRING_FROM_LITERAL(s_simple_test, "SimpleTest");
 
 /* 0x1A represents the Windows end-of-file character. Having this in the test data set allows us to verify that file

--- a/tests/stream_test.c
+++ b/tests/stream_test.c
@@ -72,12 +72,10 @@ static struct aws_input_stream *s_create_read_only_file_stream(struct aws_alloca
     return aws_input_stream_new_from_file(allocator, s_test_read_only_file_name);
 }
 
-static void s_destroy_file_stream(struct aws_input_stream *stream) {
+static void s_destroy_file_stream(struct aws_input_stream *stream, const char *file_path) {
     aws_input_stream_destroy(stream);
 
-    remove(s_test_file_name);
-    remove(s_test_binary_file_name);
-    remove(s_test_read_only_file_name);
+    remove(file_path);
 }
 
 static int s_do_simple_input_stream_test(
@@ -158,7 +156,7 @@ static int s_test_input_stream_file_simple(struct aws_allocator *allocator, void
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_string(s_simple_test);
     ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AWS_OP_SUCCESS);
 
-    s_destroy_file_stream(stream);
+    s_destroy_file_stream(stream, s_test_file_name);
 
     return AWS_OP_SUCCESS;
 }
@@ -173,7 +171,7 @@ static int s_test_input_stream_file_iterate(struct aws_allocator *allocator, voi
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_string(s_simple_test);
     ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 2, &test_cursor) == AWS_OP_SUCCESS);
 
-    s_destroy_file_stream(stream);
+    s_destroy_file_stream(stream, s_test_file_name);
 
     return AWS_OP_SUCCESS;
 }
@@ -232,7 +230,7 @@ static int s_test_input_stream_file_seek_beginning(struct aws_allocator *allocat
         s_do_input_stream_seek_test(stream, allocator, SEEK_BEGINNING_OFFSET, AWS_SSB_BEGIN, &test_cursor) ==
         AWS_OP_SUCCESS);
 
-    s_destroy_file_stream(stream);
+    s_destroy_file_stream(stream, s_test_file_name);
 
     return AWS_OP_SUCCESS;
 }
@@ -314,7 +312,7 @@ static int s_test_input_stream_file_seek_end(struct aws_allocator *allocator, vo
     ASSERT_TRUE(
         s_do_input_stream_seek_test(stream, allocator, SEEK_END_OFFSET, AWS_SSB_END, &test_cursor) == AWS_OP_SUCCESS);
 
-    s_destroy_file_stream(stream);
+    s_destroy_file_stream(stream, s_test_file_name);
 
     return AWS_OP_SUCCESS;
 }
@@ -400,7 +398,7 @@ static int s_test_input_stream_file_length(struct aws_allocator *allocator, void
     ASSERT_TRUE(aws_input_stream_get_length(stream, &length) == AWS_OP_SUCCESS);
     ASSERT_TRUE(length == (int64_t)s_simple_test->len);
 
-    s_destroy_file_stream(stream);
+    s_destroy_file_stream(stream, s_test_file_name);
 
     return AWS_OP_SUCCESS;
 }
@@ -419,7 +417,7 @@ static int s_test_input_stream_binary(struct aws_allocator *allocator, void *ctx
 
     ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AWS_OP_SUCCESS);
 
-    s_destroy_file_stream(stream);
+    s_destroy_file_stream(stream, s_simple_binary_test);
 
     return AWS_OP_SUCCESS;
 }
@@ -439,7 +437,7 @@ static int s_test_input_stream_read_only(struct aws_allocator *allocator, void *
 
     ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AWS_OP_SUCCESS);
 
-    s_destroy_file_stream(stream);
+    s_destroy_file_stream(stream, s_test_read_only_file_name);
 
     return AWS_OP_SUCCESS;
 }

--- a/tests/stream_test.c
+++ b/tests/stream_test.c
@@ -11,17 +11,19 @@
 
 #include <sys/stat.h>
 
-#ifdef _WIN32
+#ifdef _wIN32
 #    include <io.h>
 #endif
 
-AWS_STATIC_STRING_FROM_LITERAL(s_simple_test, "SimpleTest");
+AwS_STATIC_STRING_FROM_LITERAL(s_simple_test, "SimpleTest");
 
-/* 0x1A represents the Windows end-of-file character. Having this in the test data set allows us to verify that file
- * stream reads on binary files do not terminate early on Windows.*/
+/* 0x1A represents the windows end-of-file character. Having this in the test data set allows us to verify that file
+ * stream reads on binary files do not terminate early on windows.*/
 const uint8_t s_simple_binary_test[] = {'a', 'b', 'c', 'd', 'e', 'f', 0x1A, 'g', 'h', 'i', 'j', 'k'};
 
 const char *s_test_file_name = "stream.dat";
+const char *s_test_binary_file_name = "binary_stream.dat";
+const char *s_test_read_only_file_name = "readonly_stream.dat";
 
 static struct aws_input_stream *s_create_memory_stream(struct aws_allocator *allocator) {
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_string(s_simple_test);
@@ -35,7 +37,7 @@ static void s_destroy_memory_stream(struct aws_input_stream *stream) {
 static struct aws_input_stream *s_create_file_stream(struct aws_allocator *allocator) {
     remove(s_test_file_name);
 
-    FILE *file = aws_fopen(s_test_file_name, "w+");
+    FILE *file = aws_fopen(s_test_file_name, "w");
     fprintf(file, "%s", (char *)s_simple_test->bytes);
     fclose(file);
 
@@ -43,37 +45,39 @@ static struct aws_input_stream *s_create_file_stream(struct aws_allocator *alloc
 }
 
 static struct aws_input_stream *s_create_binary_file_stream(struct aws_allocator *allocator) {
-    remove(s_test_file_name);
+    remove(s_test_binary_file_name);
 
-    FILE *file = aws_fopen(s_test_file_name, "w+b");
+    FILE *file = aws_fopen(s_test_binary_file_name, "wb");
     fwrite(s_simple_binary_test, sizeof(uint8_t), sizeof(s_simple_binary_test), file);
     fclose(file);
 
-    return aws_input_stream_new_from_file(allocator, s_test_file_name);
+    return aws_input_stream_new_from_file(allocator, s_test_binary_file_name);
 }
 
 static struct aws_input_stream *s_create_read_only_file_stream(struct aws_allocator *allocator) {
-    remove(s_test_file_name);
+    remove(s_test_read_only_file_name);
 
-    FILE *file = aws_fopen(s_test_file_name, "w+b");
+    FILE *file = aws_fopen(s_test_read_only_file_name, "wb");
     fwrite(s_simple_binary_test, sizeof(uint8_t), sizeof(s_simple_binary_test), file);
     fclose(file);
-#ifdef _WIN32
-    if (_chmod(s_test_file_name, 0444)) {
+#ifdef _wIN32
+    if (_chmod(s_test_read_only_file_name, 0444)) {
         return NULL;
     }
 #else
-    if (chmod(s_test_file_name, 0444)) {
+    if (chmod(s_test_read_only_file_name, 0444)) {
         return NULL;
     }
 #endif
-    return aws_input_stream_new_from_file(allocator, s_test_file_name);
+    return aws_input_stream_new_from_file(allocator, s_test_read_only_file_name);
 }
 
 static void s_destroy_file_stream(struct aws_input_stream *stream) {
     aws_input_stream_destroy(stream);
 
     remove(s_test_file_name);
+    remove(s_test_binary_file_name);
+    remove(s_test_read_only_file_name);
 }
 
 static int s_do_simple_input_stream_test(
@@ -88,7 +92,7 @@ static int s_do_simple_input_stream_test(
     aws_byte_buf_init(&result_buf, allocator, 1024);
 
     struct aws_stream_status status;
-    AWS_ZERO_STRUCT(status);
+    AwS_ZERO_STRUCT(status);
 
     ASSERT_TRUE(aws_input_stream_get_status(stream, &status) == 0);
     ASSERT_TRUE(status.is_end_of_stream == false);
@@ -113,7 +117,7 @@ static int s_do_simple_input_stream_test(
     aws_byte_buf_clean_up(&read_buf);
     aws_byte_buf_clean_up(&result_buf);
 
-    return AWS_OP_SUCCESS;
+    return AwS_OP_SUCCESS;
 }
 
 static int s_test_input_stream_memory_simple(struct aws_allocator *allocator, void *ctx) {
@@ -122,14 +126,14 @@ static int s_test_input_stream_memory_simple(struct aws_allocator *allocator, vo
     struct aws_input_stream *stream = s_create_memory_stream(allocator);
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_string(s_simple_test);
-    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AWS_OP_SUCCESS);
+    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AwS_OP_SUCCESS);
 
     s_destroy_memory_stream(stream);
 
-    return AWS_OP_SUCCESS;
+    return AwS_OP_SUCCESS;
 }
 
-AWS_TEST_CASE(test_input_stream_memory_simple, s_test_input_stream_memory_simple);
+AwS_TEST_CASE(test_input_stream_memory_simple, s_test_input_stream_memory_simple);
 
 static int s_test_input_stream_memory_iterate(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -137,14 +141,14 @@ static int s_test_input_stream_memory_iterate(struct aws_allocator *allocator, v
     struct aws_input_stream *stream = s_create_memory_stream(allocator);
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_string(s_simple_test);
-    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 2, &test_cursor) == AWS_OP_SUCCESS);
+    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 2, &test_cursor) == AwS_OP_SUCCESS);
 
     s_destroy_memory_stream(stream);
 
-    return AWS_OP_SUCCESS;
+    return AwS_OP_SUCCESS;
 }
 
-AWS_TEST_CASE(test_input_stream_memory_iterate, s_test_input_stream_memory_iterate);
+AwS_TEST_CASE(test_input_stream_memory_iterate, s_test_input_stream_memory_iterate);
 
 static int s_test_input_stream_file_simple(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -152,14 +156,14 @@ static int s_test_input_stream_file_simple(struct aws_allocator *allocator, void
     struct aws_input_stream *stream = s_create_file_stream(allocator);
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_string(s_simple_test);
-    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AWS_OP_SUCCESS);
+    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AwS_OP_SUCCESS);
 
     s_destroy_file_stream(stream);
 
-    return AWS_OP_SUCCESS;
+    return AwS_OP_SUCCESS;
 }
 
-AWS_TEST_CASE(test_input_stream_file_simple, s_test_input_stream_file_simple);
+AwS_TEST_CASE(test_input_stream_file_simple, s_test_input_stream_file_simple);
 
 static int s_test_input_stream_file_iterate(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -167,14 +171,14 @@ static int s_test_input_stream_file_iterate(struct aws_allocator *allocator, voi
     struct aws_input_stream *stream = s_create_file_stream(allocator);
 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_string(s_simple_test);
-    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 2, &test_cursor) == AWS_OP_SUCCESS);
+    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 2, &test_cursor) == AwS_OP_SUCCESS);
 
     s_destroy_file_stream(stream);
 
-    return AWS_OP_SUCCESS;
+    return AwS_OP_SUCCESS;
 }
 
-AWS_TEST_CASE(test_input_stream_file_iterate, s_test_input_stream_file_iterate);
+AwS_TEST_CASE(test_input_stream_file_iterate, s_test_input_stream_file_iterate);
 
 static int s_do_input_stream_seek_test(
     struct aws_input_stream *stream,
@@ -194,7 +198,7 @@ static int s_do_input_stream_seek_test(
 
     aws_byte_buf_clean_up(&read_buf);
 
-    return AWS_OP_SUCCESS;
+    return AwS_OP_SUCCESS;
 }
 
 #define SEEK_BEGINNING_OFFSET 5
@@ -207,15 +211,15 @@ static int s_test_input_stream_memory_seek_beginning(struct aws_allocator *alloc
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_string(s_simple_test);
     aws_byte_cursor_advance(&test_cursor, SEEK_BEGINNING_OFFSET);
     ASSERT_TRUE(
-        s_do_input_stream_seek_test(stream, allocator, SEEK_BEGINNING_OFFSET, AWS_SSB_BEGIN, &test_cursor) ==
-        AWS_OP_SUCCESS);
+        s_do_input_stream_seek_test(stream, allocator, SEEK_BEGINNING_OFFSET, AwS_SSB_BEGIN, &test_cursor) ==
+        AwS_OP_SUCCESS);
 
     s_destroy_memory_stream(stream);
 
-    return AWS_OP_SUCCESS;
+    return AwS_OP_SUCCESS;
 }
 
-AWS_TEST_CASE(test_input_stream_memory_seek_beginning, s_test_input_stream_memory_seek_beginning);
+AwS_TEST_CASE(test_input_stream_memory_seek_beginning, s_test_input_stream_memory_seek_beginning);
 
 static int s_test_input_stream_file_seek_beginning(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -225,15 +229,15 @@ static int s_test_input_stream_file_seek_beginning(struct aws_allocator *allocat
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_string(s_simple_test);
     aws_byte_cursor_advance(&test_cursor, SEEK_BEGINNING_OFFSET);
     ASSERT_TRUE(
-        s_do_input_stream_seek_test(stream, allocator, SEEK_BEGINNING_OFFSET, AWS_SSB_BEGIN, &test_cursor) ==
-        AWS_OP_SUCCESS);
+        s_do_input_stream_seek_test(stream, allocator, SEEK_BEGINNING_OFFSET, AwS_SSB_BEGIN, &test_cursor) ==
+        AwS_OP_SUCCESS);
 
     s_destroy_file_stream(stream);
 
-    return AWS_OP_SUCCESS;
+    return AwS_OP_SUCCESS;
 }
 
-AWS_TEST_CASE(test_input_stream_file_seek_beginning, s_test_input_stream_file_seek_beginning);
+AwS_TEST_CASE(test_input_stream_file_seek_beginning, s_test_input_stream_file_seek_beginning);
 
 #define SEEK_END_OFFSET (-3)
 
@@ -245,14 +249,14 @@ static int s_test_input_stream_memory_seek_end(struct aws_allocator *allocator, 
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_string(s_simple_test);
     aws_byte_cursor_advance(&test_cursor, (size_t)((int64_t)s_simple_test->len + SEEK_END_OFFSET));
     ASSERT_TRUE(
-        s_do_input_stream_seek_test(stream, allocator, SEEK_END_OFFSET, AWS_SSB_END, &test_cursor) == AWS_OP_SUCCESS);
+        s_do_input_stream_seek_test(stream, allocator, SEEK_END_OFFSET, AwS_SSB_END, &test_cursor) == AwS_OP_SUCCESS);
 
     s_destroy_memory_stream(stream);
 
-    return AWS_OP_SUCCESS;
+    return AwS_OP_SUCCESS;
 }
 
-AWS_TEST_CASE(test_input_stream_memory_seek_end, s_test_input_stream_memory_seek_end);
+AwS_TEST_CASE(test_input_stream_memory_seek_end, s_test_input_stream_memory_seek_end);
 
 static int s_test_input_stream_memory_seek_multiple_times(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -265,40 +269,40 @@ static int s_test_input_stream_memory_seek_multiple_times(struct aws_allocator *
     struct aws_byte_buf read_buf = aws_byte_buf_from_empty_array(&read_byte, 1);
 
     /* Seek to BEGIN + 2. Read "2" */
-    ASSERT_SUCCESS(aws_input_stream_seek(stream, 2, AWS_SSB_BEGIN));
+    ASSERT_SUCCESS(aws_input_stream_seek(stream, 2, AwS_SSB_BEGIN));
     read_buf.len = 0;
     ASSERT_SUCCESS(aws_input_stream_read(stream, &read_buf));
     ASSERT_INT_EQUALS('2', read_byte);
 
     /* Seek to BEGIN + 4. Read "4" */
-    ASSERT_SUCCESS(aws_input_stream_seek(stream, 4, AWS_SSB_BEGIN));
+    ASSERT_SUCCESS(aws_input_stream_seek(stream, 4, AwS_SSB_BEGIN));
     read_buf.len = 0;
     ASSERT_SUCCESS(aws_input_stream_read(stream, &read_buf));
     ASSERT_INT_EQUALS('4', read_byte);
 
     /* Seek to END - 1. Read "9" */
-    ASSERT_SUCCESS(aws_input_stream_seek(stream, -1, AWS_SSB_END));
+    ASSERT_SUCCESS(aws_input_stream_seek(stream, -1, AwS_SSB_END));
     read_buf.len = 0;
     ASSERT_SUCCESS(aws_input_stream_read(stream, &read_buf));
     ASSERT_INT_EQUALS('9', read_byte);
 
     /* Seek to END - 5. Read "5" */
-    ASSERT_SUCCESS(aws_input_stream_seek(stream, -1, AWS_SSB_END));
+    ASSERT_SUCCESS(aws_input_stream_seek(stream, -1, AwS_SSB_END));
     read_buf.len = 0;
     ASSERT_SUCCESS(aws_input_stream_read(stream, &read_buf));
     ASSERT_INT_EQUALS('9', read_byte);
 
     /* Seek to BEGIN + 0. Read "0" */
-    ASSERT_SUCCESS(aws_input_stream_seek(stream, 4, AWS_SSB_BEGIN));
+    ASSERT_SUCCESS(aws_input_stream_seek(stream, 4, AwS_SSB_BEGIN));
     read_buf.len = 0;
     ASSERT_SUCCESS(aws_input_stream_read(stream, &read_buf));
     ASSERT_INT_EQUALS('4', read_byte);
 
     aws_input_stream_destroy(stream);
-    return AWS_OP_SUCCESS;
+    return AwS_OP_SUCCESS;
 }
 
-AWS_TEST_CASE(test_input_stream_memory_seek_multiple_times, s_test_input_stream_memory_seek_multiple_times);
+AwS_TEST_CASE(test_input_stream_memory_seek_multiple_times, s_test_input_stream_memory_seek_multiple_times);
 
 static int s_test_input_stream_file_seek_end(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -308,54 +312,54 @@ static int s_test_input_stream_file_seek_end(struct aws_allocator *allocator, vo
     struct aws_byte_cursor test_cursor = aws_byte_cursor_from_string(s_simple_test);
     aws_byte_cursor_advance(&test_cursor, (size_t)((int64_t)s_simple_test->len + SEEK_END_OFFSET));
     ASSERT_TRUE(
-        s_do_input_stream_seek_test(stream, allocator, SEEK_END_OFFSET, AWS_SSB_END, &test_cursor) == AWS_OP_SUCCESS);
+        s_do_input_stream_seek_test(stream, allocator, SEEK_END_OFFSET, AwS_SSB_END, &test_cursor) == AwS_OP_SUCCESS);
 
     s_destroy_file_stream(stream);
 
-    return AWS_OP_SUCCESS;
+    return AwS_OP_SUCCESS;
 }
 
-AWS_TEST_CASE(test_input_stream_file_seek_end, s_test_input_stream_file_seek_end);
+AwS_TEST_CASE(test_input_stream_file_seek_end, s_test_input_stream_file_seek_end);
 
 static int s_test_input_stream_memory_seek_past_end(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
     struct aws_input_stream *stream = s_create_memory_stream(allocator);
 
-    ASSERT_TRUE(aws_input_stream_seek(stream, 13, AWS_SSB_BEGIN) == AWS_OP_ERR);
-    ASSERT_TRUE(aws_last_error() == AWS_IO_STREAM_INVALID_SEEK_POSITION);
+    ASSERT_TRUE(aws_input_stream_seek(stream, 13, AwS_SSB_BEGIN) == AwS_OP_ERR);
+    ASSERT_TRUE(aws_last_error() == AwS_IO_STREAM_INVALID_SEEK_POSITION);
 
     aws_reset_error();
 
-    ASSERT_TRUE(aws_input_stream_seek(stream, 1, AWS_SSB_END) == AWS_OP_ERR);
-    ASSERT_TRUE(aws_last_error() == AWS_IO_STREAM_INVALID_SEEK_POSITION);
+    ASSERT_TRUE(aws_input_stream_seek(stream, 1, AwS_SSB_END) == AwS_OP_ERR);
+    ASSERT_TRUE(aws_last_error() == AwS_IO_STREAM_INVALID_SEEK_POSITION);
 
     s_destroy_memory_stream(stream);
 
-    return AWS_OP_SUCCESS;
+    return AwS_OP_SUCCESS;
 }
 
-AWS_TEST_CASE(test_input_stream_memory_seek_past_end, s_test_input_stream_memory_seek_past_end);
+AwS_TEST_CASE(test_input_stream_memory_seek_past_end, s_test_input_stream_memory_seek_past_end);
 
 static int s_test_input_stream_memory_seek_before_start(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
     struct aws_input_stream *stream = s_create_memory_stream(allocator);
 
-    ASSERT_TRUE(aws_input_stream_seek(stream, -13, AWS_SSB_END) == AWS_OP_ERR);
-    ASSERT_TRUE(aws_last_error() == AWS_IO_STREAM_INVALID_SEEK_POSITION);
+    ASSERT_TRUE(aws_input_stream_seek(stream, -13, AwS_SSB_END) == AwS_OP_ERR);
+    ASSERT_TRUE(aws_last_error() == AwS_IO_STREAM_INVALID_SEEK_POSITION);
 
     aws_reset_error();
 
-    ASSERT_TRUE(aws_input_stream_seek(stream, -1, AWS_SSB_BEGIN) == AWS_OP_ERR);
-    ASSERT_TRUE(aws_last_error() == AWS_IO_STREAM_INVALID_SEEK_POSITION);
+    ASSERT_TRUE(aws_input_stream_seek(stream, -1, AwS_SSB_BEGIN) == AwS_OP_ERR);
+    ASSERT_TRUE(aws_last_error() == AwS_IO_STREAM_INVALID_SEEK_POSITION);
 
     s_destroy_memory_stream(stream);
 
-    return AWS_OP_SUCCESS;
+    return AwS_OP_SUCCESS;
 }
 
-AWS_TEST_CASE(test_input_stream_memory_seek_before_start, s_test_input_stream_memory_seek_before_start);
+AwS_TEST_CASE(test_input_stream_memory_seek_before_start, s_test_input_stream_memory_seek_before_start);
 
 #define LENGTH_SEEK_OFFSET 3
 
@@ -365,21 +369,21 @@ static int s_test_input_stream_memory_length(struct aws_allocator *allocator, vo
     struct aws_input_stream *stream = s_create_memory_stream(allocator);
 
     int64_t length = 0;
-    ASSERT_TRUE(aws_input_stream_get_length(stream, &length) == AWS_OP_SUCCESS);
+    ASSERT_TRUE(aws_input_stream_get_length(stream, &length) == AwS_OP_SUCCESS);
     ASSERT_TRUE(length == (int64_t)s_simple_test->len);
 
     /* invariant under seeking */
-    aws_input_stream_seek(stream, LENGTH_SEEK_OFFSET, AWS_SSB_BEGIN);
+    aws_input_stream_seek(stream, LENGTH_SEEK_OFFSET, AwS_SSB_BEGIN);
 
-    ASSERT_TRUE(aws_input_stream_get_length(stream, &length) == AWS_OP_SUCCESS);
+    ASSERT_TRUE(aws_input_stream_get_length(stream, &length) == AwS_OP_SUCCESS);
     ASSERT_TRUE(length == (int64_t)s_simple_test->len);
 
     s_destroy_memory_stream(stream);
 
-    return AWS_OP_SUCCESS;
+    return AwS_OP_SUCCESS;
 }
 
-AWS_TEST_CASE(test_input_stream_memory_length, s_test_input_stream_memory_length);
+AwS_TEST_CASE(test_input_stream_memory_length, s_test_input_stream_memory_length);
 
 static int s_test_input_stream_file_length(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -387,21 +391,21 @@ static int s_test_input_stream_file_length(struct aws_allocator *allocator, void
     struct aws_input_stream *stream = s_create_file_stream(allocator);
 
     int64_t length = 0;
-    ASSERT_TRUE(aws_input_stream_get_length(stream, &length) == AWS_OP_SUCCESS);
+    ASSERT_TRUE(aws_input_stream_get_length(stream, &length) == AwS_OP_SUCCESS);
     ASSERT_TRUE(length == (int64_t)s_simple_test->len);
 
     /* invariant under seeking */
-    aws_input_stream_seek(stream, LENGTH_SEEK_OFFSET, AWS_SSB_BEGIN);
+    aws_input_stream_seek(stream, LENGTH_SEEK_OFFSET, AwS_SSB_BEGIN);
 
-    ASSERT_TRUE(aws_input_stream_get_length(stream, &length) == AWS_OP_SUCCESS);
+    ASSERT_TRUE(aws_input_stream_get_length(stream, &length) == AwS_OP_SUCCESS);
     ASSERT_TRUE(length == (int64_t)s_simple_test->len);
 
     s_destroy_file_stream(stream);
 
-    return AWS_OP_SUCCESS;
+    return AwS_OP_SUCCESS;
 }
 
-AWS_TEST_CASE(test_input_stream_file_length, s_test_input_stream_file_length);
+AwS_TEST_CASE(test_input_stream_file_length, s_test_input_stream_file_length);
 
 static int s_test_input_stream_binary(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -413,14 +417,14 @@ static int s_test_input_stream_binary(struct aws_allocator *allocator, void *ctx
         .len = sizeof(s_simple_binary_test),
     };
 
-    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AWS_OP_SUCCESS);
+    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AwS_OP_SUCCESS);
 
     s_destroy_file_stream(stream);
 
-    return AWS_OP_SUCCESS;
+    return AwS_OP_SUCCESS;
 }
 
-AWS_TEST_CASE(test_input_stream_binary, s_test_input_stream_binary);
+AwS_TEST_CASE(test_input_stream_binary, s_test_input_stream_binary);
 
 static int s_test_input_stream_read_only(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -433,11 +437,11 @@ static int s_test_input_stream_read_only(struct aws_allocator *allocator, void *
         .len = sizeof(s_simple_binary_test),
     };
 
-    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AWS_OP_SUCCESS);
+    ASSERT_TRUE(s_do_simple_input_stream_test(stream, allocator, 100, &test_cursor) == AwS_OP_SUCCESS);
 
     s_destroy_file_stream(stream);
 
-    return AWS_OP_SUCCESS;
+    return AwS_OP_SUCCESS;
 }
 
-AWS_TEST_CASE(test_input_stream_read_only, s_test_input_stream_read_only);
+AwS_TEST_CASE(test_input_stream_read_only, s_test_input_stream_read_only);

--- a/tests/stream_test.c
+++ b/tests/stream_test.c
@@ -65,7 +65,7 @@ static struct aws_input_stream *s_create_read_only_file_stream(struct aws_alloca
         return NULL;
     }
 #else
-    if (chmod(s_test_read_only_file_name, 0x0444)) {
+    if (chmod(s_test_read_only_file_name, S_IRUSR | S_IRGRP | S_IROTH)) {
         return NULL;
     }
 #endif


### PR DESCRIPTION
*Issue #, if available:*

- https://github.com/awslabs/aws-crt-cpp/issues/508

*Description of changes:*

- Use `rb` instead of `r+b` for supporting read only files. 
- We open file for input stream that we only needs to read from.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
