### PR TITLE
[retry]: add support for truncated exponential backoff (#583)

### DIFF
--- a/include/aws/io/retry_strategy.h
+++ b/include/aws/io/retry_strategy.h
@@ -112,6 +112,8 @@ struct aws_exponential_backoff_retry_options {
     size_t max_retries;
     /** Scaling factor to add for the backoff. Default is 25ms */
     uint32_t backoff_scale_factor_ms;
+    /** Maximum retry delay in milliseconds. A value of 0 disables this upper bound. */
+    uint32_t maximum_delay_ms;
     /** Jitter mode to use, see comments for aws_exponential_backoff_jitter_mode.
      * Default is AWS_EXPONENTIAL_BACKOFF_JITTER_DEFAULT */
     enum aws_exponential_backoff_jitter_mode jitter_mode;


### PR DESCRIPTION
Backward-compatible support for truncated exponential back-off, as per original AWS post.

This is configured via `maximum_delay_ms`. A value of 0 disables this feature.

The implementation computes the maximum retry count as
```
max_retry_count = log2(max_delay_msec / scale_factor_msec)
```
Resolves #583.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
