### PR TITLE
Change S2N security policy for 0-RTT in TLS 1.3

### DIFF
--- a/builder.json
+++ b/builder.json
@@ -5,7 +5,6 @@
         { "name": "aws-c-cal" },
         {
             "name": "s2n",
-            "revision": "v1.3.11",
             "targets": ["linux", "android"]
         }
     ],

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -1373,7 +1373,8 @@ static struct aws_tls_ctx *s_tls_ctx_new(
     }
 
     if (options->custom_key_op_handler != NULL) {
-        /* PKCS#11 integration hasn't been tested with TLS 1.3, so don't use cipher preferences that allow 1.3 */
+        /* When custom_key_op_handler is set, don't use cipher preferences that allow TLS 1.3.
+         * This hack is necessary until our PKCS#11 custom_key_op_handler supports RSA PSS */
         switch (options->minimum_tls_version) {
             case AWS_IO_SSLv3:
                 s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "CloudFront-SSL-v-3");
@@ -1396,25 +1397,26 @@ static struct aws_tls_ctx *s_tls_ctx_new(
                 s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "ELBSecurityPolicy-TLS-1-1-2017-01");
         }
     } else {
+        /* No custom_key_op_handler is set, use normal cipher preferences */
         switch (options->minimum_tls_version) {
             case AWS_IO_SSLv3:
-                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-SSLv3.0");
+                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-SSLv3.0-2023");
                 break;
             case AWS_IO_TLSv1:
-                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-TLSv1.0");
+                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-TLSv1.0-2023");
                 break;
             case AWS_IO_TLSv1_1:
-                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-TLSv1.1");
+                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-TLSv1.1-2023");
                 break;
             case AWS_IO_TLSv1_2:
-                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-TLSv1.2");
+                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-TLSv1.2-2023");
                 break;
             case AWS_IO_TLSv1_3:
-                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-TLSv1.3");
+                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-TLSv1.3-2023");
                 break;
             case AWS_IO_TLS_VER_SYS_DEFAULTS:
             default:
-                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-TLSv1.0");
+                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-TLSv1.0-2023");
         }
     }
 

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -1372,21 +1372,22 @@ static struct aws_tls_ctx *s_tls_ctx_new(
         goto cleanup_s2n_config;
     }
 
+    const char *security_policy = NULL;
     if (options->custom_key_op_handler != NULL) {
-        /* When custom_key_op_handler is set, don't use cipher preferences that allow TLS 1.3.
+        /* When custom_key_op_handler is set, don't use security policy that allow TLS 1.3.
          * This hack is necessary until our PKCS#11 custom_key_op_handler supports RSA PSS */
         switch (options->minimum_tls_version) {
             case AWS_IO_SSLv3:
-                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "CloudFront-SSL-v-3");
+                security_policy = "CloudFront-SSL-v-3";
                 break;
             case AWS_IO_TLSv1:
-                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "CloudFront-TLS-1-0-2014");
+                security_policy = "CloudFront-TLS-1-0-2014";
                 break;
             case AWS_IO_TLSv1_1:
-                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "ELBSecurityPolicy-TLS-1-1-2017-01");
+                security_policy = "ELBSecurityPolicy-TLS-1-1-2017-01";
                 break;
             case AWS_IO_TLSv1_2:
-                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "ELBSecurityPolicy-TLS-1-2-Ext-2018-06");
+                security_policy = "ELBSecurityPolicy-TLS-1-2-Ext-2018-06";
                 break;
             case AWS_IO_TLSv1_3:
                 AWS_LOGF_ERROR(AWS_LS_IO_TLS, "TLS 1.3 with PKCS#11 is not supported yet.");
@@ -1394,29 +1395,29 @@ static struct aws_tls_ctx *s_tls_ctx_new(
                 goto cleanup_s2n_config;
             case AWS_IO_TLS_VER_SYS_DEFAULTS:
             default:
-                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "ELBSecurityPolicy-TLS-1-1-2017-01");
+                security_policy = "ELBSecurityPolicy-TLS-1-1-2017-01";
         }
     } else {
-        /* No custom_key_op_handler is set, use normal cipher preferences */
+        /* No custom_key_op_handler is set, use normal security policies */
         switch (options->minimum_tls_version) {
             case AWS_IO_SSLv3:
-                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-SSLv3.0-2023");
+                security_policy = "AWS-CRT-SDK-SSLv3.0-2023";
                 break;
             case AWS_IO_TLSv1:
-                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-TLSv1.0-2023");
+                security_policy = "AWS-CRT-SDK-TLSv1.0-2023";
                 break;
             case AWS_IO_TLSv1_1:
-                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-TLSv1.1-2023");
+                security_policy = "AWS-CRT-SDK-TLSv1.1-2023";
                 break;
             case AWS_IO_TLSv1_2:
-                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-TLSv1.2-2023");
+                security_policy = "AWS-CRT-SDK-TLSv1.2-2023";
                 break;
             case AWS_IO_TLSv1_3:
-                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-TLSv1.3-2023");
+                security_policy = "AWS-CRT-SDK-TLSv1.3-2023";
                 break;
             case AWS_IO_TLS_VER_SYS_DEFAULTS:
             default:
-                s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "AWS-CRT-SDK-TLSv1.0-2023");
+                security_policy = "AWS-CRT-SDK-TLSv1.0-2023";
         }
     }
 
@@ -1425,12 +1426,24 @@ static struct aws_tls_ctx *s_tls_ctx_new(
             /* No-Op, if the user configured a minimum_tls_version then a version-specific Cipher Preference was set */
             break;
         case AWS_IO_TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05:
-            s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, "PQ-TLS-1-0-2021-05-26");
+            security_policy = "PQ-TLS-1-0-2021-05-26";
             break;
         default:
             AWS_LOGF_ERROR(AWS_LS_IO_TLS, "Unrecognized TLS Cipher Preference: %d", options->cipher_pref);
             aws_raise_error(AWS_IO_TLS_CIPHER_PREF_UNSUPPORTED);
             goto cleanup_s2n_config;
+    }
+
+    AWS_ASSERT(security_policy != NULL);
+    if (s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, security_policy)) {
+        AWS_LOGF_ERROR(
+            AWS_LS_IO_TLS,
+            "ctx: Failed setting security policy '%s' (newer S2N required?): %s (%s)",
+            security_policy,
+            s2n_strerror(s2n_errno, "EN"),
+            s2n_strerror_debug(s2n_errno, "EN"));
+        aws_raise_error(AWS_IO_TLS_CTX_ERROR);
+        goto cleanup_s2n_config;
     }
 
     if (aws_tls_options_buf_is_set(&options->certificate) && aws_tls_options_buf_is_set(&options->private_key)) {

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -1114,6 +1114,7 @@ static int s_verify_good_host(
     }
 
     struct aws_tls_ctx *client_ctx = aws_tls_client_ctx_new(allocator, &client_ctx_options);
+    ASSERT_NOT_NULL(client_ctx);
 
     struct aws_tls_connection_options tls_client_conn_options;
     aws_tls_connection_options_init_from_ctx(&tls_client_conn_options, client_ctx);


### PR DESCRIPTION
Change default S2N security policy to one that prioritizes P-256 in TLS 1.3 key, allowing zero round-trip connection setup to AWS servers supporting TLS 1.3

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
