### PR TITLE
Fix: release alpn string before set for tls_ctx_options

### DIFF
--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -441,7 +441,7 @@ int aws_tls_ctx_options_init_default_server(
 }
 
 int aws_tls_ctx_options_set_alpn_list(struct aws_tls_ctx_options *options, const char *alpn_list) {
-     aws_string_destroy(options->alpn_list);
+    aws_string_destroy(options->alpn_list);
 
     options->alpn_list = aws_string_new_from_c_str(options->allocator, alpn_list);
     if (!options->alpn_list) {

--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -441,6 +441,11 @@ int aws_tls_ctx_options_init_default_server(
 }
 
 int aws_tls_ctx_options_set_alpn_list(struct aws_tls_ctx_options *options, const char *alpn_list) {
+    if (options->alpn_list != NULL) {
+        aws_string_destroy(options->alpn_list);
+        options->alpn_list = NULL;
+    }
+
     options->alpn_list = aws_string_new_from_c_str(options->allocator, alpn_list);
     if (!options->alpn_list) {
         return AWS_OP_ERR;

--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -441,10 +441,7 @@ int aws_tls_ctx_options_init_default_server(
 }
 
 int aws_tls_ctx_options_set_alpn_list(struct aws_tls_ctx_options *options, const char *alpn_list) {
-    if (options->alpn_list != NULL) {
-        aws_string_destroy(options->alpn_list);
-        options->alpn_list = NULL;
-    }
+     aws_string_destroy(options->alpn_list);
 
     options->alpn_list = aws_string_new_from_c_str(options->allocator, alpn_list);
     if (!options->alpn_list) {


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
