### PR TITLE
log as warning for socket connect and client bootstrap

### DIFF
--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -595,11 +595,18 @@ task_cancelled:
     if (task_data->args->failed_count == task_data->args->addresses_count) {
         AWS_LOGF_ERROR(
             AWS_LS_IO_CHANNEL_BOOTSTRAP,
-            "id=%p: failed to create socket with error %d",
+            "id=%p: Last attempt failed to create socket with error %d",
             (void *)task_data->args->bootstrap,
             err_code);
         s_connection_args_setup_callback(task_data->args, err_code, NULL);
+    } else {
+        AWS_LOGF_DEBUG(
+            AWS_LS_IO_CHANNEL_BOOTSTRAP,
+            "id=%p: failed to create socket with error %d. More attempts ongoing.",
+            (void *)task_data->args->bootstrap,
+            err_code);
     }
+
     s_client_connection_args_release(task_data->args);
 
 cleanup_task:

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -602,8 +602,10 @@ task_cancelled:
     } else {
         AWS_LOGF_DEBUG(
             AWS_LS_IO_CHANNEL_BOOTSTRAP,
-            "id=%p: failed to create socket with error %d. More attempts ongoing.",
+            "id=%p: Socket connect attempt %d/%d failed with error %d. More attempts ongoing...",
             (void *)task_data->args->bootstrap,
+            task_data->args->failed_count,
+            task_data->args->addresses_count,
             err_code);
     }
 

--- a/source/channel_bootstrap.c
+++ b/source/channel_bootstrap.c
@@ -567,10 +567,6 @@ static void s_attempt_connection(struct aws_task *task, void *arg, enum aws_task
     }
 
     struct aws_socket *outgoing_socket = aws_mem_acquire(allocator, sizeof(struct aws_socket));
-    if (!outgoing_socket) {
-        goto socket_alloc_failed;
-    }
-
     if (aws_socket_init(outgoing_socket, allocator, &task_data->options)) {
         goto socket_init_failed;
     }
@@ -592,17 +588,16 @@ socket_connect_failed:
     aws_socket_clean_up(outgoing_socket);
 socket_init_failed:
     aws_mem_release(allocator, outgoing_socket);
-socket_alloc_failed:
-    err_code = aws_last_error();
-    AWS_LOGF_ERROR(
-        AWS_LS_IO_CHANNEL_BOOTSTRAP,
-        "id=%p: failed to create socket with error %d",
-        (void *)task_data->args->bootstrap,
-        err_code);
 task_cancelled:
+    err_code = aws_last_error();
     task_data->args->failed_count++;
     /* if this is the last attempted connection and it failed, notify the user */
     if (task_data->args->failed_count == task_data->args->addresses_count) {
+        AWS_LOGF_ERROR(
+            AWS_LS_IO_CHANNEL_BOOTSTRAP,
+            "id=%p: failed to create socket with error %d",
+            (void *)task_data->args->bootstrap,
+            err_code);
         s_connection_args_setup_callback(task_data->args, err_code, NULL);
     }
     s_client_connection_args_release(task_data->args);

--- a/source/posix/socket.c
+++ b/source/posix/socket.c
@@ -674,7 +674,7 @@ int aws_socket_connect(
 
     if (pton_err != 1) {
         int errno_value = errno; /* Always cache errno before potential side-effect */
-        AWS_LOGF_ERROR(
+        AWS_LOGF_WARN(
             AWS_LS_IO_SOCKET,
             "id=%p fd=%d: failed to parse address %s:%d.",
             (void *)socket,
@@ -770,7 +770,7 @@ int aws_socket_connect(
                 (unsigned long long)timeout);
             aws_event_loop_schedule_task_future(event_loop, timeout_task, timeout);
         } else {
-            AWS_LOGF_ERROR(
+            AWS_LOGF_WARN(
                 AWS_LS_IO_SOCKET,
                 "id=%p fd=%d: connect failed with error code %d.",
                 (void *)socket,

--- a/source/posix/socket.c
+++ b/source/posix/socket.c
@@ -384,7 +384,7 @@ static int s_on_connection_success(struct aws_socket *socket) {
 
     if (getsockopt(socket->io_handle.data.fd, SOL_SOCKET, SO_ERROR, &connect_result, &result_length) < 0) {
         int errno_value = errno; /* Always cache errno before potential side-effect */
-        AWS_LOGF_ERROR(
+        AWS_LOGF_DEBUG(
             AWS_LS_IO_SOCKET,
             "id=%p fd=%d: failed to determine connection error %d",
             (void *)socket,
@@ -397,7 +397,7 @@ static int s_on_connection_success(struct aws_socket *socket) {
     }
 
     if (connect_result) {
-        AWS_LOGF_ERROR(
+        AWS_LOGF_DEBUG(
             AWS_LS_IO_SOCKET,
             "id=%p fd=%d: connection error %d",
             (void *)socket,
@@ -437,7 +437,7 @@ static int s_on_connection_success(struct aws_socket *socket) {
 
 static void s_on_connection_error(struct aws_socket *socket, int error) {
     socket->state = ERROR;
-    AWS_LOGF_ERROR(AWS_LS_IO_SOCKET, "id=%p fd=%d: connection failure", (void *)socket, socket->io_handle.data.fd);
+    AWS_LOGF_DEBUG(AWS_LS_IO_SOCKET, "id=%p fd=%d: connection failure", (void *)socket, socket->io_handle.data.fd);
     if (socket->connection_result_fn) {
         socket->connection_result_fn(socket, error, socket->connect_accept_user_data);
     } else if (socket->accept_result_fn) {
@@ -674,7 +674,7 @@ int aws_socket_connect(
 
     if (pton_err != 1) {
         int errno_value = errno; /* Always cache errno before potential side-effect */
-        AWS_LOGF_WARN(
+        AWS_LOGF_DEBUG(
             AWS_LS_IO_SOCKET,
             "id=%p fd=%d: failed to parse address %s:%d.",
             (void *)socket,
@@ -770,7 +770,7 @@ int aws_socket_connect(
                 (unsigned long long)timeout);
             aws_event_loop_schedule_task_future(event_loop, timeout_task, timeout);
         } else {
-            AWS_LOGF_WARN(
+            AWS_LOGF_DEBUG(
                 AWS_LS_IO_SOCKET,
                 "id=%p fd=%d: connect failed with error code %d.",
                 (void *)socket,

--- a/source/windows/iocp/socket.c
+++ b/source/windows/iocp/socket.c
@@ -988,7 +988,7 @@ static inline int s_tcp_connect(
     if (!connect_res) {
         int error_code = WSAGetLastError();
         if (error_code != ERROR_IO_PENDING) {
-            AWS_LOGF_ERROR(
+            AWS_LOGF_WARN(
                 AWS_LS_IO_TLS,
                 "id=%p handle=%p: connection error %d",
                 (void *)socket,
@@ -1220,7 +1220,7 @@ static int s_local_connect(
 
 error:;
     int win_error = GetLastError(); /* logging may reset error, so cache it */
-    AWS_LOGF_ERROR(
+    AWS_LOGF_WARN(
         AWS_LS_IO_SOCKET,
         "id=%p handle=%p: failed to connect to named pipe %s.",
         (void *)socket,
@@ -1267,7 +1267,7 @@ static inline int s_dgram_connect(
 
     if (connect_err) {
         int wsa_err = WSAGetLastError(); /* logging may reset error, so cache it */
-        AWS_LOGF_ERROR(
+        AWS_LOGF_WARN(
             AWS_LS_IO_SOCKET,
             "id=%p handle=%p: Failed to connect to %s:%d with error %d.",
             (void *)socket,

--- a/source/windows/iocp/socket.c
+++ b/source/windows/iocp/socket.c
@@ -679,7 +679,7 @@ static int s_ipv4_stream_connection_success(struct aws_socket *socket) {
     if (getsockopt(
             (SOCKET)socket->io_handle.data.handle, SOL_SOCKET, SO_ERROR, (char *)&connect_result, &result_length) < 0) {
         int wsa_err = WSAGetLastError(); /* logging may reset error, so cache it */
-        AWS_LOGF_ERROR(
+        AWS_LOGF_DEBUG(
             AWS_LS_IO_SOCKET,
             "id=%p handle=%p: failed to determine connection error %d",
             (void *)socket,
@@ -690,7 +690,7 @@ static int s_ipv4_stream_connection_success(struct aws_socket *socket) {
     }
 
     if (connect_result) {
-        AWS_LOGF_ERROR(
+        AWS_LOGF_DEBUG(
             AWS_LS_IO_SOCKET,
             "id=%p handle=%p: connection error %d",
             (void *)socket,
@@ -740,7 +740,7 @@ static int s_ipv6_stream_connection_success(struct aws_socket *socket) {
     if (getsockopt(
             (SOCKET)socket->io_handle.data.handle, SOL_SOCKET, SO_ERROR, (char *)&connect_result, &result_length) < 0) {
         int wsa_err = WSAGetLastError(); /* logging may reset error, so cache it */
-        AWS_LOGF_ERROR(
+        AWS_LOGF_DEBUG(
             AWS_LS_IO_SOCKET,
             "id=%p handle=%p: failed to determine connection error %d",
             (void *)socket,
@@ -751,7 +751,7 @@ static int s_ipv6_stream_connection_success(struct aws_socket *socket) {
     }
 
     if (connect_result) {
-        AWS_LOGF_ERROR(
+        AWS_LOGF_DEBUG(
             AWS_LS_IO_SOCKET,
             "id=%p handle=%p: connection error %d",
             (void *)socket,
@@ -806,7 +806,7 @@ static int s_local_and_udp_connection_success(struct aws_socket *socket) {
 static void s_connection_error(struct aws_socket *socket, int error) {
     socket->state = ERRORED;
 
-    AWS_LOGF_ERROR(
+    AWS_LOGF_DEBUG(
         AWS_LS_IO_SOCKET,
         "id=%p handle=%p: connection error with code %d",
         (void *)socket,
@@ -988,7 +988,7 @@ static inline int s_tcp_connect(
     if (!connect_res) {
         int error_code = WSAGetLastError();
         if (error_code != ERROR_IO_PENDING) {
-            AWS_LOGF_WARN(
+            AWS_LOGF_DEBUG(
                 AWS_LS_IO_TLS,
                 "id=%p handle=%p: connection error %d",
                 (void *)socket,
@@ -1220,7 +1220,7 @@ static int s_local_connect(
 
 error:;
     int win_error = GetLastError(); /* logging may reset error, so cache it */
-    AWS_LOGF_WARN(
+    AWS_LOGF_DEBUG(
         AWS_LS_IO_SOCKET,
         "id=%p handle=%p: failed to connect to named pipe %s.",
         (void *)socket,
@@ -1267,7 +1267,7 @@ static inline int s_dgram_connect(
 
     if (connect_err) {
         int wsa_err = WSAGetLastError(); /* logging may reset error, so cache it */
-        AWS_LOGF_WARN(
+        AWS_LOGF_DEBUG(
             AWS_LS_IO_SOCKET,
             "id=%p handle=%p: Failed to connect to %s:%d with error %d.",
             (void *)socket,


### PR DESCRIPTION
*Issue #, if available:*

- Our client bootstrap will try to connect for multiple address resolved by the host resolver. And it may have failure for some address, as long as any one succeed, we established the connection and ignore the error came from other address. Especially, as we do happy eyeball, it will try to use ipv6 and ipv4 at the same time. Most of the case, one of the connection will fail
- It's very annoy when an error level log shows up, but it's kind expected.

*Description of changes:*
- downgrade the level we log the error from socket connect

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
