### PR TITLE
add format unknown

### DIFF
--- a/source/darwin/darwin_pki_utils.c
+++ b/source/darwin/darwin_pki_utils.c
@@ -66,7 +66,6 @@ int aws_import_ecc_key_into_keychain(
         AWS_ZERO_STRUCT(import_params);
         import_params.version = SEC_KEY_IMPORT_EXPORT_PARAMS_VERSION;
         import_params.passphrase = CFSTR("");
-        format = kSecFormatUnknown;
 
         OSStatus key_status =
             SecItemImport(key_data, NULL, &format, &item_type, 0, &import_params, import_keychain, NULL);
@@ -164,6 +163,7 @@ int aws_import_public_and_private_keys_to_identity(
         SecItemImport(cert_data, NULL, &format, &item_type, 0, &import_params, import_keychain, &cert_import_output);
 
     /* import private key */
+    format = kSecFormatUnknown;
     item_type = kSecItemTypePrivateKey;
     OSStatus key_status =
         SecItemImport(key_data, NULL, &format, &item_type, 0, &import_params, import_keychain, &key_import_output);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
SecItemImport overrides import format after the call, so we need to reset it to unknown before every call
https://developer.apple.com/documentation/security/1395728-secitemimport?language=objc

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
