### PR TITLE
Remove null check for aws_pkcs11_lib_login_user

### DIFF
--- a/source/pkcs11_tls_op_handler.c
+++ b/source/pkcs11_tls_op_handler.c
@@ -183,10 +183,8 @@ struct aws_custom_key_op_handler *aws_pkcs11_tls_op_handler_new(
         goto done;
     }
 
-    if (pkcs_user_pin != NULL) {
-        if (aws_pkcs11_lib_login_user(pkcs11_handler->lib, pkcs11_handler->session_handle, pkcs_user_pin)) {
-            goto done;
-        }
+    if (aws_pkcs11_lib_login_user(pkcs11_handler->lib, pkcs11_handler->session_handle, pkcs_user_pin)) {
+        goto done;
     }
 
     if (aws_pkcs11_lib_find_private_key(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
We do not need a null check for `aws_pkcs11_lib_login_user`. `aws_pkcs11_lib_login_user` will handle the login when user_pin is NULL. 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
