### PR TITLE
Use 500ms rather than 25ms for the exponential backoff defaults.

### DIFF
--- a/include/aws/io/retry_strategy.h
+++ b/include/aws/io/retry_strategy.h
@@ -110,7 +110,7 @@ struct aws_exponential_backoff_retry_options {
     struct aws_event_loop_group *el_group;
     /** Max retries to allow. The default value is 10 */
     size_t max_retries;
-    /** Scaling factor to add for the backoff. Default is 25ms */
+    /** Scaling factor to add for the backoff. Default is 500ms */
     uint32_t backoff_scale_factor_ms;
     /** Max retry backoff in seconds. Default is 20 seconds */
     uint32_t max_backoff_secs;

--- a/source/exponential_backoff_retry_strategy.c
+++ b/source/exponential_backoff_retry_strategy.c
@@ -373,7 +373,7 @@ struct aws_retry_strategy *aws_retry_strategy_new_exponential_backoff(
     }
 
     if (!exponential_backoff_strategy->config.backoff_scale_factor_ms) {
-        exponential_backoff_strategy->config.backoff_scale_factor_ms = 25;
+        exponential_backoff_strategy->config.backoff_scale_factor_ms = 500;
     }
 
     if (!exponential_backoff_strategy->config.max_backoff_secs) {


### PR DESCRIPTION


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
