### PR TITLE
Surface proper PKCS11 error

### DIFF
--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -199,7 +199,6 @@ int aws_tls_ctx_options_init_client_mtls_with_pkcs11(
     int custom_key_result = AWS_OP_ERR;
 
     if (pkcs11_handler == NULL) {
-        aws_raise_error(AWS_ERROR_INVALID_ARGUMENT);
         goto finish;
     }
 


### PR DESCRIPTION
`aws_pkcs11_tls_op_handler_new()` only returns NULL when something has gone wrong and an error was raised. Calling `aws_raise_error(AWS_ERROR_INVALID_ARGUMENT)` here overrides a much more useful error code with a generic one.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
