### PR TITLE
Cache the Error Before Any Side Effects

### DIFF
--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -165,12 +165,16 @@ static struct aws_event_loop_group *s_event_loop_group_new(
 
     return el_group;
 
-on_error:
+on_error:;
+    /* cache the error code before potential side effects */
+    int cached_error_code = aws_last_error();
 
     aws_mem_release(alloc, usable_cpus);
     s_aws_event_loop_group_shutdown_sync(el_group);
     s_event_loop_group_thread_exit(el_group);
 
+    /* raise the cached error code */
+    aws_raise_error(cached_error_code);
     return NULL;
 }
 

--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -166,7 +166,7 @@ static struct aws_event_loop_group *s_event_loop_group_new(
     return el_group;
 
 on_error:;
-    /* cache the error code before potential side effects */
+    /* cache the error code to prevent any potential side effects */
     int cached_error_code = aws_last_error();
 
     aws_mem_release(alloc, usable_cpus);


### PR DESCRIPTION
*Description of changes:*
- Cache the error before doing any cleanup to avoid any potential side effects on the error code. We found that in some cases, the exisiting approach was leading to a bogus error, `AWS_ERROR_PRIORITY_QUEUE_EMPTY`, when we failed in `aws_event_loop_run` while doing `pthread_create`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
