### PR TITLE
Fix NULL config clean-up

### DIFF
--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -1312,8 +1312,9 @@ struct aws_channel_handler *aws_tls_server_handler_new(
 
 static void s_s2n_ctx_destroy(struct s2n_ctx *s2n_ctx) {
     if (s2n_ctx != NULL) {
-        s2n_config_free(s2n_ctx->s2n_config);
-
+        if (s2n_ctx->s2n_config) {
+            s2n_config_free(s2n_ctx->s2n_config);
+        }
         if (s2n_ctx->custom_cert_chain_and_key) {
             s2n_cert_chain_and_key_free(s2n_ctx->custom_cert_chain_and_key);
         }


### PR DESCRIPTION
*Description of changes:*
- The s2n cleanup function https://github.com/aws/s2n-tls/blob/c74f442b55589872b1374559bb03878c49761ca6/tls/s2n_config.c#L122 doesn't check for NULL, so we should do it before calling the cleanup function.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
