### PR TITLE
Test for duplicate key import

### DIFF
--- a/source/darwin/darwin_pki_utils.c
+++ b/source/darwin/darwin_pki_utils.c
@@ -178,8 +178,6 @@ int aws_import_public_and_private_keys_to_identity(
     OSStatus cert_status =
         SecItemImport(cert_data, NULL, &format, &item_type, 0, &import_params, import_keychain, &cert_import_output);
 
-    printf("########## cert_status %d\n", cert_status);
-
     /* import private key */
     format = kSecFormatUnknown;
     item_type = kSecItemTypePrivateKey;
@@ -226,7 +224,6 @@ int aws_import_public_and_private_keys_to_identity(
         aws_array_list_get_at_ptr(&cert_chain_list, (void **)&root_cert_ptr, 0);
         AWS_ASSERT(root_cert_ptr);
         CFDataRef root_cert_data = CFDataCreate(cf_alloc, root_cert_ptr->data.buffer, root_cert_ptr->data.len);
-        AWS_FATAL_ASSERT(false);
         if (!root_cert_data) {
             AWS_LOGF_ERROR(AWS_LS_IO_PKI, "static: failed creating root cert data.");
             result = aws_raise_error(AWS_ERROR_SYS_CALL_FAILURE);

--- a/source/darwin/darwin_pki_utils.c
+++ b/source/darwin/darwin_pki_utils.c
@@ -224,6 +224,7 @@ int aws_import_public_and_private_keys_to_identity(
         aws_array_list_get_at_ptr(&cert_chain_list, (void **)&root_cert_ptr, 0);
         AWS_ASSERT(root_cert_ptr);
         CFDataRef root_cert_data = CFDataCreate(cf_alloc, root_cert_ptr->data.buffer, root_cert_ptr->data.len);
+        AWS_FATAL_ASSERT(false);
         if (!root_cert_data) {
             AWS_LOGF_ERROR(AWS_LS_IO_PKI, "static: failed creating root cert data.");
             result = aws_raise_error(AWS_ERROR_SYS_CALL_FAILURE);

--- a/source/darwin/darwin_pki_utils.c
+++ b/source/darwin/darwin_pki_utils.c
@@ -179,7 +179,6 @@ int aws_import_public_and_private_keys_to_identity(
         SecItemImport(cert_data, NULL, &format, &item_type, 0, &import_params, import_keychain, &cert_import_output);
 
     printf("########## cert_status %d\n", cert_status);
-    AWS_FATAL_ASSERT(false);
 
     /* import private key */
     format = kSecFormatUnknown;

--- a/source/darwin/darwin_pki_utils.c
+++ b/source/darwin/darwin_pki_utils.c
@@ -178,6 +178,8 @@ int aws_import_public_and_private_keys_to_identity(
     OSStatus cert_status =
         SecItemImport(cert_data, NULL, &format, &item_type, 0, &import_params, import_keychain, &cert_import_output);
 
+    printf("########## cert_status %d\n", cert_status);
+
     /* import private key */
     format = kSecFormatUnknown;
     item_type = kSecItemTypePrivateKey;

--- a/source/darwin/darwin_pki_utils.c
+++ b/source/darwin/darwin_pki_utils.c
@@ -179,6 +179,7 @@ int aws_import_public_and_private_keys_to_identity(
         SecItemImport(cert_data, NULL, &format, &item_type, 0, &import_params, import_keychain, &cert_import_output);
 
     printf("########## cert_status %d\n", cert_status);
+    AWS_FATAL_ASSERT(false);
 
     /* import private key */
     format = kSecFormatUnknown;

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -208,6 +208,7 @@ if(NOT BYO_CRYPTO)
 
     # Misc non-badssl tls tests
     add_net_test_case(test_concurrent_cert_import)
+    add_net_test_case(test_duplicate_cert_import)
     add_test_case(tls_channel_echo_and_backpressure_test)
     add_net_test_case(tls_client_channel_negotiation_error_socket_closed)
     add_net_test_case(tls_client_channel_negotiation_success)

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -2124,7 +2124,7 @@ static void s_import_cert(void *ctx) {
 #    endif /* !AWS_OS_IOS */
 }
 
-#    define NUM_PAIRS 1
+#    define NUM_PAIRS 2
 static int s_test_concurrent_cert_import(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
     /* temporarily disable this on apple until we can fix importing to be more robust */

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -2168,7 +2168,7 @@ static int s_test_concurrent_cert_import(struct aws_allocator *allocator, void *
         ASSERT_SUCCESS(aws_thread_join(thread));
         aws_tls_ctx_release(import->tls);
         aws_byte_buf_clean_up(&import->cert_buf);
-        // aws_byte_buf_clean_up(&import->key_buf);
+        aws_byte_buf_clean_up(&import->key_buf);
     }
 
     aws_io_library_clean_up();

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -2177,10 +2177,15 @@ static int s_test_duplicate_cert_import(struct aws_allocator *allocator, void *c
     (void)ctx;
 
     aws_io_library_init(allocator);
+    struct aws_byte_buf cert_buf = {0};
+    struct aws_byte_buf key_buf = {0};
 
 #    if !defined(AWS_OS_IOS)
-    struct aws_byte_cursor cert_cur = aws_byte_cursor_from_c_str("testcert_dup.pem");
-    struct aws_byte_cursor key_cur = aws_byte_cursor_from_c_str("testkey.pem");
+
+    ASSERT_SUCCESS(aws_byte_buf_init_from_file(&cert_buf, allocator, "testcert0.pem"));
+    ASSERT_SUCCESS(aws_byte_buf_init_from_file(&key_buf, allocator, "testkey.pem"));
+    struct aws_byte_cursor cert_cur = aws_byte_cursor_from_buf(&cert_buf);
+    struct aws_byte_cursor key_cur = aws_byte_cursor_from_buf(&key_buf);
     struct aws_tls_ctx_options tls_options = {0};
     AWS_FATAL_ASSERT(
         AWS_OP_SUCCESS == aws_tls_ctx_options_init_client_mtls(&tls_options, allocator, &cert_cur, &key_cur));
@@ -2197,6 +2202,8 @@ static int s_test_duplicate_cert_import(struct aws_allocator *allocator, void *c
 
     /* clean up */
     aws_tls_ctx_release(tls);
+    aws_byte_buf_clean_up(&cert_buf);
+    aws_byte_buf_clean_up(&key_buf);
     aws_io_library_clean_up();
 
     return AWS_OP_ERR;

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -2168,7 +2168,7 @@ static int s_test_concurrent_cert_import(struct aws_allocator *allocator, void *
         ASSERT_SUCCESS(aws_thread_join(thread));
         aws_tls_ctx_release(import->tls);
         aws_byte_buf_clean_up(&import->cert_buf);
-        aws_byte_buf_clean_up(&import->key_buf);
+        // aws_byte_buf_clean_up(&import->key_buf);
     }
 
     aws_io_library_clean_up();

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -2193,15 +2193,16 @@ static int s_test_duplicate_cert_import(struct aws_allocator *allocator, void *c
     /* import happens in here */
     struct aws_tls_ctx *tls = aws_tls_client_ctx_new(allocator, &tls_options);
     AWS_FATAL_ASSERT(tls);
+    aws_tls_ctx_release(tls);
     /* import the same certs twice */
     tls = aws_tls_client_ctx_new(allocator, &tls_options);
     AWS_FATAL_ASSERT(tls);
+    aws_tls_ctx_release(tls);
 
     aws_tls_ctx_options_clean_up(&tls_options);
 #    endif /* !AWS_OS_IOS */
 
     /* clean up */
-    aws_tls_ctx_release(tls);
     aws_byte_buf_clean_up(&cert_buf);
     aws_byte_buf_clean_up(&key_buf);
     aws_io_library_clean_up();

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -2179,7 +2179,6 @@ static int s_test_duplicate_cert_import(struct aws_allocator *allocator, void *c
     aws_io_library_init(allocator);
 
 #    if !defined(AWS_OS_IOS)
-    struct import_info *import = ctx;
     struct aws_byte_cursor cert_cur = aws_byte_cursor_from_c_str("testcert_dup.pem");
     struct aws_byte_cursor key_cur = aws_byte_cursor_from_c_str("testkey.pem");
     struct aws_tls_ctx_options tls_options = {0};

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -2129,9 +2129,9 @@ static int s_test_concurrent_cert_import(struct aws_allocator *allocator, void *
     (void)ctx;
     /* temporarily disable this on apple until we can fix importing to be more robust */
     /* temporarily disable this on linux until we can make CRYPTO_zalloc behave and stop angering ASan */
-#    if defined(__APPLE__) || defined(__linux__)
-    return AWS_OP_SUCCESS;
-#    endif
+    // #    if defined(__APPLE__) || defined(__linux__)
+    //     return AWS_OP_SUCCESS;
+    // #    endif
 
     aws_io_library_init(allocator);
 

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -2173,7 +2173,7 @@ static int s_test_concurrent_cert_import(struct aws_allocator *allocator, void *
 
     aws_io_library_clean_up();
 
-    return AWS_OP_SUCCESS;
+    return AWS_OP_ERR;
 }
 
 AWS_TEST_CASE(test_concurrent_cert_import, s_test_concurrent_cert_import)

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -2206,7 +2206,7 @@ static int s_test_duplicate_cert_import(struct aws_allocator *allocator, void *c
     aws_byte_buf_clean_up(&key_buf);
     aws_io_library_clean_up();
 
-    return AWS_OP_ERR;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(test_duplicate_cert_import, s_test_duplicate_cert_import)


### PR DESCRIPTION
- add a regression test for https://github.com/awslabs/aws-c-io/pull/626
  - We can see the CI failing for OSX https://github.com/awslabs/aws-c-io/actions/runs/7994446706/job/21832512891 without the fix
  - After the fix, the CI passed
- also re-enable the test for test_concurrent_cert_import, the previous issue seems to be fixed

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
