### PR TITLE
Skip rsa8192.badssl.com Test to Fix CI

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -183,13 +183,13 @@ if(NOT BYO_CRYPTO)
     # Badssl - Secure uncommon suite
     # We skip 10000san for now as its unclear the point or relevance especially with respect to the OS-based
     # TLS implementations
-    # We skip 1000san, sha384 and sha512 because the public badssl certificate is expired and we haven't migrated to
+    # We skip 1000san, sha384, rsa8192 and sha512 because the public badssl certificate is expired and we haven't migrated to
     # internal hosting yet
     # We also defer the incomplete chain test for now until we can do some further study on how to get it to
     # properly fail on windows and osx.
     # add_net_test_case(tls_client_channel_negotiation_success_sha384)
     # add_net_test_case(tls_client_channel_negotiation_success_sha512)
-    add_net_test_case(tls_client_channel_negotiation_success_rsa8192)
+    # add_net_test_case(tls_client_channel_negotiation_success_rsa8192)
     add_net_test_case(tls_client_channel_negotiation_error_no_subject)
     add_net_test_case(tls_client_channel_negotiation_success_no_verify_no_subject)
     add_net_test_case(tls_client_channel_negotiation_error_no_common_name)

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -1309,7 +1309,10 @@ AWS_STATIC_STRING_FROM_LITERAL(s_uncommon_rsa8192_host_name, "rsa8192.badssl.com
 
 static int s_tls_client_channel_negotiation_success_rsa8192_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
-    return s_verify_good_host(allocator, s_uncommon_rsa8192_host_name, 443, NULL);
+    // The certificate for rsa8192.badssl.com is expired. Disable this test until they renew the test or we find a
+    // better alternative.
+    // s_verify_good_host(allocator, s_uncommon_rsa8192_host_name, 443, NULL)
+    return AWS_OP_SKIP;
 }
 
 AWS_TEST_CASE(tls_client_channel_negotiation_success_rsa8192, s_tls_client_channel_negotiation_success_rsa8192_fn)

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -1312,7 +1312,7 @@ static int s_tls_client_channel_negotiation_success_rsa8192_fn(struct aws_alloca
     (void)s_uncommon_rsa8192_host_name;
     // The certificate for rsa8192.badssl.com is expired. Disable this test until they renew the certificate or we find
     // a better alternative. s_verify_good_host(allocator, s_uncommon_rsa8192_host_name, 443, NULL)
-    return AWS_OP_SKIP;
+    return AWS_OP_SUCCESS;
 }
 
 AWS_TEST_CASE(tls_client_channel_negotiation_success_rsa8192, s_tls_client_channel_negotiation_success_rsa8192_fn)

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -1309,6 +1309,7 @@ AWS_STATIC_STRING_FROM_LITERAL(s_uncommon_rsa8192_host_name, "rsa8192.badssl.com
 
 static int s_tls_client_channel_negotiation_success_rsa8192_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
+    (void)s_uncommon_rsa8192_host_name;
     // The certificate for rsa8192.badssl.com is expired. Disable this test until they renew the test or we find a
     // better alternative.
     // s_verify_good_host(allocator, s_uncommon_rsa8192_host_name, 443, NULL)

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -1310,9 +1310,8 @@ AWS_STATIC_STRING_FROM_LITERAL(s_uncommon_rsa8192_host_name, "rsa8192.badssl.com
 static int s_tls_client_channel_negotiation_success_rsa8192_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
     (void)s_uncommon_rsa8192_host_name;
-    // The certificate for rsa8192.badssl.com is expired. Disable this test until they renew the test or we find a
-    // better alternative.
-    // s_verify_good_host(allocator, s_uncommon_rsa8192_host_name, 443, NULL)
+    // The certificate for rsa8192.badssl.com is expired. Disable this test until they renew the certificate or we find
+    // a better alternative. s_verify_good_host(allocator, s_uncommon_rsa8192_host_name, 443, NULL)
     return AWS_OP_SKIP;
 }
 

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -1310,6 +1310,7 @@ AWS_STATIC_STRING_FROM_LITERAL(s_uncommon_rsa8192_host_name, "rsa8192.badssl.com
 static int s_tls_client_channel_negotiation_success_rsa8192_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
     (void)s_uncommon_rsa8192_host_name;
+    (void)allocator;
     // The certificate for rsa8192.badssl.com is expired. Disable this test until they renew the certificate or we find
     // a better alternative. s_verify_good_host(allocator, s_uncommon_rsa8192_host_name, 443, NULL)
     return AWS_OP_SUCCESS;

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -1309,11 +1309,7 @@ AWS_STATIC_STRING_FROM_LITERAL(s_uncommon_rsa8192_host_name, "rsa8192.badssl.com
 
 static int s_tls_client_channel_negotiation_success_rsa8192_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
-    (void)s_uncommon_rsa8192_host_name;
-    (void)allocator;
-    // The certificate for rsa8192.badssl.com is expired. Disable this test until they renew the certificate or we find
-    // a better alternative. s_verify_good_host(allocator, s_uncommon_rsa8192_host_name, 443, NULL)
-    return AWS_OP_SUCCESS;
+    return s_verify_good_host(allocator, s_uncommon_rsa8192_host_name, 443, NULL);
 }
 
 AWS_TEST_CASE(tls_client_channel_negotiation_success_rsa8192, s_tls_client_channel_negotiation_success_rsa8192_fn)


### PR DESCRIPTION
*Description of changes:*
- The certificate for `rsa8192.badssl.com` is expired. The project badssl seems dead with its last update 9 months ago and https://github.com/chromium/badssl.com/issues/527. This PR disables the test until we find an alternative or host badssl ourselves.
- I have created the following issue https://github.com/chromium/badssl.com/issues/530 to badssl.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
