### PR TITLE
Adds Host Resolver IPv6 variations test

### DIFF
--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -152,16 +152,16 @@ if(NOT BYO_CRYPTO)
     add_net_test_case(tls_client_channel_negotiation_error_untrusted_root)
     add_net_test_case(tls_client_channel_negotiation_error_untrusted_root_due_to_ca_override)
     add_net_test_case(tls_client_channel_negotiation_no_verify_expired)
-    # add_net_test_case(tls_client_channel_negotiation_no_verify_wrong_host)
-    # add_net_test_case(tls_client_channel_negotiation_no_verify_self_signed)
-    # add_net_test_case(tls_client_channel_negotiation_no_verify_untrusted_root)
+    add_net_test_case(tls_client_channel_negotiation_no_verify_wrong_host)
+    add_net_test_case(tls_client_channel_negotiation_no_verify_self_signed)
+    add_net_test_case(tls_client_channel_negotiation_no_verify_untrusted_root)
 
     # Badssl - Broken Crypto endpoint suite
     # We don't include dh1024 as it succeeds on the windows baseline configuration and there does not seem
     # to be a way to disable it
     add_net_test_case(tls_client_channel_negotiation_error_broken_crypto_rc4)
     add_net_test_case(tls_client_channel_negotiation_error_broken_crypto_rc4_md5)
-    # add_net_test_case(tls_client_channel_negotiation_error_broken_crypto_dh480)
+    add_net_test_case(tls_client_channel_negotiation_error_broken_crypto_dh480)
     add_net_test_case(tls_client_channel_negotiation_error_broken_crypto_dh512)
     add_net_test_case(tls_client_channel_negotiation_error_broken_crypto_null)
 
@@ -193,9 +193,9 @@ if(NOT BYO_CRYPTO)
     # add_net_test_case(tls_client_channel_negotiation_success_rsa8192)
     add_net_test_case(tls_client_channel_negotiation_error_no_subject)
     add_net_test_case(tls_client_channel_negotiation_success_no_verify_no_subject)
-    # add_net_test_case(tls_client_channel_negotiation_error_no_common_name)
-    # add_net_test_case(tls_client_channel_negotiation_success_no_verify_no_common_name)
-    # add_net_test_case(tls_client_channel_negotiation_success_no_verify_incomplete_chain)
+    add_net_test_case(tls_client_channel_negotiation_error_no_common_name)
+    add_net_test_case(tls_client_channel_negotiation_success_no_verify_no_common_name)
+    add_net_test_case(tls_client_channel_negotiation_success_no_verify_incomplete_chain)
 
     # Badssl - Secure common suite, all of these should succeed
     add_net_test_case(tls_client_channel_negotiation_success_tls12)
@@ -205,7 +205,7 @@ if(NOT BYO_CRYPTO)
     add_net_test_case(tls_client_channel_negotiation_success_ecc384)
 
     # add_net_test_case(tls_client_channel_negotiation_success_extended_validation) test disabled until badssl updates cert (expired 2022.08.10)
-    # add_net_test_case(tls_client_channel_negotiation_success_mozilla_modern)
+    add_net_test_case(tls_client_channel_negotiation_success_mozilla_modern)
 
     # Misc non-badssl tls tests
     add_net_test_case(test_concurrent_cert_import)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -94,6 +94,7 @@ add_test_case(channel_duplicate_shutdown)
 add_net_test_case(channel_connect_some_hosts_timeout)
 
 add_net_test_case(test_default_with_ipv6_lookup)
+add_net_test_case(test_default_host_resolver_ipv6_address_variations)
 add_test_case(test_resolver_ipv6_address_lookup)
 add_net_test_case(test_default_with_multiple_lookups)
 add_test_case(test_resolver_ipv4_address_lookup)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -153,7 +153,7 @@ if(NOT BYO_CRYPTO)
     add_net_test_case(tls_client_channel_negotiation_error_untrusted_root_due_to_ca_override)
     add_net_test_case(tls_client_channel_negotiation_no_verify_expired)
     add_net_test_case(tls_client_channel_negotiation_no_verify_wrong_host)
-    add_net_test_case(tls_client_channel_negotiation_no_verify_self_signed)
+    # add_net_test_case(tls_client_channel_negotiation_no_verify_self_signed)
     add_net_test_case(tls_client_channel_negotiation_no_verify_untrusted_root)
 
     # Badssl - Broken Crypto endpoint suite
@@ -161,7 +161,7 @@ if(NOT BYO_CRYPTO)
     # to be a way to disable it
     add_net_test_case(tls_client_channel_negotiation_error_broken_crypto_rc4)
     add_net_test_case(tls_client_channel_negotiation_error_broken_crypto_rc4_md5)
-    add_net_test_case(tls_client_channel_negotiation_error_broken_crypto_dh480)
+    # add_net_test_case(tls_client_channel_negotiation_error_broken_crypto_dh480)
     add_net_test_case(tls_client_channel_negotiation_error_broken_crypto_dh512)
     add_net_test_case(tls_client_channel_negotiation_error_broken_crypto_null)
 
@@ -194,7 +194,7 @@ if(NOT BYO_CRYPTO)
     add_net_test_case(tls_client_channel_negotiation_error_no_subject)
     add_net_test_case(tls_client_channel_negotiation_success_no_verify_no_subject)
     add_net_test_case(tls_client_channel_negotiation_error_no_common_name)
-    add_net_test_case(tls_client_channel_negotiation_success_no_verify_no_common_name)
+    # add_net_test_case(tls_client_channel_negotiation_success_no_verify_no_common_name)
     add_net_test_case(tls_client_channel_negotiation_success_no_verify_incomplete_chain)
 
     # Badssl - Secure common suite, all of these should succeed
@@ -205,7 +205,7 @@ if(NOT BYO_CRYPTO)
     add_net_test_case(tls_client_channel_negotiation_success_ecc384)
 
     # add_net_test_case(tls_client_channel_negotiation_success_extended_validation) test disabled until badssl updates cert (expired 2022.08.10)
-    add_net_test_case(tls_client_channel_negotiation_success_mozilla_modern)
+    # add_net_test_case(tls_client_channel_negotiation_success_mozilla_modern)
 
     # Misc non-badssl tls tests
     add_net_test_case(test_concurrent_cert_import)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -193,9 +193,9 @@ if(NOT BYO_CRYPTO)
     # add_net_test_case(tls_client_channel_negotiation_success_rsa8192)
     add_net_test_case(tls_client_channel_negotiation_error_no_subject)
     add_net_test_case(tls_client_channel_negotiation_success_no_verify_no_subject)
-    add_net_test_case(tls_client_channel_negotiation_error_no_common_name)
+    # add_net_test_case(tls_client_channel_negotiation_error_no_common_name)
     # add_net_test_case(tls_client_channel_negotiation_success_no_verify_no_common_name)
-    add_net_test_case(tls_client_channel_negotiation_success_no_verify_incomplete_chain)
+    # add_net_test_case(tls_client_channel_negotiation_success_no_verify_incomplete_chain)
 
     # Badssl - Secure common suite, all of these should succeed
     add_net_test_case(tls_client_channel_negotiation_success_tls12)

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -152,9 +152,9 @@ if(NOT BYO_CRYPTO)
     add_net_test_case(tls_client_channel_negotiation_error_untrusted_root)
     add_net_test_case(tls_client_channel_negotiation_error_untrusted_root_due_to_ca_override)
     add_net_test_case(tls_client_channel_negotiation_no_verify_expired)
-    add_net_test_case(tls_client_channel_negotiation_no_verify_wrong_host)
+    # add_net_test_case(tls_client_channel_negotiation_no_verify_wrong_host)
     # add_net_test_case(tls_client_channel_negotiation_no_verify_self_signed)
-    add_net_test_case(tls_client_channel_negotiation_no_verify_untrusted_root)
+    # add_net_test_case(tls_client_channel_negotiation_no_verify_untrusted_root)
 
     # Badssl - Broken Crypto endpoint suite
     # We don't include dh1024 as it succeeds on the windows baseline configuration and there does not seem

--- a/tests/default_host_resolver_test.c
+++ b/tests/default_host_resolver_test.c
@@ -182,6 +182,11 @@ static int s_test_default_host_resolver_ipv6_address_variations_fn(struct aws_al
             .ip_address = "0:0:0:0:0:0:0:1",
             .expected_resolved_ip_address = "::1",
         },
+        {
+            .ip_address = "fd00:ec2:0:0:0:0:0:23",
+            .expected_resolved_ip_address = "fd00:ec2::23",
+        },
+
     };
 
     struct aws_event_loop_group *el_group = aws_event_loop_group_new_default(allocator, 1, NULL);

--- a/tests/default_host_resolver_test.c
+++ b/tests/default_host_resolver_test.c
@@ -160,6 +160,98 @@ static int s_test_default_with_ipv6_lookup_fn(struct aws_allocator *allocator, v
 
 AWS_TEST_CASE(test_default_with_ipv6_lookup, s_test_default_with_ipv6_lookup_fn)
 
+static int s_test_default_host_resolver_ipv6_address_variations_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+
+    aws_io_library_init(allocator);
+
+    const struct test_case {
+        const char *ip_address;
+        const char *expected_resolved_ip_address;
+    } test_cases[] = {
+        /* simple full uri*/
+        {
+            .ip_address = "0:0::1",
+            .expected_resolved_ip_address = "::1",
+        },
+        {
+            .ip_address = "::1",
+            .expected_resolved_ip_address = "::1",
+        },
+        {
+            .ip_address = "0:0:0:0:0:0:0:1",
+            .expected_resolved_ip_address = "::1",
+        },
+    };
+
+    struct aws_event_loop_group *el_group = aws_event_loop_group_new_default(allocator, 1, NULL);
+
+    struct aws_host_resolver_default_options resolver_options = {
+        .el_group = el_group,
+        .max_entries = 10,
+    };
+    struct aws_host_resolver *resolver = aws_host_resolver_new_default(allocator, &resolver_options);
+
+    struct aws_host_resolution_config config = {
+        .max_ttl = 10,
+        .impl = aws_default_dns_resolve,
+        .impl_data = NULL,
+    };
+
+    struct aws_mutex mutex = AWS_MUTEX_INIT;
+    struct default_host_callback_data callback_data = {
+        .condition_variable = AWS_CONDITION_VARIABLE_INIT,
+        .invoked = false,
+        .has_aaaa_address = false,
+        .has_a_address = false,
+        .mutex = &mutex,
+    };
+
+    for (size_t case_idx = 0; case_idx < AWS_ARRAY_SIZE(test_cases); ++case_idx) {
+        struct test_case case_i = test_cases[case_idx];
+        printf(
+            "CASE[%zu]: ip_address=%s expected_resolved_ip_address=%s\n, ",
+            case_idx,
+            case_i.ip_address,
+            case_i.expected_resolved_ip_address);
+        struct aws_string *address = aws_string_new_from_c_str(allocator, case_i.ip_address);
+        struct aws_string *expected_address = aws_string_new_from_c_str(allocator, case_i.expected_resolved_ip_address);
+
+        ASSERT_SUCCESS(aws_host_resolver_resolve_host(
+            resolver, address, s_default_host_resolved_test_callback, &config, &callback_data));
+
+        ASSERT_SUCCESS(aws_mutex_lock(&mutex));
+        aws_condition_variable_wait_pred(
+            &callback_data.condition_variable, &mutex, s_default_host_resolved_predicate, &callback_data);
+
+        callback_data.invoked = false;
+        ASSERT_TRUE(callback_data.has_aaaa_address);
+        ASSERT_INT_EQUALS(AWS_ADDRESS_RECORD_TYPE_AAAA, callback_data.aaaa_address.record_type);
+        ASSERT_BIN_ARRAYS_EQUALS(
+            aws_string_bytes(expected_address),
+            expected_address->len,
+            aws_string_bytes(callback_data.aaaa_address.address),
+            callback_data.aaaa_address.address->len);
+
+        aws_host_address_clean_up(&callback_data.aaaa_address);
+        aws_host_address_clean_up(&callback_data.a_address);
+        ASSERT_SUCCESS(aws_mutex_unlock(&mutex));
+        aws_string_destroy(address);
+        aws_string_destroy(expected_address);
+    }
+
+    aws_host_resolver_release(resolver);
+    aws_event_loop_group_release(el_group);
+
+    aws_io_library_clean_up();
+
+    return 0;
+}
+
+AWS_TEST_CASE(
+    test_default_host_resolver_ipv6_address_variations,
+    s_test_default_host_resolver_ipv6_address_variations_fn)
+
 /* just FYI, this test assumes that "s3.us-east-1.amazonaws.com" does not return IPv6 addresses. */
 static int s_test_default_with_ipv4_only_lookup_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;


### PR DESCRIPTION
*Description of changes:*
- Add a IPv6 variations test which validates that we always get an IPv6 in the shortest form from the host resolver.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
