### PR TITLE
Update secure_channel_tls_handler.c

### DIFF
--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -1586,6 +1586,7 @@ static int s_handler_shutdown(
                     slot->channel, AWS_IO_MESSAGE_APPLICATION_DATA, output_buffer.cbBuffer);
 
                 if (!outgoing_message || outgoing_message->message_data.capacity < output_buffer.cbBuffer) {
+                    FreeContextBuffer(output_buffer.pvBuffer); // add free for InitializeSecurityContextA
                     return aws_channel_slot_on_handler_shutdown_complete(slot, dir, aws_last_error(), true);
                 }
                 memcpy(outgoing_message->message_data.buffer, output_buffer.pvBuffer, output_buffer.cbBuffer);
@@ -1596,6 +1597,7 @@ static int s_handler_shutdown(
                     aws_mem_release(outgoing_message->allocator, outgoing_message);
                 }
             }
+            FreeContextBuffer(output_buffer.pvBuffer); // add free for InitializeSecurityContextA
         }
     }
 


### PR DESCRIPTION
Fix memory leak.

*Issue from [aws-sdk-cpp](https://github.com/aws/aws-sdk-cpp/issues/3021) if available: S3Client Uploading Leaks Memory on Windows caused by InitializeSecurityContext misuse*

*Description of changes: add free for InitializeSecurityContext*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
