### PR TITLE
remove uv headers from CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -44,10 +44,6 @@ file(GLOB AWS_IO_HEADERS
         "include/aws/io/*.h"
         )
 
-file(GLOB AWS_IO_UV_HEADERS
-        "include/aws/io/uv/*.h"
-        )
-
 file(GLOB AWS_IO_TESTING_HEADERS
         "include/aws/testing/*.h"
         )


### PR DESCRIPTION
Trivial: remove uv headers from CMakeLists. They were originally added here: https://github.com/awslabs/aws-c-io/pull/110/files but are no longer necessary.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
