### PR TITLE
Fix undefined type enum aws_tls_handler_state in secure_channel_tls_h…

### DIFF
--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -105,7 +105,7 @@ struct secure_channel_handler {
     bool verify_peer;
     struct aws_channel_task read_task;
     bool read_task_pending;
-    enum aws_tls_handler_state read_state;
+    enum aws_tls_handler_read_state read_state;
     int shutdown_error_code;
 };
 


### PR DESCRIPTION
Fix undefined type `enum aws_tls_handler_state` in `source/windows/secure_channel_tls_handler.c` when building on Windows.