### PR TITLE
Make port more random for test_socket_with_bind_to_interface test

### DIFF
--- a/tests/socket_test.c
+++ b/tests/socket_test.c
@@ -460,7 +460,7 @@ static int s_test_socket_with_bind_to_interface(struct aws_allocator *allocator,
     options.domain = AWS_SOCKET_IPV4;
     ASSERT_SUCCESS(s_test_socket(allocator, &options, &endpoint));
 
-    struct aws_socket_endpoint endpoint_ipv6 = {.address = "::1", .port = 1024};
+    struct aws_socket_endpoint endpoint_ipv6 = {.address = "::1", .port = 8128};
     options.type = AWS_SOCKET_STREAM;
     options.domain = AWS_SOCKET_IPV6;
     if (s_test_socket(allocator, &options, &endpoint_ipv6)) {


### PR DESCRIPTION
*Issue #, if available:*
#665 

*Description of changes:*
The error that we are getting is that the address is already in use. Try randomizing the port to something other than 1024. We don't encounter issues with other tests that use ports starting with 8, so this should work.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
