### PR TITLE
Provide I/O operation status back to event loop

### DIFF
--- a/include/aws/io/event_loop.h
+++ b/include/aws/io/event_loop.h
@@ -25,6 +25,7 @@ enum aws_io_event_type {
 struct aws_event_loop;
 struct aws_task;
 struct aws_thread_options;
+struct aws_event_loop_io_op_result;
 
 #if AWS_USE_IO_COMPLETION_PORTS
 
@@ -99,6 +100,10 @@ struct aws_event_loop_vtable {
         void *user_data);
 #endif
     int (*unsubscribe_from_io_events)(struct aws_event_loop *event_loop, struct aws_io_handle *handle);
+    void (*feedback_io_result)(
+        struct aws_event_loop *event_loop,
+        struct aws_io_handle *handle,
+        const struct aws_event_loop_io_op_result *io_op_result);
     void (*free_io_event_resources)(void *user_data);
     bool (*is_on_callers_thread)(struct aws_event_loop *event_loop);
 };
@@ -138,6 +143,11 @@ struct aws_event_loop_group {
     struct aws_array_list event_loops;
     struct aws_ref_count ref_count;
     struct aws_shutdown_callback_options shutdown_options;
+};
+
+struct aws_event_loop_io_op_result {
+    size_t read_bytes;
+    int error_code;
 };
 
 AWS_EXTERN_C_BEGIN
@@ -365,6 +375,15 @@ int aws_event_loop_subscribe_to_io_events(
  */
 AWS_IO_API
 int aws_event_loop_unsubscribe_from_io_events(struct aws_event_loop *event_loop, struct aws_io_handle *handle);
+
+/**
+ * Update the I/O operation completion status on the given I/O handle.
+ */
+AWS_IO_API
+void aws_event_loop_feedback_io_op_result(
+    struct aws_event_loop *event_loop,
+    struct aws_io_handle *handle,
+    const struct aws_event_loop_io_op_result *io_op_result);
 
 /**
  * Cleans up resources (user_data) associated with the I/O eventing subsystem for a given handle. This should only

--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -514,6 +514,15 @@ int aws_event_loop_unsubscribe_from_io_events(struct aws_event_loop *event_loop,
     return event_loop->vtable->unsubscribe_from_io_events(event_loop, handle);
 }
 
+void aws_event_loop_feedback_io_op_result(
+    struct aws_event_loop *event_loop,
+    struct aws_io_handle *handle,
+    const struct aws_event_loop_io_op_result *io_op_result) {
+    if (event_loop->vtable->feedback_io_result) {
+        event_loop->vtable->feedback_io_result(event_loop, handle, io_op_result);
+    }
+}
+
 void aws_event_loop_free_io_event_resources(struct aws_event_loop *event_loop, struct aws_io_handle *handle) {
     AWS_ASSERT(event_loop && event_loop->vtable->free_io_event_resources);
     event_loop->vtable->free_io_event_resources(handle->additional_data);


### PR DESCRIPTION
To support QNX, the event loop should be implemented based on `ionotify` function. `ionotify` is similar to `epoll` and `kqueue` functions with a couple of differences. One of these differences is `ionotify` needs to know the result of I/O operation performed on the fd (e.g. `EWOULDBLOCK` or `EAGAIN`).

In the current implementation of the event loop, I/O event callbacks (`aws_event_loop_on_event_fn`) do not return results of the I/O operations.

This PR adds feedback functionality to the socket channel.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
