### PR TITLE
Use s2n_cleanup_thread() and path

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,7 +155,10 @@ if (USE_S2N)
     file(GLOB AWS_IO_TLS_SRC
             "source/s2n/*.c"
             )
-    aws_use_package(s2n)
+    # NOTE: using find_package() (instead of aws_use_package() which may do an IN_SOURCE_BUILD).
+    # We do this because IN_SOURCE_BUILDS of S2N have different paths to the <s2n/unstable/*.h> headers.
+    find_package(s2n REQUIRED)
+    list(APPEND DEP_AWS_LIBS AWS::s2n)
 endif()
 
 file(GLOB IO_HEADERS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,11 +155,19 @@ if (USE_S2N)
         file(GLOB AWS_IO_TLS_SRC
                 "source/s2n/*.c"
                 )
-        if (IN_SOURCE_BUILD)
-           # We do in source build, set the flag to use the insource path to the <s2n/unstable/*.h> headers.
-           add_definitions(-DAWS_S2N_INSOURCE_PATH)
+        # Try to find s2n directly first. In case of s2n already built.
+        find_package(s2n QUIET)
+
+        if (NOT s2n_FOUND)
+                # If s2n was not found, try to do the IN_SOURCE_BUILD.
+                # If not IN_SOURCE_BUILD, s2n will be required to be found and fail from aws_use_package
+                # If in source build, set the flag to use the insource path to the <s2n/unstable/*.h> headers.
+                aws_use_package(s2n)
+                add_definitions(-DAWS_S2N_INSOURCE_PATH)
+        else()
+                # Found s2n, use the install path
+                list(APPEND DEP_AWS_LIBS AWS::s2n)
         endif()
-        aws_use_package(s2n)
 endif()
 
 file(GLOB IO_HEADERS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,20 +155,11 @@ if (USE_S2N)
         file(GLOB AWS_IO_TLS_SRC
                 "source/s2n/*.c"
                 )
-        # NOTE: using find_package() (instead of aws_use_package() which may do an IN_SOURCE_BUILD).
-        # We do this because IN_SOURCE_BUILDS of S2N have different paths to the <s2n/unstable/*.h> headers.
-        find_package(s2n QUIET)
-
-        if (NOT s2n_FOUND)
-                # If s2n was not found, try to fallback to the IN_SOURCE_BUILD.
-                # If not IN_SOURCE_BUILD, s2n will be required to be found and fail from aws_use_package.
-                # If secceed from aws_use_package set the flag to use the insource path to the <s2n/unstable/*.h> headers.
-                aws_use_package(s2n)
-                add_definitions(-DAWS_S2N_INSOURCE_PATH)
-        else()
-                # Found s2n, use the install path
-                list(APPEND DEP_AWS_LIBS AWS::s2n)
+        if (IN_SOURCE_BUILD)
+           # We do in source build, set the flag to use the insource path to the <s2n/unstable/*.h> headers.
+           add_definitions(-DAWS_S2N_INSOURCE_PATH)
         endif()
+        aws_use_package(s2n)
 endif()
 
 file(GLOB IO_HEADERS

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -155,18 +155,15 @@ if (USE_S2N)
         file(GLOB AWS_IO_TLS_SRC
                 "source/s2n/*.c"
                 )
-        # Try to find s2n directly first. In case of s2n already built.
-        find_package(s2n QUIET)
-
-        if (NOT s2n_FOUND)
-                # If s2n was not found, try to do the IN_SOURCE_BUILD.
-                # If not IN_SOURCE_BUILD, s2n will be required to be found and fail from aws_use_package
-                # If in source build, set the flag to use the insource path to the <s2n/unstable/*.h> headers.
-                aws_use_package(s2n)
-                add_definitions(-DAWS_S2N_INSOURCE_PATH)
+        # Prefer find_package() because it's the normal CMake way to do dependencies.
+        # But fall back on aws_use_package() because some projects still need to do an IN_SOURCE_BUILD of S2N.
+        # (e.g. aws-crt-java until this is resolved: https://github.com/awslabs/aws-crt-java/pull/817)
+        if (s2n_FOUND)
+            list(APPEND DEP_AWS_LIBS AWS::s2n)
         else()
-                # Found s2n, use the install path
-                list(APPEND DEP_AWS_LIBS AWS::s2n)
+            # Set flag to use in-source path to  <s2n/unstable/*.h> headers if we do an IN_SOURCE_BUILD.
+            aws_use_package(s2n)
+            add_definitions(-DAWS_S2N_INSOURCE_PATH)
         endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -160,11 +160,11 @@ if (USE_S2N)
         find_package(s2n QUIET)
 
         if (NOT s2n_FOUND)
-                # Check if s2n was not found, try to do the IN_SOURCE_BUILD.
-                # If not IN_SOURCE_BUILD, s2n will be required to be found and fail from aws_use_package
+                # If s2n was not found, try to fallback to the IN_SOURCE_BUILD.
+                # If not IN_SOURCE_BUILD, s2n will be required to be found and fail from aws_use_package.
                 # If secceed from aws_use_package set the flag to use the insource path to the <s2n/unstable/*.h> headers.
                 aws_use_package(s2n)
-                option(AWS_S2N_INSOURCE_PATH "Use the insource path for S2N" ON)
+                add_definitions(-DAWS_S2N_INSOURCE_PATH)
         else()
                 # Found s2n, use the install path
                 list(APPEND DEP_AWS_LIBS AWS::s2n)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,8 @@ if (USE_S2N)
         # Prefer find_package() because it's the normal CMake way to do dependencies.
         # But fall back on aws_use_package() because some projects still need to do an IN_SOURCE_BUILD of S2N.
         # (e.g. aws-crt-java until this is resolved: https://github.com/awslabs/aws-crt-java/pull/817)
+        find_package(s2n QUIET)
+
         if (s2n_FOUND)
             list(APPEND DEP_AWS_LIBS AWS::s2n)
         else()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,13 +152,23 @@ if (BYO_CRYPTO)
 endif()
 
 if (USE_S2N)
-    file(GLOB AWS_IO_TLS_SRC
-            "source/s2n/*.c"
-            )
-    # NOTE: using find_package() (instead of aws_use_package() which may do an IN_SOURCE_BUILD).
-    # We do this because IN_SOURCE_BUILDS of S2N have different paths to the <s2n/unstable/*.h> headers.
-    find_package(s2n REQUIRED)
-    list(APPEND DEP_AWS_LIBS AWS::s2n)
+        file(GLOB AWS_IO_TLS_SRC
+                "source/s2n/*.c"
+                )
+        # NOTE: using find_package() (instead of aws_use_package() which may do an IN_SOURCE_BUILD).
+        # We do this because IN_SOURCE_BUILDS of S2N have different paths to the <s2n/unstable/*.h> headers.
+        find_package(s2n QUIET)
+
+        if (NOT s2n_FOUND)
+                # Check if s2n was not found, try to do the IN_SOURCE_BUILD.
+                # If not IN_SOURCE_BUILD, s2n will be required to be found and fail from aws_use_package
+                # If secceed from aws_use_package set the flag to use the insource path to the <s2n/unstable/*.h> headers.
+                aws_use_package(s2n)
+                option(AWS_S2N_INSOURCE_PATH "Use the insource path for S2N" ON)
+        else()
+                # Found s2n, use the install path
+                list(APPEND DEP_AWS_LIBS AWS::s2n)
+        endif()
 endif()
 
 file(GLOB IO_HEADERS

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -20,6 +20,9 @@
 #include <aws/common/task_scheduler.h>
 #include <aws/common/thread.h>
 
+#include <s2n.h>
+#include <s2n/unstable/cleanup.h>
+
 #include <errno.h>
 #include <inttypes.h>
 #include <math.h>

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -1253,7 +1253,7 @@ static struct aws_event_loop_local_object s_tl_cleanup_object = {
 static void s_aws_cleanup_s2n_thread_local_state(void *user_data) {
     (void)user_data;
 
-    s2n_cleanup();
+    s2n_cleanup_thread();
 }
 
 /* s2n allocates thread-local data structures. We need to clean these up when the event loop's thread exits. */

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -21,12 +21,15 @@
 #include <aws/common/thread.h>
 
 #include <s2n.h>
-#include <s2n/unstable/cleanup.h>
+#ifdef AWS_S2N_INSOURCE_PATH
+#    include <api/unstable/cleanup.h>
+#else
+#    include <s2n/unstable/cleanup.h>
+#endif
 
 #include <errno.h>
 #include <inttypes.h>
 #include <math.h>
-#include <s2n.h>
 #include <stdio.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
See: https://github.com/aws/s2n-tls/pull/4584

follow up for https://github.com/awslabs/aws-c-io/pull/680
- Tested on java with insource build [here](https://github.com/awslabs/aws-crt-java/pull/835)
- Tested on Python with prebuild-s2n [here](https://github.com/awslabs/aws-crt-python/pull/602)
- Also tested the nodejs issue locally, no crash.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
