### PR TITLE
Handle PKCS#8 private keys in Windows

### DIFF
--- a/source/windows/windows_pki_utils.c
+++ b/source/windows/windows_pki_utils.c
@@ -678,7 +678,6 @@ int aws_import_key_pair_to_cert_context(
                     &decoded_len)) {
                 cert_type = AWS_CT_X509_RSA;
             }
-            LocalFree(key_wrapper);
         }
 #ifndef AWS_SUPPORT_WIN7
         else if (CryptDecodeObjectEx(
@@ -745,6 +744,7 @@ clean_up:
     aws_pem_objects_clean_up(&private_keys);
 
     LocalFree(key);
+    LocalFree(key_wrapper);
 
     if (result == AWS_OP_ERR) {
         if (*store != NULL) {

--- a/source/windows/windows_pki_utils.c
+++ b/source/windows/windows_pki_utils.c
@@ -559,6 +559,7 @@ int aws_import_key_pair_to_cert_context(
 
     int result = AWS_OP_ERR;
     BYTE *key = NULL;
+    BYTE *key_wrapper = NULL;
 
     if (aws_pem_objects_init_from_file_contents(&certificates, alloc, *public_cert_chain)) {
         AWS_LOGF_ERROR(
@@ -640,7 +641,6 @@ int aws_import_key_pair_to_cert_context(
 
     struct aws_pem_object *private_key_ptr = NULL;
     DWORD decoded_len = 0;
-    BYTE *key_wrapper = NULL;
     DWORD decoded_wrapper_len = 0;
     enum aws_certificate_type cert_type = AWS_CT_X509_UNKNOWN;
     size_t private_key_count = aws_array_list_length(&private_keys);

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -246,6 +246,7 @@ if(NOT BYO_CRYPTO)
     add_net_test_case(alpn_successfully_negotiates)
     add_net_test_case(alpn_no_protocol_message)
     add_net_test_case(test_ecc_cert_import)
+    add_net_test_case(test_pkcs8_import)
 
     add_test_case(alpn_error_creating_handler)
     add_test_case(tls_destroy_null_context)

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -2503,4 +2503,40 @@ static int s_test_ecc_cert_import(struct aws_allocator *allocator, void *ctx) {
 
 AWS_TEST_CASE(test_ecc_cert_import, s_test_ecc_cert_import)
 
+static int s_test_pkcs8_import(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+    (void)allocator;
+
+    aws_io_library_init(allocator);
+
+    struct aws_byte_buf cert_buf;
+    struct aws_byte_buf key_buf;
+
+    ASSERT_SUCCESS(aws_byte_buf_init_from_file(&cert_buf, allocator, "unittests.crt"));
+    ASSERT_SUCCESS(aws_byte_buf_init_from_file(&key_buf, allocator, "unittests.p8"));
+
+    struct aws_byte_cursor cert_cur = aws_byte_cursor_from_buf(&cert_buf);
+    struct aws_byte_cursor key_cur = aws_byte_cursor_from_buf(&key_buf);
+    struct aws_tls_ctx_options tls_options = {0};
+    AWS_FATAL_ASSERT(
+        AWS_OP_SUCCESS == aws_tls_ctx_options_init_client_mtls(&tls_options, allocator, &cert_cur, &key_cur));
+
+    /* import happens in here */
+    struct aws_tls_ctx *tls_context = aws_tls_client_ctx_new(allocator, &tls_options);
+    ASSERT_NOT_NULL(tls_context);
+
+    aws_tls_ctx_release(tls_context);
+
+    aws_tls_ctx_options_clean_up(&tls_options);
+
+    aws_byte_buf_clean_up(&cert_buf);
+    aws_byte_buf_clean_up(&key_buf);
+
+    aws_io_library_clean_up();
+
+    return AWS_OP_SUCCESS;
+}
+
+AWS_TEST_CASE(test_pkcs8_import, s_test_pkcs8_import)
+
 #endif /* BYO_CRYPTO */


### PR DESCRIPTION
*Issue #, if available:*

Currently, Windows implementation of PKI utils cannot decode private keys stored in the [PKCS#8](https://en.wikipedia.org/wiki/PKCS_8) format.

*Description of changes:*

PKCS#8 can be encrypted and unencrypted. This PR adds support for unencrypted PKCS#8 format only.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
