### PR TITLE
use the path from api/

### DIFF
--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -22,7 +22,7 @@
 
 #include <s2n.h>
 #ifdef AWS_S2N_INSOURCE_PATH
-#    include <api/unstable/cleanup.h>
+#    include <unstable/cleanup.h>
 #else
 #    include <s2n/unstable/cleanup.h>
 #endif


### PR DESCRIPTION
*Issue #, if available:*

- In case of building s2n taking `api/` as the header path, eg: https://github.com/awslabs/aws-crt-swift/blob/main/Package.swift#L100

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
