### PR TITLE
Fix CI for GCC-13 on Ubuntu-18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,10 +83,6 @@ jobs:
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
-
-    - name: Checkout Sources
-      uses: actions/checkout@v4
-
     - name: Build ${{ matrix.variant.name }}
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,25 @@ jobs:
           - name: gcc-8
           - name: gcc-11
           - name: gcc-13
+          # See Issue: https://github.com/llvm/llvm-project/issues/59007. Although this issue 
+          # has been fixed in LLVM, the fix will not propagate to older versions of Ubuntu 
+          # anytime soon.
+          #
+          # GCC relies on LLVM for ASAN. Starting with GLIBC version 2.34, the `dn_expand` 
+          # function, previously found in `libresolv.so`, was moved to `libc.so`. This 
+          # function is used internally by the `getaddrinfo()` system call.
+          #
+          # In our setup (As of December 2024), we are using an Ubuntu 18 Docker image on a newer Ubuntu host. 
+          # However, due to compatibility issues between newer LLVM (used with GCC-13) 
+          # and the older Ubuntu image, the linker does not link with `libresolv.so`. 
+          # This results in crashes in `getaddrinfo()` since Ubuntu-18 GLIBC is 2.31.
+          #
+          # This problem does not occur on Ubuntu 22 and newer because GLIBC versions 2.34 
+          # and above include `dn_expand` in `libc.so`, eliminating the dependency on 
+          # `libresolv.so`.
+          #
+          # We can bypass this problem by linking with "resolv" manually until we bump 
+          # our base Linux image to Ubuntu 22.
             extra-build-flag: --cmake-extra=-DCMAKE_EXE_LINKER_FLAGS="-lresolv" 
     steps:
       - uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
   linux-compiler-compat:
     runs-on: ubuntu-24.04 # latest
     strategy:
-      fail-fast: false
       matrix:
         variant:
           - name: clang-3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-io
-  LINUX_BASE_IMAGE: ubuntu-22-x64
+  LINUX_BASE_IMAGE: ubuntu-18-x64
   RUN: ${{ github.run_id }}-${{ github.run_number }}
   CRT_CI_ROLE: ${{ secrets.CRT_CI_ROLE_ARN }}
   AWS_DEFAULT_REGION: us-east-1
@@ -57,7 +57,7 @@ jobs:
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-al2-x64 build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DBYO_CRYPTO=ON
 
   linux-compiler-compat:
-    runs-on: ubuntu-24.04 # latest
+    runs-on: ubuntu-20.04 # latest
     strategy:
       matrix:
         compiler:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           - name: gcc-8
           - name: gcc-11
           - name: gcc-13
-            extra-build-flag: --cmake-extra -DSHARED_LINKER_FLAGS=-lresolv
+            extra-build-flag: --cmake-extra -DCMAKE_SHARED_LINKER_FLAGS=-lresolv
     steps:
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-io
-  LINUX_BASE_IMAGE: ubuntu-22-x64
+  LINUX_BASE_IMAGE: ubuntu-18-x64
   RUN: ${{ github.run_id }}-${{ github.run_number }}
   CRT_CI_ROLE: ${{ secrets.CRT_CI_ROLE_ARN }}
   AWS_DEFAULT_REGION: us-east-1
@@ -57,36 +57,40 @@ jobs:
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-al2-x64 build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DBYO_CRYPTO=ON
 
   linux-compiler-compat:
-    runs-on: ubuntu-24.04 # latest
-    strategy:
-      fail-fast: false
-      matrix:
-        compiler:
-          - clang-3
-          - clang-6
-          - clang-8
-          - clang-9
-          - clang-10
-          - clang-11
-          - clang-15
-          - clang-17
-          - gcc-4.8
-          - gcc-5
-          - gcc-6
-          - gcc-7
-          - gcc-8
-          - gcc-11
-          - gcc-13
-    steps:
+  runs-on: ubuntu-24.04 # latest
+  strategy:
+    fail-fast: false
+    matrix:
+      variant:
+        - name: clang-3
+        - name: clang-6
+        - name: clang-8
+        - name: clang-9
+        - name: clang-10
+        - name: clang-11
+        - name: clang-15
+        - name: clang-17
+        - name: gcc-4.8
+        - name: gcc-5
+        - name: gcc-6
+        - name: gcc-7
+        - name: gcc-8
+        - name: gcc-11
+        - name: gcc-13
+          extra-build-flag: --cmake-extra -DSHARED_LINKER_FLAGS=-lresolv
+  steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}
         aws-region: ${{ env.AWS_DEFAULT_REGION }}
-    # We can't use the `uses: docker://image` version yet, GitHub lacks authentication for actions -> packages
-    - name: Build ${{ env.PACKAGE_NAME }}
+
+    - name: Checkout Sources
+      uses: actions/checkout@v4
+
+    - name: Build ${{ matrix.variant.name }}
       run: |
         aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler }}
+        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.variant.name }} ${{ matrix.variant.extra-build-flag }}
 
   linux-debug:
     runs-on: ubuntu-24.04 # latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,10 +77,9 @@ jobs:
           - name: gcc-11
           - name: gcc-13
           # See Issue: https://github.com/llvm/llvm-project/issues/59007. Although this issue 
-          # has been fixed in LLVM, the fix will not propagate to older versions of Ubuntu and GCC 13.1. 
+          # has been fixed in LLVM, the fix will probably not propagate to older versions of Ubuntu and GCC 13.1. 
           #
-          # GCC relies on LLVM for ASAN. Starting with GLIBC version 2.34, the `dn_expand` 
-          # function, previously found in `libresolv.so`, was moved to `libc.so`. This 
+          # Starting with GLIBC version 2.34, the `dn_expand` function, previously found in `libresolv.so`, was moved to `libc.so`. This 
           # function is used internally by the `getaddrinfo()` system call.
           #
           # In our setup (As of December 2024), we are using an Ubuntu 18 Docker image on a newer Ubuntu host. 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-io
-  LINUX_BASE_IMAGE: ubuntu-18-x64
+  LINUX_BASE_IMAGE: ubuntu-20-x64
   RUN: ${{ github.run_id }}-${{ github.run_number }}
   CRT_CI_ROLE: ${{ secrets.CRT_CI_ROLE_ARN }}
   AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-io
-  LINUX_BASE_IMAGE: ubuntu-18-x64
+  LINUX_BASE_IMAGE: ubuntu-22-x64
   RUN: ${{ github.run_id }}-${{ github.run_number }}
   CRT_CI_ROLE: ${{ secrets.CRT_CI_ROLE_ARN }}
   AWS_DEFAULT_REGION: us-east-1
@@ -59,22 +59,23 @@ jobs:
   linux-compiler-compat:
     runs-on: ubuntu-24.04 # latest
     strategy:
+      fail-fast: false
       matrix:
         compiler:
-          # - clang-3
-          # - clang-6
-          # - clang-8
-          # - clang-9
-          # - clang-10
-          # - clang-11
-          # - clang-15
-          # - clang-17
-          # - gcc-4.8
-          # - gcc-5
-          # - gcc-6
-          # - gcc-7
-          # - gcc-8
-          # - gcc-11
+          - clang-3
+          - clang-6
+          - clang-8
+          - clang-9
+          - clang-10
+          - clang-11
+          - clang-15
+          - clang-17
+          - gcc-4.8
+          - gcc-5
+          - gcc-6
+          - gcc-7
+          - gcc-8
+          - gcc-11
           - gcc-13
     steps:
     - uses: aws-actions/configure-aws-credentials@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -78,8 +78,7 @@ jobs:
           - name: gcc-11
           - name: gcc-13
           # See Issue: https://github.com/llvm/llvm-project/issues/59007. Although this issue 
-          # has been fixed in LLVM, the fix will not propagate to older versions of Ubuntu 
-          # anytime soon.
+          # has been fixed in LLVM, the fix will not propagate to older versions of Ubuntu and GCC 13.1. 
           #
           # GCC relies on LLVM for ASAN. Starting with GLIBC version 2.34, the `dn_expand` 
           # function, previously found in `libresolv.so`, was moved to `libc.so`. This 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           - name: gcc-8
           - name: gcc-11
           - name: gcc-13
-            extra-build-flag: --cmake-extra -DCMAKE_EXE_LINKER_FLAGS="-lresolv" 
+            extra-build-flag: --cmake-extra=-DCMAKE_EXE_LINKER_FLAGS="-lresolv" 
     steps:
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,7 +77,7 @@ jobs:
           - name: gcc-8
           - name: gcc-11
           - name: gcc-13
-            extra-build-flag: --cmake-extra -DCMAKE_SHARED_LINKER_FLAGS=-lresolv
+            extra-build-flag: --cmake-extra -DCMAKE_EXE_LINKER_FLAGS="-lresolv" 
     steps:
       - uses: aws-actions/configure-aws-credentials@v4
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,11 @@ jobs:
           - gcc-11
           - gcc-13
     steps:
+    - name: Fix kernel mmap rnd bits
+      # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
+      # high-entropy ASLR in much newer kernels that GitHub runners are
+      # using leading to random crashes: https://reviews.llvm.org/D148280
+      run: sudo sysctl vm.mmap_rnd_bits=28
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,7 +75,7 @@ jobs:
           - gcc-7
           - gcc-8
           - gcc-11
-          # - gcc-13 TODO: figure out why its not passing
+          - gcc-13
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-io
-  LINUX_BASE_IMAGE: ubuntu-18-x64
+  LINUX_BASE_IMAGE: ubuntu-22-x64
   RUN: ${{ github.run_id }}-${{ github.run_number }}
   CRT_CI_ROLE: ${{ secrets.CRT_CI_ROLE_ARN }}
   AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,36 +57,36 @@ jobs:
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-al2-x64 build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DBYO_CRYPTO=ON
 
   linux-compiler-compat:
-  runs-on: ubuntu-24.04 # latest
-  strategy:
-    fail-fast: false
-    matrix:
-      variant:
-        - name: clang-3
-        - name: clang-6
-        - name: clang-8
-        - name: clang-9
-        - name: clang-10
-        - name: clang-11
-        - name: clang-15
-        - name: clang-17
-        - name: gcc-4.8
-        - name: gcc-5
-        - name: gcc-6
-        - name: gcc-7
-        - name: gcc-8
-        - name: gcc-11
-        - name: gcc-13
-          extra-build-flag: --cmake-extra -DSHARED_LINKER_FLAGS=-lresolv
-  steps:
-    - uses: aws-actions/configure-aws-credentials@v4
-      with:
-        role-to-assume: ${{ env.CRT_CI_ROLE }}
-        aws-region: ${{ env.AWS_DEFAULT_REGION }}
-    - name: Build ${{ matrix.variant.name }}
-      run: |
-        aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.variant.name }} ${{ matrix.variant.extra-build-flag }}
+    runs-on: ubuntu-24.04 # latest
+    strategy:
+      fail-fast: false
+      matrix:
+        variant:
+          - name: clang-3
+          - name: clang-6
+          - name: clang-8
+          - name: clang-9
+          - name: clang-10
+          - name: clang-11
+          - name: clang-15
+          - name: clang-17
+          - name: gcc-4.8
+          - name: gcc-5
+          - name: gcc-6
+          - name: gcc-7
+          - name: gcc-8
+          - name: gcc-11
+          - name: gcc-13
+            extra-build-flag: --cmake-extra -DSHARED_LINKER_FLAGS=-lresolv
+    steps:
+      - uses: aws-actions/configure-aws-credentials@v4
+        with:
+          role-to-assume: ${{ env.CRT_CI_ROLE }}
+          aws-region: ${{ env.AWS_DEFAULT_REGION }}
+      - name: Build ${{ matrix.variant.name }}
+        run: |
+          aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
+          ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.variant.name }} ${{ matrix.variant.extra-build-flag }}
 
   linux-debug:
     runs-on: ubuntu-24.04 # latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,20 +61,20 @@ jobs:
     strategy:
       matrix:
         compiler:
-          - clang-3
-          - clang-6
-          - clang-8
-          - clang-9
-          - clang-10
-          - clang-11
-          - clang-15
-          - clang-17
-          - gcc-4.8
-          - gcc-5
-          - gcc-6
-          - gcc-7
-          - gcc-8
-          - gcc-11
+          # - clang-3
+          # - clang-6
+          # - clang-8
+          # - clang-9
+          # - clang-10
+          # - clang-11
+          # - clang-15
+          # - clang-17
+          # - gcc-4.8
+          # - gcc-5
+          # - gcc-6
+          # - gcc-7
+          # - gcc-8
+          # - gcc-11
           - gcc-13
     steps:
     - name: Fix kernel mmap rnd bits

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,7 +57,7 @@ jobs:
         ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-al2-x64 build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DBYO_CRYPTO=ON
 
   linux-compiler-compat:
-    runs-on: ubuntu-20.04 # latest
+    runs-on: ubuntu-24.04 # latest
     strategy:
       matrix:
         compiler:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -83,7 +83,7 @@ jobs:
           # function is used internally by the `getaddrinfo()` system call.
           #
           # In our setup (As of December 2024), we are using an Ubuntu 18 Docker image on a newer Ubuntu host. 
-          # However, due to compatibility issues between newer LLVM (used with GCC-13) 
+          # However, due to compatibility issues between newer libasan.so in GCC 13.1
           # and the older Ubuntu image, the linker does not link with `libresolv.so`. 
           # This results in crashes in `getaddrinfo()` since Ubuntu-18 GLIBC is 2.31.
           #

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,7 @@ jobs:
     runs-on: ubuntu-24.04 # latest
     strategy:
       matrix:
-        variant:
+        compiler:
           - name: clang-3
           - name: clang-6
           - name: clang-8
@@ -95,14 +95,14 @@ jobs:
           # our base Linux image to Ubuntu 22.
             extra-build-flag: --cmake-extra=-DCMAKE_EXE_LINKER_FLAGS="-lresolv" 
     steps:
-      - uses: aws-actions/configure-aws-credentials@v4
-        with:
-          role-to-assume: ${{ env.CRT_CI_ROLE }}
-          aws-region: ${{ env.AWS_DEFAULT_REGION }}
-      - name: Build ${{ matrix.variant.name }}
-        run: |
-          aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
-          ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.variant.name }} ${{ matrix.variant.extra-build-flag }}
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ env.CRT_CI_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+    - name: Build ${{ matrix.compiler.name }}
+      run: |
+        aws s3 cp s3://aws-crt-test-stuff/ci/${{ env.BUILDER_VERSION }}/linux-container-ci.sh ./linux-container-ci.sh && chmod a+x ./linux-container-ci.sh
+        ./linux-container-ci.sh ${{ env.BUILDER_VERSION }} aws-crt-${{ env.LINUX_BASE_IMAGE }} build -p ${{ env.PACKAGE_NAME }} --compiler=${{ matrix.compiler.name }} ${{ matrix.compiler.extra-build-flag }}
 
   linux-debug:
     runs-on: ubuntu-24.04 # latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-io
-  LINUX_BASE_IMAGE: ubuntu-20-x64
+  LINUX_BASE_IMAGE: ubuntu-18-x64
   RUN: ${{ github.run_id }}-${{ github.run_number }}
   CRT_CI_ROLE: ${{ secrets.CRT_CI_ROLE_ARN }}
   AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-io
-  LINUX_BASE_IMAGE: ubuntu-22-x64
+  LINUX_BASE_IMAGE: ubuntu-24-x64
   RUN: ${{ github.run_id }}-${{ github.run_number }}
   CRT_CI_ROLE: ${{ secrets.CRT_CI_ROLE_ARN }}
   AWS_DEFAULT_REGION: us-east-1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ env:
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-io
-  LINUX_BASE_IMAGE: ubuntu-24-x64
+  LINUX_BASE_IMAGE: ubuntu-22-x64
   RUN: ${{ github.run_id }}-${{ github.run_number }}
   CRT_CI_ROLE: ${{ secrets.CRT_CI_ROLE_ARN }}
   AWS_DEFAULT_REGION: us-east-1
@@ -77,11 +77,6 @@ jobs:
           # - gcc-11
           - gcc-13
     steps:
-    - name: Fix kernel mmap rnd bits
-      # Asan in llvm 14 provided in ubuntu 22.04 is incompatible with
-      # high-entropy ASLR in much newer kernels that GitHub runners are
-      # using leading to random crashes: https://reviews.llvm.org/D148280
-      run: sudo sysctl vm.mmap_rnd_bits=28
     - uses: aws-actions/configure-aws-credentials@v4
       with:
         role-to-assume: ${{ env.CRT_CI_ROLE }}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,6 +213,7 @@ aws_use_package(aws-c-common)
 aws_use_package(aws-c-cal)
 target_link_libraries(${PROJECT_NAME} PUBLIC ${DEP_AWS_LIBS})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${PLATFORM_LIBS})
+target_link_libraries(${PROJECT_NAME} PRIVATE resolv)
 
 aws_prepare_shared_lib_exports(${PROJECT_NAME})
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -213,7 +213,6 @@ aws_use_package(aws-c-common)
 aws_use_package(aws-c-cal)
 target_link_libraries(${PROJECT_NAME} PUBLIC ${DEP_AWS_LIBS})
 target_link_libraries(${PROJECT_NAME} PRIVATE ${PLATFORM_LIBS})
-target_link_libraries(${PROJECT_NAME} PRIVATE resolv)
 
 aws_prepare_shared_lib_exports(${PROJECT_NAME})
 


### PR DESCRIPTION
See Issue: https://github.com/llvm/llvm-project/issues/59007. Although this issue has been fixed in LLVM, the fix will not probably propagate to older versions of Ubuntu and GCC-13.1.

Starting with GLIBC version 2.34, the `dn_expand` function, previously found in `libresolv.so`, was moved to `libc.so`. This function is used internally by the `getaddrinfo()` system call.

In our setup, we are using an Ubuntu 18 Docker image on a newer Ubuntu host. However, due to compatibility issues between newer libasan.so in GCC 13.1 and the older Ubuntu image, the linker does not link with `libresolv.so`. This results in crashes in `getaddrinfo()`.

This problem does not occur on Ubuntu 22 and newer because GLIBC versions 2.34 and above include `dn_expand` in `libc.so`, eliminating the dependency on `libresolv.so`.

We can bypass this problem by linking with "resolv" manually until we bump our base Linux image to Ubuntu 22.