### PR TITLE
PR change pass.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -243,7 +243,7 @@ jobs:
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
-        ./builder build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DAWS_USE_APPLE_NETWORK_FRAMEWORK=${{ matrix.eventloop == 'dispatch_queue' && 'ON' || 'OFF' }} --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS="${{ matrix.sanitizers }}"
+        ./builder build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DAWS_USE_APPLE_DISPATCH_QUEUE=${{ matrix.eventloop == 'dispatch_queue' && 'ON' || 'OFF' }} --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS="${{ matrix.sanitizers }}"
 
   macos-x64:
     runs-on: macos-14-large # latest
@@ -274,7 +274,7 @@ jobs:
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
-        ./builder build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DAWS_USE_APPLE_NETWORK_FRAMEWORK=${{ matrix.eventloop == 'dispatch_queue' && 'ON' || 'OFF' }} --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS="${{ matrix.sanitizers }}" --config Debug
+        ./builder build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DAWS_USE_APPLE_DISPATCH_QUEUE=${{ matrix.eventloop == 'dispatch_queue' && 'ON' || 'OFF' }} --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS="${{ matrix.sanitizers }}" --config Debug
 
   freebsd:
     runs-on: ubuntu-24.04  # latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,27 +1,11 @@
 
-cmake_minimum_required(VERSION 3.9)
+cmake_minimum_required(VERSION 3.9...3.31)
 project(aws-c-io C)
 
-if (DEFINED CMAKE_PREFIX_PATH)
-    file(TO_CMAKE_PATH "${CMAKE_PREFIX_PATH}" CMAKE_PREFIX_PATH)
+if (NOT IN_SOURCE_BUILD)
+    # this is required so we can use aws-c-common's CMake modules
+    find_package(aws-c-common REQUIRED)
 endif()
-
-if (DEFINED CMAKE_INSTALL_PREFIX)
-    file(TO_CMAKE_PATH "${CMAKE_INSTALL_PREFIX}" CMAKE_INSTALL_PREFIX)
-endif()
-
-
-if (UNIX AND NOT APPLE)
-    include(GNUInstallDirs)
-elseif(NOT DEFINED CMAKE_INSTALL_LIBDIR)
-    set(CMAKE_INSTALL_LIBDIR "lib")
-endif()
-
-# This is required in order to append /lib/cmake to each element in CMAKE_PREFIX_PATH
-set(AWS_MODULE_DIR "/${CMAKE_INSTALL_LIBDIR}/cmake")
-string(REPLACE ";" "${AWS_MODULE_DIR};" AWS_MODULE_PATH "${CMAKE_PREFIX_PATH}${AWS_MODULE_DIR}")
-# Append that generated list to the module search path
-list(APPEND CMAKE_MODULE_PATH ${AWS_MODULE_PATH})
 
 include(AwsCFlags)
 include(AwsCheckHeaders)
@@ -29,6 +13,7 @@ include(AwsSharedLibSetup)
 include(AwsSanitizers)
 include(AwsFindPackage)
 include(CTest)
+include(GNUInstallDirs)
 
 option(BUILD_RELOCATABLE_BINARIES
         "Build Relocatable Binaries, this will turn off features that will fail on older kernels than used for the build."
@@ -230,8 +215,8 @@ target_link_libraries(${PROJECT_NAME} PRIVATE ${PLATFORM_LIBS})
 
 aws_prepare_shared_lib_exports(${PROJECT_NAME})
 
-install(FILES ${AWS_IO_HEADERS} DESTINATION "include/aws/io" COMPONENT Development)
-install(FILES ${AWS_IO_TESTING_HEADERS} DESTINATION "include/aws/testing" COMPONENT Development)
+install(FILES ${AWS_IO_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/aws/io" COMPONENT Development)
+install(FILES ${AWS_IO_TESTING_HEADERS} DESTINATION "${CMAKE_INSTALL_INCLUDEDIR}/aws/testing" COMPONENT Development)
 
 if (BUILD_SHARED_LIBS)
    set (TARGET_DIR "shared")
@@ -240,7 +225,7 @@ else()
 endif()
 
 install(EXPORT "${PROJECT_NAME}-targets"
-        DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/${TARGET_DIR}"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/${TARGET_DIR}"
         NAMESPACE AWS::
         COMPONENT Development)
 
@@ -249,7 +234,7 @@ configure_file("cmake/${PROJECT_NAME}-config.cmake"
         @ONLY)
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
-        DESTINATION "${LIBRARY_DIRECTORY}/${PROJECT_NAME}/cmake/"
+        DESTINATION "${CMAKE_INSTALL_LIBDIR}/cmake/${PROJECT_NAME}/"
         COMPONENT Development)
 
 if (NOT CMAKE_CROSSCOMPILING)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -203,6 +203,10 @@ if (AWS_USE_APPLE_NETWORK_FRAMEWORK)
     target_compile_definitions(${PROJECT_NAME} PUBLIC "-DAWS_USE_APPLE_NETWORK_FRAMEWORK")
 endif()
 
+if (AWS_USE_APPLE_DISPATCH_QUEUE)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC "-DAWS_USE_APPLE_DISPATCH_QUEUE")
+endif()
+
 target_include_directories(${PROJECT_NAME} PUBLIC
         $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
         $<INSTALL_INTERFACE:include>)

--- a/include/aws/io/event_loop.h
+++ b/include/aws/io/event_loop.h
@@ -45,6 +45,7 @@ struct aws_event_loop_vtable {
         void *user_data);
     int (*unsubscribe_from_io_events)(struct aws_event_loop *event_loop, struct aws_io_handle *handle);
     void (*free_io_event_resources)(void *user_data);
+    void *(*get_base_event_loop_group)(struct aws_event_loop *event_loop);
     bool (*is_on_callers_thread)(struct aws_event_loop *event_loop);
 };
 

--- a/include/aws/io/io.h
+++ b/include/aws/io/io.h
@@ -16,7 +16,6 @@ AWS_PUSH_SANE_WARNING_LEVEL
 
 struct aws_io_handle;
 typedef void aws_io_set_queue_on_handle_fn(struct aws_io_handle *handle, void *queue);
-typedef void aws_io_clear_queue_on_handle_fn(struct aws_io_handle *handle);
 
 struct aws_io_handle {
     union {
@@ -26,7 +25,6 @@ struct aws_io_handle {
     } data;
     void *additional_data;
     aws_io_set_queue_on_handle_fn *set_queue;
-    aws_io_clear_queue_on_handle_fn *clear_queue;
 };
 
 enum aws_io_message_type {

--- a/include/aws/io/private/event_loop_impl.h
+++ b/include/aws/io/private/event_loop_impl.h
@@ -321,6 +321,14 @@ int aws_event_loop_unsubscribe_from_io_events(struct aws_event_loop *event_loop,
 AWS_IO_API
 void aws_event_loop_free_io_event_resources(struct aws_event_loop *event_loop, struct aws_io_handle *handle);
 
+/**
+ * Retrieves the aws_event_loop_group that is the parent of the aws_event_loop. This is only supported when using a
+ * dispatch queue event loop as they are async and their sockets need to retain a refcount on the elg to keep it alive
+ * and insure it has not been asyncronously destroyed before anything that needs it.
+ */
+AWS_IO_API
+void *get_base_event_loop_group(struct aws_event_loop *event_loop);
+
 AWS_IO_API
 struct aws_event_loop_group *aws_event_loop_group_new_internal(
     struct aws_allocator *allocator,

--- a/include/aws/io/private/event_loop_impl.h
+++ b/include/aws/io/private/event_loop_impl.h
@@ -96,6 +96,15 @@ struct aws_event_loop_options {
      * creation function will automatically use the platform’s default event loop type.
      */
     enum aws_event_loop_type type;
+
+    /**
+     * The parent `aws_event_loop_group` needs to be accessible from its individual `aws_event_loop` children when using
+     * dispatch queue event loops. Apple dispatch queue event loops are async and so we must insure that the event loops
+     * they use are alive during socket shutdown for the entirety of its shutdown process. To this end, we acquire a
+     * refcount to the parent elg when using Apple network sockets and release the refcount to the parent elg when the
+     * socket is shutdown and cleaned up.
+     */
+    struct aws_event_loop_group *parent_elg;
 };
 
 struct aws_event_loop *aws_event_loop_new_with_iocp(

--- a/source/bsd/kqueue_event_loop.c
+++ b/source/bsd/kqueue_event_loop.c
@@ -48,6 +48,15 @@ static int s_subscribe_to_io_events(
     void *user_data);
 static int s_unsubscribe_from_io_events(struct aws_event_loop *event_loop, struct aws_io_handle *handle);
 static void s_free_io_event_resources(void *user_data);
+static void *s_get_base_event_loop_group(struct aws_event_loop *event_loop) {
+    (void)event_loop;
+    AWS_LOGF_ERROR(
+        AWS_LS_IO_EVENT_LOOP,
+        "id=%p: get_base_event_loop_group() is not supported using KQueue Event Loops",
+        (void *)event_loop);
+    aws_raise_error(AWS_ERROR_PLATFORM_NOT_SUPPORTED);
+    return NULL;
+}
 static bool s_is_event_thread(struct aws_event_loop *event_loop);
 
 static void aws_event_loop_thread(void *user_data);
@@ -137,6 +146,7 @@ struct aws_event_loop_vtable s_kqueue_vtable = {
     .subscribe_to_io_events = s_subscribe_to_io_events,
     .unsubscribe_from_io_events = s_unsubscribe_from_io_events,
     .free_io_event_resources = s_free_io_event_resources,
+    .get_base_event_loop_group = s_get_base_event_loop_group,
     .is_on_callers_thread = s_is_event_thread,
 };
 

--- a/source/bsd/kqueue_event_loop.c
+++ b/source/bsd/kqueue_event_loop.c
@@ -32,6 +32,14 @@ static int s_wait_for_stop_completion(struct aws_event_loop *event_loop);
 static void s_schedule_task_now(struct aws_event_loop *event_loop, struct aws_task *task);
 static void s_schedule_task_future(struct aws_event_loop *event_loop, struct aws_task *task, uint64_t run_at_nanos);
 static void s_cancel_task(struct aws_event_loop *event_loop, struct aws_task *task);
+static int s_connect_to_io_completion_port(struct aws_event_loop *event_loop, struct aws_io_handle *handle) {
+    (void)handle;
+    AWS_LOGF_ERROR(
+        AWS_LS_IO_EVENT_LOOP,
+        "id=%p: connect_to_io_completion_port() is not supported using KQueue Event Loops",
+        (void *)event_loop);
+    return aws_raise_error(AWS_ERROR_PLATFORM_NOT_SUPPORTED);
+}
 static int s_subscribe_to_io_events(
     struct aws_event_loop *event_loop,
     struct aws_io_handle *handle,
@@ -124,8 +132,9 @@ struct aws_event_loop_vtable s_kqueue_vtable = {
     .wait_for_stop_completion = s_wait_for_stop_completion,
     .schedule_task_now = s_schedule_task_now,
     .schedule_task_future = s_schedule_task_future,
-    .subscribe_to_io_events = s_subscribe_to_io_events,
     .cancel_task = s_cancel_task,
+    .connect_to_io_completion_port = s_connect_to_io_completion_port,
+    .subscribe_to_io_events = s_subscribe_to_io_events,
     .unsubscribe_from_io_events = s_unsubscribe_from_io_events,
     .free_io_event_resources = s_free_io_event_resources,
     .is_on_callers_thread = s_is_event_thread,

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -153,7 +153,9 @@ static struct scheduled_iteration_entry *s_scheduled_iteration_entry_new(
     return entry;
 }
 
-/* Cleans up a `scheduled_iteration_entry` */
+/*
+ * Cleans up the memory allocated for a `scheduled_iteration_entry`.
+ */
 static void s_scheduled_iteration_entry_destroy(struct scheduled_iteration_entry *entry) {
     aws_mem_release(entry->allocator, entry);
 }

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -311,11 +311,12 @@ struct aws_event_loop *aws_event_loop_new_with_dispatch_queue(
 
     struct dispatch_loop_context *dispatch_loop_context =
         aws_mem_calloc(alloc, 1, sizeof(struct dispatch_loop_context));
-    aws_ref_count_init(&dispatch_loop_context->ref_count, dispatch_loop_context, s_dispatch_loop_context_destroy);
     dispatch_loop_context->allocator = alloc;
+    aws_ref_count_init(&dispatch_loop_context->ref_count, dispatch_loop_context, s_dispatch_loop_context_destroy);
     dispatch_loop->context = dispatch_loop_context;
-    aws_rw_lock_init(&dispatch_loop_context->lock);
     dispatch_loop_context->io_dispatch_loop = dispatch_loop;
+
+    aws_rw_lock_init(&dispatch_loop_context->lock);
 
     aws_mutex_init(&dispatch_loop_context->scheduling_state.services_lock);
     if (aws_priority_queue_init_dynamic(

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -690,6 +690,12 @@ static int s_connect_to_io_completion_port(struct aws_event_loop *event_loop, st
     return AWS_OP_SUCCESS;
 }
 
+/*
+ * Because dispatch queue is async we may need to acquire a refcount of the parent event loop group to prevent
+ * the event loop or dispatch loop from being cleaned out from underneath something that needs it. We expose the
+ * base elg so anything that needs to insure the event loops and dispatch loops don't get prematurely cleaned can
+ * hold a refcount.
+ */
 static void *s_get_base_event_loop_group(struct aws_event_loop *event_loop) {
     struct aws_dispatch_loop *dispatch_loop = event_loop->impl_data;
     return dispatch_loop->base_elg;

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -241,6 +241,7 @@ struct aws_event_loop *aws_event_loop_new_with_dispatch_queue(
     dispatch_loop->allocator = alloc;
     loop->impl_data = dispatch_loop;
     dispatch_loop->base_loop = loop;
+    dispatch_loop->base_elg = options->parent_elg;
 
     char dispatch_queue_id[AWS_IO_APPLE_DISPATCH_QUEUE_ID_LENGTH] = {0};
     s_get_unique_dispatch_queue_id(dispatch_queue_id);

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -85,7 +85,7 @@ struct dispatch_scheduling_state {
      * The lock is used to protect the scheduled_services list cross threads. It must be held when we add or remove
      * scheduled_service_entry entries from the scheduled_services list.
      */
-    struct aws_mutex services_lock;
+    struct aws_mutex schedule_services_lock;
     /**
      * priority queue of <scheduled_service_entry> in sorted order by timestamp. Each scheduled_service_entry represents
      * a block ALREADY SCHEDULED on apple dispatch queue.
@@ -149,20 +149,20 @@ static int s_wunlock_dispatch_loop_context(struct dispatch_loop_context *context
     return aws_rw_lock_wunlock(&context->dispatch_loop_context_lock);
 }
 
-static int s_lock_cross_thread_data(struct dispatch_loop *loop) {
+static int s_lock_synced_data(struct dispatch_loop *loop) {
     return aws_mutex_lock(&loop->synced_data.synced_data_lock);
 }
 
-static int s_unlock_cross_thread_data(struct dispatch_loop *loop) {
+static int s_unlock_synced_data(struct dispatch_loop *loop) {
     return aws_mutex_unlock(&loop->synced_data.synced_data_lock);
 }
 
 static int s_lock_service_entries(struct dispatch_loop_context *context) {
-    return aws_mutex_lock(&context->scheduling_state.services_lock);
+    return aws_mutex_lock(&context->scheduling_state.schedule_services_lock);
 }
 
 static int s_unlock_service_entries(struct dispatch_loop_context *context) {
-    return aws_mutex_unlock(&context->scheduling_state.services_lock);
+    return aws_mutex_unlock(&context->scheduling_state.schedule_services_lock);
 }
 
 // Not sure why use 7 as the default queue size. Just follow what we used in task_scheduler.c
@@ -211,7 +211,7 @@ static bool s_should_schedule_iteration(
 static void s_dispatch_loop_context_destroy(void *context) {
     struct dispatch_loop_context *dispatch_loop_context = context;
     aws_priority_queue_clean_up(&dispatch_loop_context->scheduling_state.scheduled_services);
-    aws_mutex_clean_up(&dispatch_loop_context->scheduling_state.services_lock);
+    aws_mutex_clean_up(&dispatch_loop_context->scheduling_state.schedule_services_lock);
     aws_rw_lock_clean_up(&dispatch_loop_context->dispatch_loop_context_lock);
     aws_mem_release(dispatch_loop_context->allocator, dispatch_loop_context);
 }
@@ -295,12 +295,23 @@ struct aws_event_loop *aws_event_loop_new_with_dispatch_queue(
      */
     dispatch_loop->dispatch_queue = dispatch_queue_create(dispatch_queue_id, DISPATCH_QUEUE_SERIAL);
 
+    /*
+     * Suspend will increase the dispatch reference count.
+     * A suspended dispatch queue must have dispatch_release() called on it for Apple to release the dispatch queue.
+     * We suspend the newly created Apple dispatch queue here to conform with other event loop types. A new event loop
+     * should start in a non-running state until run() is called.
+     */
+    dispatch_suspend(dispatch_loop->dispatch_queue);
+
     AWS_LOGF_INFO(
         AWS_LS_IO_EVENT_LOOP, "id=%p: Apple dispatch queue created with id: %s", (void *)loop, dispatch_queue_id);
 
     aws_mutex_init(&dispatch_loop->synced_data.synced_data_lock);
+
+    /* The dispatch queue is both suspended and has no active blocks on it at this point*/
+    dispatch_loop->synced_data.stopped = true;
+    dispatch_loop->synced_data.suspended = true;
     dispatch_loop->synced_data.is_executing = false;
-    dispatch_loop->synced_data.stopped = false;
 
     if (aws_task_scheduler_init(&dispatch_loop->scheduler, alloc)) {
         AWS_LOGF_ERROR(AWS_LS_IO_EVENT_LOOP, "id=%p: Initialization of task scheduler failed", (void *)loop);
@@ -318,7 +329,7 @@ struct aws_event_loop *aws_event_loop_new_with_dispatch_queue(
 
     aws_rw_lock_init(&dispatch_loop_context->dispatch_loop_context_lock);
 
-    aws_mutex_init(&dispatch_loop_context->scheduling_state.services_lock);
+    aws_mutex_init(&dispatch_loop_context->scheduling_state.schedule_services_lock);
     if (aws_priority_queue_init_dynamic(
             &dispatch_loop_context->scheduling_state.scheduled_services,
             alloc,
@@ -353,8 +364,8 @@ static void s_dispatch_queue_destroy_task(void *context) {
     struct dispatch_loop *dispatch_loop = context;
     s_rlock_dispatch_loop_context(dispatch_loop->context);
 
-    s_lock_cross_thread_data(dispatch_loop);
-    dispatch_loop->synced_data.suspended = true;
+    s_lock_synced_data(dispatch_loop);
+    dispatch_loop->synced_data.is_destroying = true;
     dispatch_loop->synced_data.current_thread_id = aws_thread_current_thread_id();
     dispatch_loop->synced_data.is_executing = true;
 
@@ -362,7 +373,7 @@ static void s_dispatch_queue_destroy_task(void *context) {
     struct aws_linked_list local_cross_thread_tasks;
     aws_linked_list_init(&local_cross_thread_tasks);
     aws_linked_list_swap_contents(&dispatch_loop->synced_data.cross_thread_tasks, &local_cross_thread_tasks);
-    s_unlock_cross_thread_data(dispatch_loop);
+    s_unlock_synced_data(dispatch_loop);
 
     aws_task_scheduler_clean_up(&dispatch_loop->scheduler); /* Tasks in scheduler get cancelled*/
     while (!aws_linked_list_empty(&local_cross_thread_tasks)) {
@@ -371,9 +382,9 @@ static void s_dispatch_queue_destroy_task(void *context) {
         task->fn(task, task->arg, AWS_TASK_STATUS_CANCELED);
     }
 
-    s_lock_cross_thread_data(dispatch_loop);
+    s_lock_synced_data(dispatch_loop);
     dispatch_loop->synced_data.is_executing = false;
-    s_unlock_cross_thread_data(dispatch_loop);
+    s_unlock_synced_data(dispatch_loop);
 
     s_runlock_dispatch_loop_context(dispatch_loop->context);
     s_dispatch_event_loop_destroy(dispatch_loop->base_loop);
@@ -386,7 +397,14 @@ static void s_destroy(struct aws_event_loop *event_loop) {
     /* make sure the loop is running so we can schedule a last task. */
     s_run(event_loop);
 
-    /* cancel outstanding tasks */
+    /*
+     * Schedules `s_dispatch_queue_destroy_task()` to run on the Apple dispatch queue of the event loop.
+     *
+     * Any block that is currently running or already scheduled on the dispatch queue will be completed before
+     * `s_dispatch_queue_destroy_task()`.
+     *
+     * `s_dispatch_queue_destroy_task()` will cancel outstanding tasks and then run `s_dispatch_event_loop_destroy()`
+     */
     dispatch_async_and_wait_f(dispatch_loop->dispatch_queue, dispatch_loop, s_dispatch_queue_destroy_task);
 
     AWS_LOGF_TRACE(AWS_LS_IO_EVENT_LOOP, "id=%p: Releasing Dispatch Queue.", (void *)event_loop);
@@ -403,19 +421,18 @@ static void s_try_schedule_new_iteration(struct dispatch_loop_context *loop, uin
 static int s_run(struct aws_event_loop *event_loop) {
     struct dispatch_loop *dispatch_loop = event_loop->impl_data;
 
-    s_lock_cross_thread_data(dispatch_loop);
-    if (dispatch_loop->synced_data.suspended || dispatch_loop->synced_data.stopped) {
+    s_lock_synced_data(dispatch_loop);
+    if (dispatch_loop->synced_data.suspended) {
         AWS_LOGF_INFO(AWS_LS_IO_EVENT_LOOP, "id=%p: Starting event-loop thread.", (void *)event_loop);
         dispatch_resume(dispatch_loop->dispatch_queue);
         dispatch_loop->synced_data.suspended = false;
-        dispatch_loop->synced_data.stopped = false;
         s_rlock_dispatch_loop_context(dispatch_loop->context);
         s_lock_service_entries(dispatch_loop->context);
         s_try_schedule_new_iteration(dispatch_loop->context, 0);
         s_unlock_service_entries(dispatch_loop->context);
         s_runlock_dispatch_loop_context(dispatch_loop->context);
     }
-    s_unlock_cross_thread_data(dispatch_loop);
+    s_unlock_synced_data(dispatch_loop);
 
     return AWS_OP_SUCCESS;
 }
@@ -423,7 +440,7 @@ static int s_run(struct aws_event_loop *event_loop) {
 static int s_stop(struct aws_event_loop *event_loop) {
     struct dispatch_loop *dispatch_loop = event_loop->impl_data;
 
-    s_lock_cross_thread_data(dispatch_loop);
+    s_lock_synced_data(dispatch_loop);
     if (!dispatch_loop->synced_data.suspended) {
         dispatch_loop->synced_data.suspended = true;
         AWS_LOGF_INFO(AWS_LS_IO_EVENT_LOOP, "id=%p: Stopping event-loop thread.", (void *)event_loop);
@@ -431,7 +448,7 @@ static int s_stop(struct aws_event_loop *event_loop) {
          * releasing the dispatch queue. */
         dispatch_suspend(dispatch_loop->dispatch_queue);
     }
-    s_unlock_cross_thread_data(dispatch_loop);
+    s_unlock_synced_data(dispatch_loop);
 
     return AWS_OP_SUCCESS;
 }
@@ -445,7 +462,7 @@ static void s_end_iteration(struct scheduled_service_entry *entry) {
     struct dispatch_loop_context *dispatch_queue_context = entry->dispatch_queue_context;
     struct dispatch_loop *dispatch_loop = dispatch_queue_context->io_dispatch_loop;
 
-    s_lock_cross_thread_data(dispatch_loop);
+    s_lock_synced_data(dispatch_loop);
     dispatch_loop->synced_data.is_executing = false;
 
     // Remove the node before do scheduling so we didnt consider the entry itself
@@ -470,7 +487,7 @@ static void s_end_iteration(struct scheduled_service_entry *entry) {
         s_unlock_service_entries(dispatch_queue_context);
     }
 
-    s_unlock_cross_thread_data(dispatch_loop);
+    s_unlock_synced_data(dispatch_loop);
 }
 
 // Iteration function that scheduled and executed by the Dispatch Queue API
@@ -489,11 +506,12 @@ static void s_run_iteration(void *service_entry) {
     // swap the cross-thread tasks into task-local data
     struct aws_linked_list local_cross_thread_tasks;
     aws_linked_list_init(&local_cross_thread_tasks);
-    s_lock_cross_thread_data(dispatch_loop);
+    s_lock_synced_data(dispatch_loop);
+    dispatch_loop->synced_data.stopped = false;
     dispatch_loop->synced_data.current_thread_id = aws_thread_current_thread_id();
     dispatch_loop->synced_data.is_executing = true;
     aws_linked_list_swap_contents(&dispatch_loop->synced_data.cross_thread_tasks, &local_cross_thread_tasks);
-    s_unlock_cross_thread_data(dispatch_loop);
+    s_unlock_synced_data(dispatch_loop);
 
     aws_event_loop_register_tick_start(dispatch_loop->base_loop);
 
@@ -540,13 +558,13 @@ iteration_done:
  * If timestamp==0, the function will always schedule a new iteration as long as the event loop is not suspended.
  *
  * The function should be wrapped with the following locks:
- *      dispatch_loop->context->lock: To retain the dispatch loop
+ *      dispatch_loop->context->dispatch_loop_context_lock: To retain the dispatch loop
  *      dispatch_loop->synced_data.synced_data_lock : To verify if the dispatch loop is suspended
- *      dispatch_loop_context->scheduling_state->services_lock: To modify the scheduled_services list
+ *      dispatch_loop_context->scheduling_state->schedule_services_lock: To modify the scheduled_services list
  */
 static void s_try_schedule_new_iteration(struct dispatch_loop_context *dispatch_loop_context, uint64_t timestamp) {
     struct dispatch_loop *dispatch_loop = dispatch_loop_context->io_dispatch_loop;
-    if (!dispatch_loop || dispatch_loop->synced_data.suspended) {
+    if (!dispatch_loop || dispatch_loop->synced_data.suspended || dispatch_loop->synced_data.is_destroying) {
         return;
     }
     if (!s_should_schedule_iteration(&dispatch_loop_context->scheduling_state.scheduled_services, timestamp)) {
@@ -584,7 +602,7 @@ static void s_schedule_task_common(struct aws_event_loop *event_loop, struct aws
     if (dispatch_loop->context->io_dispatch_loop == NULL) {
         goto schedule_task_common_cleanup;
     }
-    s_lock_cross_thread_data(dispatch_loop);
+    s_lock_synced_data(dispatch_loop);
     task->timestamp = run_at_nanos;
 
     bool was_empty = aws_linked_list_empty(&dispatch_loop->synced_data.cross_thread_tasks);
@@ -618,7 +636,7 @@ static void s_schedule_task_common(struct aws_event_loop *event_loop, struct aws
         s_unlock_service_entries(dispatch_loop->context);
     }
 
-    s_unlock_cross_thread_data(dispatch_loop);
+    s_unlock_synced_data(dispatch_loop);
 schedule_task_common_cleanup:
     s_runlock_dispatch_loop_context(dispatch_loop->context);
 }
@@ -662,15 +680,16 @@ static int s_unsubscribe_from_io_events(struct aws_event_loop *event_loop, struc
     return AWS_OP_SUCCESS;
 }
 
-// The dispatch queue will assign the task block to threads, we will threat all
-// tasks as cross thread tasks. Ignore the caller thread verification for apple
-// dispatch queue.
+/*
+ * We use aws_thread_id_equal with syched_data.current_thread_id and synced_data.is_executing to determine
+ * if operation is being executed on the same dispatch queue thread.
+ */
 static bool s_is_on_callers_thread(struct aws_event_loop *event_loop) {
     struct dispatch_loop *dispatch_queue = event_loop->impl_data;
-    s_lock_cross_thread_data(dispatch_queue);
+    s_lock_synced_data(dispatch_queue);
     bool result =
         dispatch_queue->synced_data.is_executing &&
         aws_thread_thread_id_equal(dispatch_queue->synced_data.current_thread_id, aws_thread_current_thread_id());
-    s_unlock_cross_thread_data(dispatch_queue);
+    s_unlock_synced_data(dispatch_queue);
     return result;
 }

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -668,6 +668,11 @@ static void s_cancel_task(struct aws_event_loop *event_loop, struct aws_task *ta
     aws_task_scheduler_cancel_task(&dispatch_loop->scheduler, task);
 }
 
+/*
+ * We use this to obtain a direct pointer to the underlying dispatch queue. This is required to perform various
+ * operations in the socket, socket handler, and probably anything else that requires use of Apple API needing a
+ * dispatch queue.
+ */
 static int s_connect_to_io_completion_port(struct aws_event_loop *event_loop, struct aws_io_handle *handle) {
     AWS_PRECONDITION(handle->set_queue);
     AWS_LOGF_TRACE(

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -309,7 +309,6 @@ static void s_dispatch_queue_destroy_task(void *context) {
     AWS_LOGF_TRACE(AWS_LS_IO_EVENT_LOOP, "id=%p: Releasing Dispatch Queue.", (void *)dispatch_loop->base_loop);
 
     s_lock_synced_data(dispatch_loop);
-    dispatch_loop->synced_data.is_destroying = true;
     dispatch_loop->synced_data.current_thread_id = aws_thread_current_thread_id();
     dispatch_loop->synced_data.is_executing = true;
 
@@ -557,7 +556,7 @@ static void s_run_iteration(void *service_entry) {
  * aws_dispatch_loop->sycned_data
  */
 static void s_try_schedule_new_iteration(struct aws_dispatch_loop *dispatch_loop, uint64_t timestamp) {
-    if (dispatch_loop->synced_data.suspended || dispatch_loop->synced_data.is_destroying) {
+    if (dispatch_loop->synced_data.suspended || dispatch_loop->synced_data.is_executing) {
         return;
     }
 

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -153,7 +153,7 @@ static bool s_should_schedule_iteration(
     return entry->timestamp > proposed_iteration_time;
 }
 
-// Manually called to destroy an aws_event_loop
+/* Manually called to destroy an aws_event_loop */
 static void s_dispatch_event_loop_destroy(struct aws_event_loop *event_loop) {
     struct aws_dispatch_loop *dispatch_loop = event_loop->impl_data;
 
@@ -301,6 +301,7 @@ static void s_dispatch_queue_destroy_task(void *context) {
     }
     s_unlock_synced_data(dispatch_loop);
 
+    AWS_LOGF_TRACE(AWS_LS_IO_EVENT_LOOP, "id=%p: Cancelling scheduled tasks.", (void *)dispatch_loop->base_loop);
     /* Cancel all tasks currently scheduled in the task scheduler. */
     aws_task_scheduler_clean_up(&dispatch_loop->scheduler);
 
@@ -460,8 +461,6 @@ static void s_run_iteration(void *service_entry) {
     aws_linked_list_swap_contents(&dispatch_loop->synced_data.cross_thread_tasks, &local_cross_thread_tasks);
     s_unlock_synced_data(dispatch_loop);
 
-    aws_event_loop_register_tick_start(dispatch_loop->base_loop);
-
     // run the full iteration here: local cross-thread tasks
     while (!aws_linked_list_empty(&local_cross_thread_tasks)) {
         struct aws_linked_list_node *node = aws_linked_list_pop_front(&local_cross_thread_tasks);
@@ -475,9 +474,11 @@ static void s_run_iteration(void *service_entry) {
         }
     }
 
+    aws_event_loop_register_tick_start(dispatch_loop->base_loop);
     // run all scheduled tasks
     uint64_t now_ns = 0;
     aws_event_loop_current_clock_time(dispatch_loop->base_loop, &now_ns);
+    AWS_LOGF_TRACE(AWS_LS_IO_EVENT_LOOP, "id=%p: running scheduled tasks.", (void *)dispatch_loop->base_loop);
     aws_task_scheduler_run_all(&dispatch_loop->scheduler, now_ns);
     aws_event_loop_register_tick_end(dispatch_loop->base_loop);
 

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -59,7 +59,7 @@ static void s_free_io_event_resources(void *user_data) {
     /* No io event resources to free */
     (void)user_data;
 }
-
+static void *s_get_base_event_loop_group(struct aws_event_loop *event_loop);
 static bool s_is_on_callers_thread(struct aws_event_loop *event_loop);
 
 static struct aws_event_loop_vtable s_vtable = {
@@ -74,6 +74,7 @@ static struct aws_event_loop_vtable s_vtable = {
     .subscribe_to_io_events = s_subscribe_to_io_events,
     .unsubscribe_from_io_events = s_unsubscribe_from_io_events,
     .free_io_event_resources = s_free_io_event_resources,
+    .get_base_event_loop_group = s_get_base_event_loop_group,
     .is_on_callers_thread = s_is_on_callers_thread,
 };
 
@@ -687,6 +688,11 @@ static int s_connect_to_io_completion_port(struct aws_event_loop *event_loop, st
     handle->set_queue(handle, dispatch_loop->dispatch_queue);
 
     return AWS_OP_SUCCESS;
+}
+
+static void *s_get_base_event_loop_group(struct aws_event_loop *event_loop) {
+    struct aws_dispatch_loop *dispatch_loop = event_loop->impl_data;
+    return dispatch_loop->base_elg;
 }
 
 /*

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -556,7 +556,7 @@ static void s_run_iteration(void *service_entry) {
  * aws_dispatch_loop->sycned_data
  */
 static void s_try_schedule_new_iteration(struct aws_dispatch_loop *dispatch_loop, uint64_t timestamp) {
-    if (dispatch_loop->synced_data.suspended) {
+    if (dispatch_loop->synced_data.suspended || dispatch_loop->synced_data.is_destroying) {
         return;
     }
 

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -30,6 +30,12 @@ static void s_schedule_task_now(struct aws_event_loop *event_loop, struct aws_ta
 static void s_schedule_task_future(struct aws_event_loop *event_loop, struct aws_task *task, uint64_t run_at_nanos);
 static void s_cancel_task(struct aws_event_loop *event_loop, struct aws_task *task);
 static int s_connect_to_dispatch_queue(struct aws_event_loop *event_loop, struct aws_io_handle *handle);
+static int s_subscribe_to_io_events(
+    struct aws_event_loop *event_loop,
+    struct aws_io_handle *handle,
+    int events,
+    aws_event_loop_on_event_fn *on_event,
+    void *user_data);
 static int s_unsubscribe_from_io_events(struct aws_event_loop *event_loop, struct aws_io_handle *handle);
 static void s_free_io_event_resources(void *user_data) {
     (void)user_data;
@@ -45,6 +51,7 @@ static struct aws_event_loop_vtable s_vtable = {
     .schedule_task_future = s_schedule_task_future,
     .cancel_task = s_cancel_task,
     .connect_to_io_completion_port = s_connect_to_dispatch_queue,
+    .subscribe_to_io_events = s_subscribe_to_io_events,
     .unsubscribe_from_io_events = s_unsubscribe_from_io_events,
     .free_io_event_resources = s_free_io_event_resources,
     .is_on_callers_thread = s_is_on_callers_thread,
@@ -639,6 +646,19 @@ static void s_cancel_task(struct aws_event_loop *event_loop, struct aws_task *ta
 
     /* Then we attempt to cancel the task. */
     aws_task_scheduler_cancel_task(&dispatch_loop->scheduler, task);
+}
+
+static int s_subscribe_to_io_events(
+    struct aws_event_loop *event_loop,
+    struct aws_io_handle *handle,
+    int events,
+    aws_event_loop_on_event_fn *on_event,
+    void *user_data) {
+    (void)event_loop;
+    (void)handle;
+    (void)events;
+    (void)on_event;
+    (void)user_data;
 }
 
 static int s_connect_to_dispatch_queue(struct aws_event_loop *event_loop, struct aws_io_handle *handle) {

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -558,6 +558,8 @@ static void s_try_schedule_new_iteration(struct aws_dispatch_loop *dispatch_loop
          * immediately using `dispatch_async_f()` which schedules a block to run on the dispatch queue in a FIFO order.
          */
         dispatch_async_f(dispatch_loop->dispatch_queue, entry, s_run_iteration);
+        AWS_LOGF_TRACE(
+            AWS_LS_IO_EVENT_LOOP, "id=%p: Scheduling run iteration on event loop.", (void *)dispatch_loop->base_loop);
     } else {
         /*
          * If the timestamp is set to execute sometime in the future, we clamp the time to 1 second max, convert the
@@ -570,6 +572,11 @@ static void s_try_schedule_new_iteration(struct aws_dispatch_loop *dispatch_loop
         delta = aws_min_u64(delta, AWS_TIMESTAMP_NANOS);
         dispatch_time_t when = dispatch_time(DISPATCH_TIME_NOW, delta);
         dispatch_after_f(when, dispatch_loop->dispatch_queue, entry, s_run_iteration);
+        AWS_LOGF_TRACE(
+            AWS_LS_IO_EVENT_LOOP,
+            "id=%p: Scheduling future run iteration on event loop with next occurring in %llu ns.",
+            (void *)dispatch_loop->base_loop,
+            delta);
     }
 }
 

--- a/source/darwin/dispatch_queue_event_loop_private.h
+++ b/source/darwin/dispatch_queue_event_loop_private.h
@@ -44,11 +44,6 @@ struct aws_dispatch_loop {
          */
         bool suspended;
 
-        /*
-         * Will be true when dispatch loop has entered state where it is being destroyed.
-         */
-        bool is_destroying;
-
         struct aws_linked_list cross_thread_tasks;
 
         /*

--- a/source/darwin/dispatch_queue_event_loop_private.h
+++ b/source/darwin/dispatch_queue_event_loop_private.h
@@ -42,13 +42,18 @@ struct dispatch_loop {
         bool is_executing;
         aws_thread_id_t current_thread_id;
 
-        // once suspended is set to true, event loop will no longer schedule any future services entry (the running
-        // iteration will still be finished.).
+        /*
+         * Set to true when `stop()` is called on event loop. Once suspended is set to true, underlying dispatch queue
+         * is set to suspend and event loop will no longer schedule any future service entries. If an iteration block is
+         * running it will continue till it finishes. `run()` must be called on a suspended dispatch queue event loop to
+         * schedule an iteration block.
+         */
         bool suspended;
 
         /*
-         * Will be true when the underlying dispatch_queue has been suspended and is no longer processing any further
-         * blocks. `run()` must be called to resume the event loop and for stopped to be false.
+         * Will be true when the underlying dispatch_queue is both suspended and has completed running any in progress
+         * iteration block. `run()` must be called to resume the event loop and its underlying dispatch queue to
+         * schedule an iteration block.
          */
         bool stopped;
 

--- a/source/darwin/dispatch_queue_event_loop_private.h
+++ b/source/darwin/dispatch_queue_event_loop_private.h
@@ -30,10 +30,10 @@ struct dispatch_loop {
     /* Synced data handle cross thread tasks and events, and event loop operations*/
     struct {
         /**
-         * The lock is used to protect synced_data across the threads. It should be acquired whenever data in the
-         * synched_data struct is accessed or modified.
+         * This lock is used to protect synced_data across the threads. It should be acquired whenever data in the
+         * synced_data struct is accessed or modified.
          */
-        struct aws_mutex lock;
+        struct aws_mutex synced_data_lock;
         /*
          * `is_executing` flag and `current_thread_id` together are used
          * to identify the executing thread id for dispatch queue. See `static bool s_is_on_callers_thread(struct

--- a/source/darwin/dispatch_queue_event_loop_private.h
+++ b/source/darwin/dispatch_queue_event_loop_private.h
@@ -44,12 +44,6 @@ struct aws_dispatch_loop {
         bool suspended;
 
         /*
-         * Will be true when the underlying dispatch_queue has completed running all enqueued blocks and no futher work
-         * is enqueued.
-         */
-        bool stopped;
-
-        /*
          * Will be true when dispatch loop has entered state where it is being destroyed.
          */
         bool is_destroying;

--- a/source/darwin/dispatch_queue_event_loop_private.h
+++ b/source/darwin/dispatch_queue_event_loop_private.h
@@ -16,6 +16,7 @@ struct aws_dispatch_loop {
     dispatch_queue_t dispatch_queue;
     struct aws_task_scheduler scheduler;
     struct aws_event_loop *base_loop;
+    struct aws_event_loop_group *base_elg;
 
     /* Synced data handle cross thread tasks and events, and event loop operations*/
     struct {

--- a/source/darwin/dispatch_queue_event_loop_private.h
+++ b/source/darwin/dispatch_queue_event_loop_private.h
@@ -30,8 +30,8 @@ struct dispatch_loop {
     /* Synced data handle cross thread tasks and events, and event loop operations*/
     struct {
         /**
-         * The lock is used to protect synced_data across the threads. It should be acquired whenever we touched the
-         * data in this synced_data struct.
+         * The lock is used to protect synced_data across the threads. It should be acquired whenever data in the
+         * synched_data struct is accessed or modified.
          */
         struct aws_mutex lock;
         /*
@@ -45,6 +45,12 @@ struct dispatch_loop {
         // once suspended is set to true, event loop will no longer schedule any future services entry (the running
         // iteration will still be finished.).
         bool suspended;
+
+        /*
+         * Will be true when the underlying dispatch_queue has been suspended and is no longer processing any further
+         * blocks. `run()` must be called to resume the event loop and for stopped to be false.
+         */
+        bool stopped;
 
         struct aws_linked_list cross_thread_tasks;
     } synced_data;

--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -288,6 +288,7 @@ struct aws_event_loop_group *aws_event_loop_group_new_internal(
                 .clock = clock,
                 .thread_options = &thread_options,
                 .type = options->type,
+                .parent_elg = el_group,
             };
 
             if (pin_threads) {

--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -18,6 +18,9 @@
 #ifdef AWS_USE_APPLE_NETWORK_FRAMEWORK
 static enum aws_event_loop_type s_default_event_loop_type_override = AWS_EVENT_LOOP_DISPATCH_QUEUE;
 #else
+// DEBUG WIP CHANGE THIS BACK TO AWS_EVENT_LOOP_PLATFORM_DEFAULT
+// Currently forcing it to be AWS_EVENT_LOOP_DISPATCH_QUEUE for local testing of dispatch queue.
+// static enum aws_event_loop_type s_default_event_loop_type_override = AWS_EVENT_LOOP_DISPATCH_QUEUE;
 static enum aws_event_loop_type s_default_event_loop_type_override = AWS_EVENT_LOOP_PLATFORM_DEFAULT;
 #endif
 

--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -18,7 +18,8 @@
 #ifdef AWS_USE_APPLE_NETWORK_FRAMEWORK
 static enum aws_event_loop_type s_default_event_loop_type_override = AWS_EVENT_LOOP_DISPATCH_QUEUE;
 #else
-static enum aws_event_loop_type s_default_event_loop_type_override = AWS_EVENT_LOOP_PLATFORM_DEFAULT;
+// DEBUG WIP CHANGE THIS BACK TO AWS_EVENT_LOOP_PLATFORM_DEFAULT
+static enum aws_event_loop_type s_default_event_loop_type_override = AWS_EVENT_LOOP_DISPATCH_QUEUE;
 #endif
 
 struct aws_event_loop *aws_event_loop_new_default(struct aws_allocator *alloc, aws_io_clock_fn *clock) {

--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -623,6 +623,11 @@ void aws_event_loop_free_io_event_resources(struct aws_event_loop *event_loop, s
     event_loop->vtable->free_io_event_resources(handle->additional_data);
 }
 
+void *get_base_event_loop_group(struct aws_event_loop *event_loop) {
+    AWS_ASSERT(event_loop && event_loop->vtable->get_base_event_loop_group);
+    return event_loop->vtable->get_base_event_loop_group(event_loop);
+}
+
 bool aws_event_loop_thread_is_callers_thread(struct aws_event_loop *event_loop) {
     AWS_ASSERT(event_loop->vtable && event_loop->vtable->is_on_callers_thread);
     return event_loop->vtable->is_on_callers_thread(event_loop);

--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -15,12 +15,11 @@
 #include <aws/common/system_info.h>
 #include <aws/common/thread.h>
 
-#ifdef AWS_USE_APPLE_NETWORK_FRAMEWORK
+#if defined(AWS_USE_APPLE_NETWORK_FRAMEWORK)
+static enum aws_event_loop_type s_default_event_loop_type_override = AWS_EVENT_LOOP_DISPATCH_QUEUE;
+#elif defined(AWS_USE_APPLE_DISPATCH_QUEUE)
 static enum aws_event_loop_type s_default_event_loop_type_override = AWS_EVENT_LOOP_DISPATCH_QUEUE;
 #else
-// DEBUG WIP CHANGE THIS BACK TO AWS_EVENT_LOOP_PLATFORM_DEFAULT
-// Currently forcing it to be AWS_EVENT_LOOP_DISPATCH_QUEUE for local testing of dispatch queue.
-// static enum aws_event_loop_type s_default_event_loop_type_override = AWS_EVENT_LOOP_DISPATCH_QUEUE;
 static enum aws_event_loop_type s_default_event_loop_type_override = AWS_EVENT_LOOP_PLATFORM_DEFAULT;
 #endif
 

--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -573,8 +573,8 @@ int aws_event_loop_wait_for_stop_completion(struct aws_event_loop *event_loop) {
 }
 
 void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct aws_task *task) {
-    AWS_ASSERT(event_loop->vtable && event_loop->vtable->schedule_task_now);
     AWS_ASSERT(task);
+    AWS_ASSERT(event_loop->vtable && event_loop->vtable->schedule_task_now);
     event_loop->vtable->schedule_task_now(event_loop, task);
 }
 
@@ -582,24 +582,22 @@ void aws_event_loop_schedule_task_future(
     struct aws_event_loop *event_loop,
     struct aws_task *task,
     uint64_t run_at_nanos) {
-
-    AWS_ASSERT(event_loop->vtable && event_loop->vtable->schedule_task_future);
     AWS_ASSERT(task);
+    AWS_ASSERT(event_loop->vtable && event_loop->vtable->schedule_task_future);
     event_loop->vtable->schedule_task_future(event_loop, task, run_at_nanos);
 }
 
 void aws_event_loop_cancel_task(struct aws_event_loop *event_loop, struct aws_task *task) {
+    AWS_ASSERT(task);
     AWS_ASSERT(event_loop->vtable && event_loop->vtable->cancel_task);
     AWS_ASSERT(aws_event_loop_thread_is_callers_thread(event_loop));
-    AWS_ASSERT(task);
     event_loop->vtable->cancel_task(event_loop, task);
 }
 
 int aws_event_loop_connect_handle_to_io_completion_port(
     struct aws_event_loop *event_loop,
     struct aws_io_handle *handle) {
-
-    AWS_ASSERT(event_loop->vtable && event_loop->vtable->cancel_task);
+    AWS_ASSERT(event_loop->vtable && event_loop->vtable->connect_to_io_completion_port);
     return event_loop->vtable->connect_to_io_completion_port(event_loop, handle);
 }
 
@@ -609,8 +607,7 @@ int aws_event_loop_subscribe_to_io_events(
     int events,
     aws_event_loop_on_event_fn *on_event,
     void *user_data) {
-
-    AWS_ASSERT(event_loop && event_loop->vtable->free_io_event_resources);
+    AWS_ASSERT(event_loop->vtable && event_loop->vtable->subscribe_to_io_events);
     return event_loop->vtable->subscribe_to_io_events(event_loop, handle, events, on_event, user_data);
 }
 

--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -18,8 +18,7 @@
 #ifdef AWS_USE_APPLE_NETWORK_FRAMEWORK
 static enum aws_event_loop_type s_default_event_loop_type_override = AWS_EVENT_LOOP_DISPATCH_QUEUE;
 #else
-// DEBUG WIP CHANGE THIS BACK TO AWS_EVENT_LOOP_PLATFORM_DEFAULT
-static enum aws_event_loop_type s_default_event_loop_type_override = AWS_EVENT_LOOP_DISPATCH_QUEUE;
+static enum aws_event_loop_type s_default_event_loop_type_override = AWS_EVENT_LOOP_PLATFORM_DEFAULT;
 #endif
 
 struct aws_event_loop *aws_event_loop_new_default(struct aws_allocator *alloc, aws_io_clock_fn *clock) {

--- a/source/linux/epoll_event_loop.c
+++ b/source/linux/epoll_event_loop.c
@@ -51,6 +51,14 @@ static int s_wait_for_stop_completion(struct aws_event_loop *event_loop);
 static void s_schedule_task_now(struct aws_event_loop *event_loop, struct aws_task *task);
 static void s_schedule_task_future(struct aws_event_loop *event_loop, struct aws_task *task, uint64_t run_at_nanos);
 static void s_cancel_task(struct aws_event_loop *event_loop, struct aws_task *task);
+static int s_connect_to_io_completion_port(struct aws_event_loop *event_loop, struct aws_io_handle *handle) {
+    (void)handle;
+    AWS_LOGF_ERROR(
+        AWS_LS_IO_EVENT_LOOP,
+        "id=%p: connect_to_io_completion_port() is not supported using Epoll Event Loops",
+        (void *)event_loop);
+    return aws_raise_error(AWS_ERROR_PLATFORM_NOT_SUPPORTED);
+}
 static int s_subscribe_to_io_events(
     struct aws_event_loop *event_loop,
     struct aws_io_handle *handle,
@@ -71,6 +79,7 @@ static struct aws_event_loop_vtable s_vtable = {
     .schedule_task_now = s_schedule_task_now,
     .schedule_task_future = s_schedule_task_future,
     .cancel_task = s_cancel_task,
+    .connect_to_io_completion_port = s_connect_to_io_completion_port,
     .subscribe_to_io_events = s_subscribe_to_io_events,
     .unsubscribe_from_io_events = s_unsubscribe_from_io_events,
     .free_io_event_resources = s_free_io_event_resources,

--- a/source/linux/epoll_event_loop.c
+++ b/source/linux/epoll_event_loop.c
@@ -67,6 +67,15 @@ static int s_subscribe_to_io_events(
     void *user_data);
 static int s_unsubscribe_from_io_events(struct aws_event_loop *event_loop, struct aws_io_handle *handle);
 static void s_free_io_event_resources(void *user_data);
+static void *s_get_base_event_loop_group(struct aws_event_loop *event_loop) {
+    (void)event_loop;
+    AWS_LOGF_ERROR(
+        AWS_LS_IO_EVENT_LOOP,
+        "id=%p: get_base_event_loop_group() is not supported using Epoll Event Loops",
+        (void *)event_loop);
+    aws_raise_error(AWS_ERROR_PLATFORM_NOT_SUPPORTED);
+    return NULL;
+}
 static bool s_is_on_callers_thread(struct aws_event_loop *event_loop);
 
 static void aws_event_loop_thread(void *args);
@@ -83,6 +92,7 @@ static struct aws_event_loop_vtable s_vtable = {
     .subscribe_to_io_events = s_subscribe_to_io_events,
     .unsubscribe_from_io_events = s_unsubscribe_from_io_events,
     .free_io_event_resources = s_free_io_event_resources,
+    .get_base_event_loop_group = s_get_base_event_loop_group,
     .is_on_callers_thread = s_is_on_callers_thread,
 };
 

--- a/source/socket.c
+++ b/source/socket.c
@@ -39,7 +39,7 @@ int aws_socket_start_accept(
     struct aws_event_loop *accept_loop,
     aws_socket_on_accept_result_fn *on_accept_result,
     void *user_data) {
-    AWS_PRECONDITION(socket->vtable && socket->vtable->socket_listen_fn);
+    AWS_PRECONDITION(socket->vtable && socket->vtable->socket_start_accept_fn);
     return socket->vtable->socket_start_accept_fn(socket, accept_loop, on_accept_result, user_data);
 }
 

--- a/source/windows/iocp/iocp_event_loop.c
+++ b/source/windows/iocp/iocp_event_loop.c
@@ -105,6 +105,22 @@ static void s_schedule_task_future(struct aws_event_loop *event_loop, struct aws
 static void s_cancel_task(struct aws_event_loop *event_loop, struct aws_task *task);
 static int s_connect_to_io_completion_port(struct aws_event_loop *event_loop, struct aws_io_handle *handle);
 static bool s_is_event_thread(struct aws_event_loop *event_loop);
+static int s_subscribe_to_io_events(
+    struct aws_event_loop *event_loop,
+    struct aws_io_handle *handle,
+    int events,
+    aws_event_loop_on_event_fn *on_event,
+    void *user_data) {
+    (void)handle;
+    (void)events;
+    (void)on_event;
+    (void)user_data;
+    AWS_LOGF_ERROR(
+        AWS_LS_IO_EVENT_LOOP,
+        "id=%p: subscribe_to_io_events() is not supported using IOCP Event Loops",
+        (void *)event_loop);
+    return aws_raise_error(AWS_ERROR_PLATFORM_NOT_SUPPORTED);
+}
 static int s_unsubscribe_from_io_events(struct aws_event_loop *event_loop, struct aws_io_handle *handle);
 static void s_free_io_event_resources(void *user_data);
 static void aws_event_loop_thread(void *user_data);
@@ -139,9 +155,10 @@ struct aws_event_loop_vtable s_iocp_vtable = {
     .schedule_task_future = s_schedule_task_future,
     .cancel_task = s_cancel_task,
     .connect_to_io_completion_port = s_connect_to_io_completion_port,
-    .is_on_callers_thread = s_is_event_thread,
+    .subscribe_to_io_events = s_subscribe_to_io_events,
     .unsubscribe_from_io_events = s_unsubscribe_from_io_events,
     .free_io_event_resources = s_free_io_event_resources,
+    .is_on_callers_thread = s_is_event_thread,
 };
 
 struct aws_event_loop *aws_event_loop_new_with_iocp(

--- a/source/windows/iocp/iocp_event_loop.c
+++ b/source/windows/iocp/iocp_event_loop.c
@@ -123,6 +123,15 @@ static int s_subscribe_to_io_events(
 }
 static int s_unsubscribe_from_io_events(struct aws_event_loop *event_loop, struct aws_io_handle *handle);
 static void s_free_io_event_resources(void *user_data);
+static void *s_get_base_event_loop_group(struct aws_event_loop *event_loop) {
+    (void)event_loop;
+    AWS_LOGF_ERROR(
+        AWS_LS_IO_EVENT_LOOP,
+        "id=%p: get_base_event_loop_group() is not supported using IOCP Event Loops",
+        (void *)event_loop);
+    aws_raise_error(AWS_ERROR_PLATFORM_NOT_SUPPORTED);
+    return NULL;
+}
 static void aws_event_loop_thread(void *user_data);
 
 void aws_overlapped_init(
@@ -158,6 +167,7 @@ struct aws_event_loop_vtable s_iocp_vtable = {
     .subscribe_to_io_events = s_subscribe_to_io_events,
     .unsubscribe_from_io_events = s_unsubscribe_from_io_events,
     .free_io_event_resources = s_free_io_event_resources,
+    .get_base_event_loop_group = s_get_base_event_loop_group,
     .is_on_callers_thread = s_is_event_thread,
 };
 

--- a/tests/event_loop_test.c
+++ b/tests/event_loop_test.c
@@ -13,10 +13,6 @@
 #include <aws/io/private/event_loop_impl.h>
 #include <aws/testing/aws_test_harness.h>
 
-#if defined(AWS_USE_APPLE_DISPATCH_QUEUE)
-#    include <unistd.h> // for sleep()
-#endif
-
 struct task_args {
     bool invoked;
     bool was_in_thread;
@@ -63,7 +59,7 @@ static void s_dispatch_queue_sleep(void) {
      * Apple dispatch queue to run its delayed blocks and clean up for memory release purposes.
      */
 #if defined(AWS_USE_APPLE_DISPATCH_QUEUE)
-    sleep(2);
+    aws_thread_current_sleep(2000000000);
 #endif
 }
 

--- a/tests/event_loop_test.c
+++ b/tests/event_loop_test.c
@@ -52,6 +52,12 @@ static bool s_validate_thread_id_equal(aws_thread_id_t thread_id, bool expected_
     return expected_result;
 }
 
+static void s_dispatch_queue_sleep(void) {
+#if defined(AWS_USE_APPLE_DISPATCH_QUEUE)
+    sleep(2);
+#endif
+}
+
 /*
  * Test that a scheduled task from a non-event loop owned thread executes.
  */
@@ -178,6 +184,8 @@ static int s_test_event_loop_canceled_tasks_run_in_el_thread(struct aws_allocato
     ASSERT_TRUE(task2_args.was_in_thread);
     ASSERT_TRUE(s_validate_thread_id_equal(task2_args.thread_id, true));
     ASSERT_INT_EQUALS(AWS_TASK_STATUS_CANCELED, task2_args.status);
+
+    s_dispatch_queue_sleep();
 
     return AWS_OP_SUCCESS;
 }

--- a/tests/event_loop_test.c
+++ b/tests/event_loop_test.c
@@ -13,7 +13,9 @@
 #include <aws/io/private/event_loop_impl.h>
 #include <aws/testing/aws_test_harness.h>
 
-#include <unistd.h> // for sleep()
+#if defined(AWS_USE_APPLE_DISPATCH_QUEUE)
+#    include <unistd.h> // for sleep()
+#endif
 
 struct task_args {
     bool invoked;

--- a/tests/event_loop_test.c
+++ b/tests/event_loop_test.c
@@ -13,6 +13,8 @@
 #include <aws/io/private/event_loop_impl.h>
 #include <aws/testing/aws_test_harness.h>
 
+#include <unistd.h> // for sleep()
+
 struct task_args {
     bool invoked;
     bool was_in_thread;
@@ -53,6 +55,11 @@ static bool s_validate_thread_id_equal(aws_thread_id_t thread_id, bool expected_
 }
 
 static void s_dispatch_queue_sleep(void) {
+    /*
+     * The dispatch queue can have a block waiting to execute up to one second in the future. This iteration block needs
+     * to run to clean up memory allocated to the paired scheduled iteration entry. We wait for two seconds to allow the
+     * Apple dispatch queue to run its delayed blocks and clean up for memory release purposes.
+     */
 #if defined(AWS_USE_APPLE_DISPATCH_QUEUE)
     sleep(2);
 #endif


### PR DESCRIPTION
Changes:
- Remove two mutex locks and use a singular lock to reduce probability of deadlocks and simplify logic around shared data between threads.
- Shutdown/cleanup restructure
- Added storage of parent elg to aws_dispatch_loop.
- More error reporting and logging for clarity.
- Add comments wherever applicable and especially around Apple API.
- Post-test sleep for dispatch queue for memory cleanup.
- Bug fixes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
