### PR TITLE
Dispatch Queue Shutdown Polish

### DIFF
--- a/include/aws/io/event_loop.h
+++ b/include/aws/io/event_loop.h
@@ -247,17 +247,21 @@ void aws_event_loop_clean_up_base(struct aws_event_loop *event_loop);
 /**
  * @internal - Don't use outside of testing.
  *
- * Invokes the destroy() fn for the event loop implementation.
+ * Destroys an event loop implementation.
  * If the event loop is still in a running state, this function will block waiting on the event loop to shutdown.
- * If you do not want this function to block, call aws_event_loop_stop() manually first.
  * If the event loop is shared by multiple threads then destroy must be called by exactly one thread. All other threads
  * must ensure their API calls to the event loop happen-before the call to destroy.
+ *
+ * Internally, this calls aws_event_loop_start_destroy() followed by aws_event_loop_complete_destroy()
  */
 AWS_IO_API
 void aws_event_loop_destroy(struct aws_event_loop *event_loop);
 
 /**
  * @internal
+ *
+ * Signals an event loop to begin its destruction process.  If an event loop's implementation of this API does anything,
+ * it must be quick and non-blocking.  Most event loop implementations have an empty implementation for this function.
  */
 AWS_IO_API
 void aws_event_loop_start_destroy(struct aws_event_loop *event_loop);
@@ -265,6 +269,8 @@ void aws_event_loop_start_destroy(struct aws_event_loop *event_loop);
 /**
  * @internal
  *
+ * Waits for an event loop to complete its destruction process.  aws_event_loop_start_destroy() must have been called
+ * previously for this function to not deadlock.
  */
 AWS_IO_API
 void aws_event_loop_complete_destroy(struct aws_event_loop *event_loop);

--- a/include/aws/io/event_loop.h
+++ b/include/aws/io/event_loop.h
@@ -29,7 +29,8 @@ typedef void(aws_event_loop_on_event_fn)(
  * @internal
  */
 struct aws_event_loop_vtable {
-    void (*destroy)(struct aws_event_loop *event_loop);
+    void (*start_destroy)(struct aws_event_loop *event_loop);
+    void (*complete_destroy)(struct aws_event_loop *event_loop);
     int (*run)(struct aws_event_loop *event_loop);
     int (*stop)(struct aws_event_loop *event_loop);
     int (*wait_for_stop_completion)(struct aws_event_loop *event_loop);
@@ -254,6 +255,19 @@ void aws_event_loop_clean_up_base(struct aws_event_loop *event_loop);
  */
 AWS_IO_API
 void aws_event_loop_destroy(struct aws_event_loop *event_loop);
+
+/**
+ * @internal
+ */
+AWS_IO_API
+void aws_event_loop_start_destroy(struct aws_event_loop *event_loop);
+
+/**
+ * @internal
+ *
+ */
+AWS_IO_API
+void aws_event_loop_complete_destroy(struct aws_event_loop *event_loop);
 
 AWS_EXTERN_C_END
 

--- a/include/aws/testing/io_testing_channel.h
+++ b/include/aws/testing/io_testing_channel.h
@@ -57,7 +57,11 @@ static bool s_testing_loop_is_on_callers_thread(struct aws_event_loop *event_loo
     return testing_loop->mock_on_callers_thread;
 }
 
-static void s_testing_loop_destroy(struct aws_event_loop *event_loop) {
+static void s_testing_loop_start_destroy(struct aws_event_loop *event_loop) {
+    (void)event_loop;
+}
+
+static void s_testing_loop_complete_destroy(struct aws_event_loop *event_loop) {
     struct testing_loop *testing_loop = (struct testing_loop *)aws_event_loop_get_impl(event_loop);
     struct aws_allocator *allocator = testing_loop->allocator;
     aws_task_scheduler_clean_up(&testing_loop->scheduler);
@@ -67,7 +71,8 @@ static void s_testing_loop_destroy(struct aws_event_loop *event_loop) {
 }
 
 static struct aws_event_loop_vtable s_testing_loop_vtable = {
-    .destroy = s_testing_loop_destroy,
+    .start_destroy = s_testing_loop_start_destroy,
+    .complete_destroy = s_testing_loop_complete_destroy,
     .is_on_callers_thread = s_testing_loop_is_on_callers_thread,
     .run = s_testing_loop_run,
     .schedule_task_now = s_testing_loop_schedule_task_now,

--- a/source/bsd/kqueue_event_loop.c
+++ b/source/bsd/kqueue_event_loop.c
@@ -25,7 +25,8 @@
 #include <limits.h>
 #include <unistd.h>
 
-static void s_destroy(struct aws_event_loop *event_loop);
+static void s_start_destroy(struct aws_event_loop *event_loop);
+static void s_complete_destroy(struct aws_event_loop *event_loop);
 static int s_run(struct aws_event_loop *event_loop);
 static int s_stop(struct aws_event_loop *event_loop);
 static int s_wait_for_stop_completion(struct aws_event_loop *event_loop);
@@ -135,7 +136,8 @@ enum {
 };
 
 struct aws_event_loop_vtable s_kqueue_vtable = {
-    .destroy = s_destroy,
+    .start_destroy = s_start_destroy,
+    .complete_destroy = s_complete_destroy,
     .run = s_run,
     .stop = s_stop,
     .wait_for_stop_completion = s_wait_for_stop_completion,
@@ -313,7 +315,11 @@ clean_up:
 }
 #endif // AWS_ENABLE_KQUEUE
 
-static void s_destroy(struct aws_event_loop *event_loop) {
+static void s_start_destroy(struct aws_event_loop *event_loop) {
+    (void)event_loop;
+}
+
+static void s_complete_destroy(struct aws_event_loop *event_loop) {
     AWS_LOGF_INFO(AWS_LS_IO_EVENT_LOOP, "id=%p: destroying event_loop", (void *)event_loop);
     struct kqueue_loop *impl = event_loop->impl_data;
 

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -19,7 +19,8 @@
 #include <dispatch/dispatch.h>
 #include <dispatch/queue.h>
 
-static void s_destroy(struct aws_event_loop *event_loop);
+static void s_start_destroy(struct aws_event_loop *event_loop);
+static void s_complete_destroy(struct aws_event_loop *event_loop);
 static int s_run(struct aws_event_loop *event_loop);
 static int s_stop(struct aws_event_loop *event_loop);
 static int s_wait_for_stop_completion(struct aws_event_loop *event_loop);
@@ -60,7 +61,8 @@ static void *s_get_base_event_loop_group(struct aws_event_loop *event_loop);
 static bool s_is_on_callers_thread(struct aws_event_loop *event_loop);
 
 static struct aws_event_loop_vtable s_vtable = {
-    .destroy = s_destroy,
+    .start_destroy = s_start_destroy,
+    .complete_destroy = s_complete_destroy,
     .run = s_run,
     .stop = s_stop,
     .wait_for_stop_completion = s_wait_for_stop_completion,
@@ -380,7 +382,11 @@ populate_local_cross_thread_tasks:
     s_dispatch_event_loop_destroy(dispatch_loop->base_loop);
 }
 
-static void s_destroy(struct aws_event_loop *event_loop) {
+static void s_start_destroy(struct aws_event_loop *event_loop) {
+    (void)event_loop;
+}
+
+static void s_complete_destroy(struct aws_event_loop *event_loop) {
     AWS_LOGF_TRACE(AWS_LS_IO_EVENT_LOOP, "id=%p: Destroying Dispatch Queue Event Loop", (void *)event_loop);
     struct aws_dispatch_loop *dispatch_loop = event_loop->impl_data;
 

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -396,7 +396,7 @@ static void s_start_destroy(struct aws_event_loop *event_loop) {
     struct aws_dispatch_loop *dispatch_loop = event_loop->impl_data;
 
     s_lock_synced_data(dispatch_loop);
-    enum aws_dispatch_queue_execution_state execution_state = dispatch_loop->synced_data.execution_state;
+    enum aws_dispatch_loop_execution_state execution_state = dispatch_loop->synced_data.execution_state;
     AWS_FATAL_ASSERT(execution_state == AWS_DLES_RUNNING || execution_state == AWS_DLES_SUSPENDED);
     if (execution_state == AWS_DLES_SUSPENDED) {
         dispatch_resume(dispatch_loop->dispatch_queue);

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -631,7 +631,7 @@ static bool s_should_schedule_iteration(
  * aws_dispatch_loop->sycned_data
  */
 static void s_try_schedule_new_iteration(struct aws_dispatch_loop *dispatch_loop, uint64_t timestamp) {
-    if (dispatch_loop->synced_data.execution_state == AWS_DLES_SUSPENDED || dispatch_loop->synced_data.is_executing) {
+    if (dispatch_loop->synced_data.execution_state != AWS_DLES_RUNNING) {
         return;
     }
 

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -639,8 +639,8 @@ static void s_try_schedule_new_iteration(struct aws_dispatch_loop *dispatch_loop
      * Apple dispatch queue uses automatic reference counting (ARC). If an iteration is scheduled to run in the future,
      * the dispatch queue will persist until it is executed. Scheduling a block far into the future will keep the
      * dispatch queue alive unnecessarily long, which blocks event loop group shutdown from completion.
-     * To mitigate this, we ensure an iteration is scheduled no longer than 1 second in the
-     * future.
+     * To mitigate this, we ensure an iteration is scheduled no longer than
+     * AWS_DISPATCH_QUEUE_MAX_FUTURE_SERVICE_INTERVAL second in the future.
      */
     uint64_t now_ns = 0;
     aws_event_loop_current_clock_time(dispatch_loop->base_loop, &now_ns);

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -305,7 +305,6 @@ struct aws_event_loop *aws_event_loop_new_with_dispatch_queue(
         AWS_LS_IO_EVENT_LOOP, "id=%p: Apple dispatch queue created with id: %s", (void *)loop, dispatch_queue_id);
 
     /* The dispatch queue is suspended at this point. */
-    // dispatch_loop->synced_data.suspended = true;
     dispatch_loop->synced_data.is_executing = false;
 
     if (aws_task_scheduler_init(&dispatch_loop->scheduler, alloc)) {
@@ -397,10 +396,9 @@ static void s_start_destroy(struct aws_event_loop *event_loop) {
     struct aws_dispatch_loop *dispatch_loop = event_loop->impl_data;
 
     s_lock_synced_data(dispatch_loop);
-    AWS_FATAL_ASSERT(
-        dispatch_loop->synced_data.execution_state == AWS_DLES_RUNNING ||
-        dispatch_loop->synced_data.execution_state == AWS_DLES_SUSPENDED);
-    if (dispatch_loop->synced_data.execution_state == AWS_DLES_SUSPENDED) {
+    enum aws_dispatch_queue_execution_state execution_state = dispatch_loop->synced_data.execution_state;
+    AWS_FATAL_ASSERT(execution_state == AWS_DLES_RUNNING || execution_state == AWS_DLES_SUSPENDED);
+    if (execution_state == AWS_DLES_SUSPENDED) {
         dispatch_resume(dispatch_loop->dispatch_queue);
     }
     dispatch_loop->synced_data.execution_state = AWS_DLES_SHUTTING_DOWN;

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -631,7 +631,7 @@ static bool s_should_schedule_iteration(
  * aws_dispatch_loop->sycned_data
  */
 static void s_try_schedule_new_iteration(struct aws_dispatch_loop *dispatch_loop, uint64_t timestamp) {
-    if (dispatch_loop->synced_data.execution_state != AWS_DLES_RUNNING) {
+    if (dispatch_loop->synced_data.execution_state != AWS_DLES_RUNNING || dispatch_loop->synced_data.is_executing) {
         return;
     }
 

--- a/source/darwin/dispatch_queue_event_loop_private.h
+++ b/source/darwin/dispatch_queue_event_loop_private.h
@@ -11,12 +11,21 @@
 #include <aws/io/tls_channel_handler.h>
 #include <dispatch/dispatch.h>
 
+enum aws_dispatch_loop_execution_state {
+    AWS_DLES_SUSPENDED,
+    AWS_DLES_RUNNING,
+    AWS_DLES_SHUTTING_DOWN,
+    AWS_DLES_TERMINATED
+};
+
 struct aws_dispatch_loop {
     struct aws_allocator *allocator;
     dispatch_queue_t dispatch_queue;
     struct aws_task_scheduler scheduler;
     struct aws_event_loop *base_loop;
     struct aws_event_loop_group *base_elg;
+
+    //struct aws_ref_count ref_count;
 
     /* Synced data handle cross thread tasks and events, and event loop operations*/
     struct {
@@ -43,6 +52,7 @@ struct aws_dispatch_loop {
          * Calling dispatch_sync() on a suspended dispatch queue will deadlock.
          */
         bool suspended;
+        //enum aws_dispatch_loop_execution_state execution_state;
 
         struct aws_linked_list cross_thread_tasks;
 
@@ -54,6 +64,7 @@ struct aws_dispatch_loop {
          * redundant.
          */
         struct aws_priority_queue scheduled_iterations;
+        //struct aws_linked_list scheduled_iterations;
     } synced_data;
 };
 

--- a/source/darwin/dispatch_queue_event_loop_private.h
+++ b/source/darwin/dispatch_queue_event_loop_private.h
@@ -25,7 +25,7 @@ struct aws_dispatch_loop {
     struct aws_event_loop *base_loop;
     struct aws_event_loop_group *base_elg;
 
-    //struct aws_ref_count ref_count;
+    struct aws_ref_count ref_count;
 
     /* Synced data handle cross thread tasks and events, and event loop operations*/
     struct {
@@ -52,7 +52,7 @@ struct aws_dispatch_loop {
          * Calling dispatch_sync() on a suspended dispatch queue will deadlock.
          */
         bool suspended;
-        //enum aws_dispatch_loop_execution_state execution_state;
+        enum aws_dispatch_loop_execution_state execution_state;
 
         struct aws_linked_list cross_thread_tasks;
 
@@ -64,7 +64,6 @@ struct aws_dispatch_loop {
          * redundant.
          */
         struct aws_priority_queue scheduled_iterations;
-        //struct aws_linked_list scheduled_iterations;
     } synced_data;
 };
 

--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -495,10 +495,34 @@ void aws_event_loop_destroy(struct aws_event_loop *event_loop) {
         return;
     }
 
-    AWS_ASSERT(event_loop->vtable && event_loop->vtable->destroy);
+    AWS_ASSERT(event_loop->vtable && event_loop->vtable->start_destroy);
+    AWS_ASSERT(event_loop->vtable && event_loop->vtable->complete_destroy);
     AWS_ASSERT(!aws_event_loop_thread_is_callers_thread(event_loop));
 
-    event_loop->vtable->destroy(event_loop);
+    event_loop->vtable->start_destroy(event_loop);
+    event_loop->vtable->complete_destroy(event_loop);
+}
+
+void aws_event_loop_start_destroy(struct aws_event_loop *event_loop) {
+    if (!event_loop) {
+        return;
+    }
+
+    AWS_ASSERT(event_loop->vtable && event_loop->vtable->start_destroy);
+    AWS_ASSERT(!aws_event_loop_thread_is_callers_thread(event_loop));
+
+    event_loop->vtable->start_destroy(event_loop);
+}
+
+void aws_event_loop_complete_destroy(struct aws_event_loop *event_loop) {
+    if (!event_loop) {
+        return;
+    }
+
+    AWS_ASSERT(event_loop->vtable && event_loop->vtable->complete_destroy);
+    AWS_ASSERT(!aws_event_loop_thread_is_callers_thread(event_loop));
+
+    event_loop->vtable->complete_destroy(event_loop);
 }
 
 int aws_event_loop_fetch_local_object(

--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -187,11 +187,19 @@ static void s_event_loop_group_thread_exit(void *user_data) {
 }
 
 static void s_aws_event_loop_group_shutdown_sync(struct aws_event_loop_group *el_group) {
+    size_t loop_count = aws_array_list_length(&el_group->event_loops);
+    for (size_t i = 0; i < loop_count; ++i) {
+        struct aws_event_loop *loop = NULL;
+        aws_array_list_get_at(&el_group->event_loops, &loop, i);
+
+        aws_event_loop_start_destroy(loop);
+    }
+
     while (aws_array_list_length(&el_group->event_loops) > 0) {
         struct aws_event_loop *loop = NULL;
 
         if (!aws_array_list_back(&el_group->event_loops, &loop)) {
-            aws_event_loop_destroy(loop);
+            aws_event_loop_complete_destroy(loop);
         }
 
         aws_array_list_pop_back(&el_group->event_loops);

--- a/source/linux/epoll_event_loop.c
+++ b/source/linux/epoll_event_loop.c
@@ -44,7 +44,8 @@
 #    define EPOLLRDHUP 0x2000
 #endif
 
-static void s_destroy(struct aws_event_loop *event_loop);
+static void s_start_destroy(struct aws_event_loop *event_loop);
+static void s_complete_destroy(struct aws_event_loop *event_loop);
 static int s_run(struct aws_event_loop *event_loop);
 static int s_stop(struct aws_event_loop *event_loop);
 static int s_wait_for_stop_completion(struct aws_event_loop *event_loop);
@@ -81,7 +82,8 @@ static bool s_is_on_callers_thread(struct aws_event_loop *event_loop);
 static void aws_event_loop_thread(void *args);
 
 static struct aws_event_loop_vtable s_vtable = {
-    .destroy = s_destroy,
+    .start_destroy = s_start_destroy,
+    .complete_destroy = s_complete_destroy,
     .run = s_run,
     .stop = s_stop,
     .wait_for_stop_completion = s_wait_for_stop_completion,
@@ -248,7 +250,11 @@ clean_up_loop:
     return NULL;
 }
 
-static void s_destroy(struct aws_event_loop *event_loop) {
+static void s_start_destroy(struct aws_event_loop *event_loop) {
+    (void)event_loop;
+}
+
+static void s_complete_destroy(struct aws_event_loop *event_loop) {
     AWS_LOGF_INFO(AWS_LS_IO_EVENT_LOOP, "id=%p: Destroying event_loop", (void *)event_loop);
 
     struct epoll_loop *epoll_loop = event_loop->impl_data;

--- a/source/windows/iocp/iocp_event_loop.c
+++ b/source/windows/iocp/iocp_event_loop.c
@@ -96,7 +96,8 @@ enum {
     MAX_COMPLETION_PACKETS_PER_LOOP = 100,
 };
 
-static void s_destroy(struct aws_event_loop *event_loop);
+static void s_start_destroy(struct aws_event_loop *event_loop);
+static void s_complete_destroy(struct aws_event_loop *event_loop);
 static int s_run(struct aws_event_loop *event_loop);
 static int s_stop(struct aws_event_loop *event_loop);
 static int s_wait_for_stop_completion(struct aws_event_loop *event_loop);
@@ -156,7 +157,8 @@ struct _OVERLAPPED *aws_overlapped_to_windows_overlapped(struct aws_overlapped *
 }
 
 struct aws_event_loop_vtable s_iocp_vtable = {
-    .destroy = s_destroy,
+    .start_destroy = s_start_destroy,
+    .complete_destroy = s_complete_destroy,
     .run = s_run,
     .stop = s_stop,
     .wait_for_stop_completion = s_wait_for_stop_completion,
@@ -306,8 +308,12 @@ clean_up:
     return NULL;
 }
 
+static void s_start_destroy(struct aws_event_loop *event_loop) {
+    (void)event_loop;
+}
+
 /* Should not be called from event-thread */
-static void s_destroy(struct aws_event_loop *event_loop) {
+static void s_complete_destroy(struct aws_event_loop *event_loop) {
     AWS_LOGF_TRACE(AWS_LS_IO_EVENT_LOOP, "id=%p: destroying event-loop", (void *)event_loop);
 
     struct iocp_loop *impl = event_loop->impl_data;


### PR DESCRIPTION
Refactors dispatch queue shutdown so that no loop-associated memory is unreleased at the time event loop group destroy completes.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
