### PR TITLE
Nw socket shutdown2

### DIFF
--- a/include/aws/io/event_loop.h
+++ b/include/aws/io/event_loop.h
@@ -247,17 +247,21 @@ void aws_event_loop_clean_up_base(struct aws_event_loop *event_loop);
 /**
  * @internal - Don't use outside of testing.
  *
- * Invokes the destroy() fn for the event loop implementation.
+ * Destroys an event loop implementation.
  * If the event loop is still in a running state, this function will block waiting on the event loop to shutdown.
- * If you do not want this function to block, call aws_event_loop_stop() manually first.
  * If the event loop is shared by multiple threads then destroy must be called by exactly one thread. All other threads
  * must ensure their API calls to the event loop happen-before the call to destroy.
+ *
+ * Internally, this calls aws_event_loop_start_destroy() followed by aws_event_loop_complete_destroy()
  */
 AWS_IO_API
 void aws_event_loop_destroy(struct aws_event_loop *event_loop);
 
 /**
  * @internal
+ *
+ * Signals an event loop to begin its destruction process.  If an event loop's implementation of this API does anything,
+ * it must be quick and non-blocking.  Most event loop implementations have an empty implementation for this function.
  */
 AWS_IO_API
 void aws_event_loop_start_destroy(struct aws_event_loop *event_loop);
@@ -265,6 +269,8 @@ void aws_event_loop_start_destroy(struct aws_event_loop *event_loop);
 /**
  * @internal
  *
+ * Waits for an event loop to complete its destruction process.  aws_event_loop_start_destroy() must have been called
+ * previously for this function to not deadlock.
  */
 AWS_IO_API
 void aws_event_loop_complete_destroy(struct aws_event_loop *event_loop);

--- a/include/aws/io/event_loop.h
+++ b/include/aws/io/event_loop.h
@@ -29,7 +29,8 @@ typedef void(aws_event_loop_on_event_fn)(
  * @internal
  */
 struct aws_event_loop_vtable {
-    void (*destroy)(struct aws_event_loop *event_loop);
+    void (*start_destroy)(struct aws_event_loop *event_loop);
+    void (*complete_destroy)(struct aws_event_loop *event_loop);
     int (*run)(struct aws_event_loop *event_loop);
     int (*stop)(struct aws_event_loop *event_loop);
     int (*wait_for_stop_completion)(struct aws_event_loop *event_loop);
@@ -254,6 +255,19 @@ void aws_event_loop_clean_up_base(struct aws_event_loop *event_loop);
  */
 AWS_IO_API
 void aws_event_loop_destroy(struct aws_event_loop *event_loop);
+
+/**
+ * @internal
+ */
+AWS_IO_API
+void aws_event_loop_start_destroy(struct aws_event_loop *event_loop);
+
+/**
+ * @internal
+ *
+ */
+AWS_IO_API
+void aws_event_loop_complete_destroy(struct aws_event_loop *event_loop);
 
 AWS_EXTERN_C_END
 

--- a/include/aws/testing/io_testing_channel.h
+++ b/include/aws/testing/io_testing_channel.h
@@ -57,7 +57,11 @@ static bool s_testing_loop_is_on_callers_thread(struct aws_event_loop *event_loo
     return testing_loop->mock_on_callers_thread;
 }
 
-static void s_testing_loop_destroy(struct aws_event_loop *event_loop) {
+static void s_testing_loop_start_destroy(struct aws_event_loop *event_loop) {
+    (void)event_loop;
+}
+
+static void s_testing_loop_complete_destroy(struct aws_event_loop *event_loop) {
     struct testing_loop *testing_loop = (struct testing_loop *)aws_event_loop_get_impl(event_loop);
     struct aws_allocator *allocator = testing_loop->allocator;
     aws_task_scheduler_clean_up(&testing_loop->scheduler);
@@ -67,7 +71,8 @@ static void s_testing_loop_destroy(struct aws_event_loop *event_loop) {
 }
 
 static struct aws_event_loop_vtable s_testing_loop_vtable = {
-    .destroy = s_testing_loop_destroy,
+    .start_destroy = s_testing_loop_start_destroy,
+    .complete_destroy = s_testing_loop_complete_destroy,
     .is_on_callers_thread = s_testing_loop_is_on_callers_thread,
     .run = s_testing_loop_run,
     .schedule_task_now = s_testing_loop_schedule_task_now,

--- a/source/bsd/kqueue_event_loop.c
+++ b/source/bsd/kqueue_event_loop.c
@@ -25,7 +25,8 @@
 #include <limits.h>
 #include <unistd.h>
 
-static void s_destroy(struct aws_event_loop *event_loop);
+static void s_start_destroy(struct aws_event_loop *event_loop);
+static void s_complete_destroy(struct aws_event_loop *event_loop);
 static int s_run(struct aws_event_loop *event_loop);
 static int s_stop(struct aws_event_loop *event_loop);
 static int s_wait_for_stop_completion(struct aws_event_loop *event_loop);
@@ -135,7 +136,8 @@ enum {
 };
 
 struct aws_event_loop_vtable s_kqueue_vtable = {
-    .destroy = s_destroy,
+    .start_destroy = s_start_destroy,
+    .complete_destroy = s_complete_destroy,
     .run = s_run,
     .stop = s_stop,
     .wait_for_stop_completion = s_wait_for_stop_completion,
@@ -313,7 +315,11 @@ clean_up:
 }
 #endif // AWS_ENABLE_KQUEUE
 
-static void s_destroy(struct aws_event_loop *event_loop) {
+static void s_start_destroy(struct aws_event_loop *event_loop) {
+    (void)event_loop;
+}
+
+static void s_complete_destroy(struct aws_event_loop *event_loop) {
     AWS_LOGF_INFO(AWS_LS_IO_EVENT_LOOP, "id=%p: destroying event_loop", (void *)event_loop);
     struct kqueue_loop *impl = event_loop->impl_data;
 

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -19,7 +19,8 @@
 #include <dispatch/dispatch.h>
 #include <dispatch/queue.h>
 
-static void s_destroy(struct aws_event_loop *event_loop);
+static void s_start_destroy(struct aws_event_loop *event_loop);
+static void s_complete_destroy(struct aws_event_loop *event_loop);
 static int s_run(struct aws_event_loop *event_loop);
 static int s_stop(struct aws_event_loop *event_loop);
 static int s_wait_for_stop_completion(struct aws_event_loop *event_loop);
@@ -60,7 +61,8 @@ static void *s_get_base_event_loop_group(struct aws_event_loop *event_loop);
 static bool s_is_on_callers_thread(struct aws_event_loop *event_loop);
 
 static struct aws_event_loop_vtable s_vtable = {
-    .destroy = s_destroy,
+    .start_destroy = s_start_destroy,
+    .complete_destroy = s_complete_destroy,
     .run = s_run,
     .stop = s_stop,
     .wait_for_stop_completion = s_wait_for_stop_completion,
@@ -380,7 +382,11 @@ populate_local_cross_thread_tasks:
     s_dispatch_event_loop_destroy(dispatch_loop->base_loop);
 }
 
-static void s_destroy(struct aws_event_loop *event_loop) {
+static void s_start_destroy(struct aws_event_loop *event_loop) {
+    (void)event_loop;
+}
+
+static void s_complete_destroy(struct aws_event_loop *event_loop) {
     AWS_LOGF_TRACE(AWS_LS_IO_EVENT_LOOP, "id=%p: Destroying Dispatch Queue Event Loop", (void *)event_loop);
     struct aws_dispatch_loop *dispatch_loop = event_loop->impl_data;
 

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -396,7 +396,7 @@ static void s_start_destroy(struct aws_event_loop *event_loop) {
     struct aws_dispatch_loop *dispatch_loop = event_loop->impl_data;
 
     s_lock_synced_data(dispatch_loop);
-    enum aws_dispatch_queue_execution_state execution_state = dispatch_loop->synced_data.execution_state;
+    enum aws_dispatch_loop_execution_state execution_state = dispatch_loop->synced_data.execution_state;
     AWS_FATAL_ASSERT(execution_state == AWS_DLES_RUNNING || execution_state == AWS_DLES_SUSPENDED);
     if (execution_state == AWS_DLES_SUSPENDED) {
         dispatch_resume(dispatch_loop->dispatch_queue);

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -631,7 +631,7 @@ static bool s_should_schedule_iteration(
  * aws_dispatch_loop->sycned_data
  */
 static void s_try_schedule_new_iteration(struct aws_dispatch_loop *dispatch_loop, uint64_t timestamp) {
-    if (dispatch_loop->synced_data.execution_state == AWS_DLES_SUSPENDED || dispatch_loop->synced_data.is_executing) {
+    if (dispatch_loop->synced_data.execution_state != AWS_DLES_RUNNING) {
         return;
     }
 

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -305,7 +305,6 @@ struct aws_event_loop *aws_event_loop_new_with_dispatch_queue(
         AWS_LS_IO_EVENT_LOOP, "id=%p: Apple dispatch queue created with id: %s", (void *)loop, dispatch_queue_id);
 
     /* The dispatch queue is suspended at this point. */
-    // dispatch_loop->synced_data.suspended = true;
     dispatch_loop->synced_data.is_executing = false;
 
     if (aws_task_scheduler_init(&dispatch_loop->scheduler, alloc)) {
@@ -397,10 +396,9 @@ static void s_start_destroy(struct aws_event_loop *event_loop) {
     struct aws_dispatch_loop *dispatch_loop = event_loop->impl_data;
 
     s_lock_synced_data(dispatch_loop);
-    AWS_FATAL_ASSERT(
-        dispatch_loop->synced_data.execution_state == AWS_DLES_RUNNING ||
-        dispatch_loop->synced_data.execution_state == AWS_DLES_SUSPENDED);
-    if (dispatch_loop->synced_data.execution_state == AWS_DLES_SUSPENDED) {
+    enum aws_dispatch_queue_execution_state execution_state = dispatch_loop->synced_data.execution_state;
+    AWS_FATAL_ASSERT(execution_state == AWS_DLES_RUNNING || execution_state == AWS_DLES_SUSPENDED);
+    if (execution_state == AWS_DLES_SUSPENDED) {
         dispatch_resume(dispatch_loop->dispatch_queue);
     }
     dispatch_loop->synced_data.execution_state = AWS_DLES_SHUTTING_DOWN;

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -631,7 +631,7 @@ static bool s_should_schedule_iteration(
  * aws_dispatch_loop->sycned_data
  */
 static void s_try_schedule_new_iteration(struct aws_dispatch_loop *dispatch_loop, uint64_t timestamp) {
-    if (dispatch_loop->synced_data.execution_state != AWS_DLES_RUNNING) {
+    if (dispatch_loop->synced_data.execution_state != AWS_DLES_RUNNING || dispatch_loop->synced_data.is_executing) {
         return;
     }
 

--- a/source/darwin/dispatch_queue_event_loop_private.h
+++ b/source/darwin/dispatch_queue_event_loop_private.h
@@ -11,12 +11,21 @@
 #include <aws/io/tls_channel_handler.h>
 #include <dispatch/dispatch.h>
 
+enum aws_dispatch_loop_execution_state {
+    AWS_DLES_SUSPENDED,
+    AWS_DLES_RUNNING,
+    AWS_DLES_SHUTTING_DOWN,
+    AWS_DLES_TERMINATED
+};
+
 struct aws_dispatch_loop {
     struct aws_allocator *allocator;
     dispatch_queue_t dispatch_queue;
     struct aws_task_scheduler scheduler;
     struct aws_event_loop *base_loop;
     struct aws_event_loop_group *base_elg;
+
+    //struct aws_ref_count ref_count;
 
     /* Synced data handle cross thread tasks and events, and event loop operations*/
     struct {
@@ -43,6 +52,7 @@ struct aws_dispatch_loop {
          * Calling dispatch_sync() on a suspended dispatch queue will deadlock.
          */
         bool suspended;
+        //enum aws_dispatch_loop_execution_state execution_state;
 
         struct aws_linked_list cross_thread_tasks;
 
@@ -54,6 +64,7 @@ struct aws_dispatch_loop {
          * redundant.
          */
         struct aws_priority_queue scheduled_iterations;
+        //struct aws_linked_list scheduled_iterations;
     } synced_data;
 };
 

--- a/source/darwin/dispatch_queue_event_loop_private.h
+++ b/source/darwin/dispatch_queue_event_loop_private.h
@@ -25,7 +25,7 @@ struct aws_dispatch_loop {
     struct aws_event_loop *base_loop;
     struct aws_event_loop_group *base_elg;
 
-    //struct aws_ref_count ref_count;
+    struct aws_ref_count ref_count;
 
     /* Synced data handle cross thread tasks and events, and event loop operations*/
     struct {
@@ -52,7 +52,7 @@ struct aws_dispatch_loop {
          * Calling dispatch_sync() on a suspended dispatch queue will deadlock.
          */
         bool suspended;
-        //enum aws_dispatch_loop_execution_state execution_state;
+        enum aws_dispatch_loop_execution_state execution_state;
 
         struct aws_linked_list cross_thread_tasks;
 
@@ -64,7 +64,6 @@ struct aws_dispatch_loop {
          * redundant.
          */
         struct aws_priority_queue scheduled_iterations;
-        //struct aws_linked_list scheduled_iterations;
     } synced_data;
 };
 

--- a/source/darwin/dispatch_queue_event_loop_private.h
+++ b/source/darwin/dispatch_queue_event_loop_private.h
@@ -60,7 +60,7 @@ struct aws_dispatch_loop {
          */
         bool is_executing;
         aws_thread_id_t current_thread_id;
-        
+
         enum aws_dispatch_loop_execution_state execution_state;
 
         struct aws_linked_list cross_thread_tasks;

--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -495,10 +495,34 @@ void aws_event_loop_destroy(struct aws_event_loop *event_loop) {
         return;
     }
 
-    AWS_ASSERT(event_loop->vtable && event_loop->vtable->destroy);
+    AWS_ASSERT(event_loop->vtable && event_loop->vtable->start_destroy);
+    AWS_ASSERT(event_loop->vtable && event_loop->vtable->complete_destroy);
     AWS_ASSERT(!aws_event_loop_thread_is_callers_thread(event_loop));
 
-    event_loop->vtable->destroy(event_loop);
+    event_loop->vtable->start_destroy(event_loop);
+    event_loop->vtable->complete_destroy(event_loop);
+}
+
+void aws_event_loop_start_destroy(struct aws_event_loop *event_loop) {
+    if (!event_loop) {
+        return;
+    }
+
+    AWS_ASSERT(event_loop->vtable && event_loop->vtable->start_destroy);
+    AWS_ASSERT(!aws_event_loop_thread_is_callers_thread(event_loop));
+
+    event_loop->vtable->start_destroy(event_loop);
+}
+
+void aws_event_loop_complete_destroy(struct aws_event_loop *event_loop) {
+    if (!event_loop) {
+        return;
+    }
+
+    AWS_ASSERT(event_loop->vtable && event_loop->vtable->complete_destroy);
+    AWS_ASSERT(!aws_event_loop_thread_is_callers_thread(event_loop));
+
+    event_loop->vtable->complete_destroy(event_loop);
 }
 
 int aws_event_loop_fetch_local_object(

--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -187,11 +187,19 @@ static void s_event_loop_group_thread_exit(void *user_data) {
 }
 
 static void s_aws_event_loop_group_shutdown_sync(struct aws_event_loop_group *el_group) {
+    size_t loop_count = aws_array_list_length(&el_group->event_loops);
+    for (size_t i = 0; i < loop_count; ++i) {
+        struct aws_event_loop *loop = NULL;
+        aws_array_list_get_at(&el_group->event_loops, &loop, i);
+
+        aws_event_loop_start_destroy(loop);
+    }
+
     while (aws_array_list_length(&el_group->event_loops) > 0) {
         struct aws_event_loop *loop = NULL;
 
         if (!aws_array_list_back(&el_group->event_loops, &loop)) {
-            aws_event_loop_destroy(loop);
+            aws_event_loop_complete_destroy(loop);
         }
 
         aws_array_list_pop_back(&el_group->event_loops);

--- a/source/linux/epoll_event_loop.c
+++ b/source/linux/epoll_event_loop.c
@@ -44,7 +44,8 @@
 #    define EPOLLRDHUP 0x2000
 #endif
 
-static void s_destroy(struct aws_event_loop *event_loop);
+static void s_start_destroy(struct aws_event_loop *event_loop);
+static void s_complete_destroy(struct aws_event_loop *event_loop);
 static int s_run(struct aws_event_loop *event_loop);
 static int s_stop(struct aws_event_loop *event_loop);
 static int s_wait_for_stop_completion(struct aws_event_loop *event_loop);
@@ -81,7 +82,8 @@ static bool s_is_on_callers_thread(struct aws_event_loop *event_loop);
 static void aws_event_loop_thread(void *args);
 
 static struct aws_event_loop_vtable s_vtable = {
-    .destroy = s_destroy,
+    .start_destroy = s_start_destroy,
+    .complete_destroy = s_complete_destroy,
     .run = s_run,
     .stop = s_stop,
     .wait_for_stop_completion = s_wait_for_stop_completion,
@@ -248,7 +250,11 @@ clean_up_loop:
     return NULL;
 }
 
-static void s_destroy(struct aws_event_loop *event_loop) {
+static void s_start_destroy(struct aws_event_loop *event_loop) {
+    (void)event_loop;
+}
+
+static void s_complete_destroy(struct aws_event_loop *event_loop) {
     AWS_LOGF_INFO(AWS_LS_IO_EVENT_LOOP, "id=%p: Destroying event_loop", (void *)event_loop);
 
     struct epoll_loop *epoll_loop = event_loop->impl_data;

--- a/source/windows/iocp/iocp_event_loop.c
+++ b/source/windows/iocp/iocp_event_loop.c
@@ -96,7 +96,8 @@ enum {
     MAX_COMPLETION_PACKETS_PER_LOOP = 100,
 };
 
-static void s_destroy(struct aws_event_loop *event_loop);
+static void s_start_destroy(struct aws_event_loop *event_loop);
+static void s_complete_destroy(struct aws_event_loop *event_loop);
 static int s_run(struct aws_event_loop *event_loop);
 static int s_stop(struct aws_event_loop *event_loop);
 static int s_wait_for_stop_completion(struct aws_event_loop *event_loop);
@@ -156,7 +157,8 @@ struct _OVERLAPPED *aws_overlapped_to_windows_overlapped(struct aws_overlapped *
 }
 
 struct aws_event_loop_vtable s_iocp_vtable = {
-    .destroy = s_destroy,
+    .start_destroy = s_start_destroy,
+    .complete_destroy = s_complete_destroy,
     .run = s_run,
     .stop = s_stop,
     .wait_for_stop_completion = s_wait_for_stop_completion,
@@ -306,8 +308,12 @@ clean_up:
     return NULL;
 }
 
+static void s_start_destroy(struct aws_event_loop *event_loop) {
+    (void)event_loop;
+}
+
 /* Should not be called from event-thread */
-static void s_destroy(struct aws_event_loop *event_loop) {
+static void s_complete_destroy(struct aws_event_loop *event_loop) {
     AWS_LOGF_TRACE(AWS_LS_IO_EVENT_LOOP, "id=%p: destroying event-loop", (void *)event_loop);
 
     struct iocp_loop *impl = event_loop->impl_data;

--- a/tests/channel_test.c
+++ b/tests/channel_test.c
@@ -669,13 +669,6 @@ static bool s_shutdown_complete_pred(void *user_data) {
     return test_args->shutdown;
 }
 
-static void s_sleep_for_dispatch_queue(void) {
-#ifdef AWS_USE_APPLE_NETWORK_FRAMEWORK
-    // DEBUG WIP: SLEEP TO MAKE SURE THE EVENT LOOP IS DESTROYED
-    aws_thread_current_sleep(2000000000);
-#endif
-}
-
 static int s_test_channel_connect_some_hosts_timeout(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
 
@@ -847,8 +840,6 @@ static int s_test_channel_connect_some_hosts_timeout(struct aws_allocator *alloc
     aws_array_list_clean_up(&bh_addresses);
 
     aws_io_library_clean_up();
-
-    s_sleep_for_dispatch_queue();
 
     return 0;
 }

--- a/tests/exponential_backoff_retry_test.c
+++ b/tests/exponential_backoff_retry_test.c
@@ -19,13 +19,6 @@ struct exponential_backoff_test_data {
     struct aws_condition_variable cvar;
 };
 
-static void s_sleep_for_dispatch_queue(void) {
-#ifdef AWS_USE_APPLE_NETWORK_FRAMEWORK
-    // DEBUG WIP: SLEEP TO MAKE SURE THE EVENT LOOP IS DESTROYED
-    aws_thread_current_sleep(2000000000);
-#endif
-}
-
 static void s_too_many_retries_test_on_retry_ready(struct aws_retry_token *token, int error_code, void *user_data) {
     (void)error_code;
 
@@ -107,8 +100,6 @@ static int s_test_exponential_backoff_retry_too_many_retries_for_jitter_mode(
     aws_event_loop_group_release(el_group);
 
     aws_io_library_clean_up();
-
-    s_sleep_for_dispatch_queue();
 
     return AWS_OP_SUCCESS;
 }
@@ -204,8 +195,6 @@ static int s_test_exponential_backoff_retry_client_errors_do_not_count_fn(struct
 
     aws_io_library_clean_up();
 
-    s_sleep_for_dispatch_queue();
-
     return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(
@@ -261,8 +250,6 @@ static int s_test_exponential_backoff_retry_no_jitter_time_taken_fn(struct aws_a
 
     aws_io_library_clean_up();
 
-    // DEBUG WIP: SLEEP TO MAKE SURE THE EVENT LOOP IS DESTROYED
-    s_sleep_for_dispatch_queue();
     return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(
@@ -325,8 +312,6 @@ static int s_test_exponential_max_backoff_retry_no_jitter_fn(struct aws_allocato
 
     aws_io_library_clean_up();
 
-    s_sleep_for_dispatch_queue();
-
     return AWS_OP_SUCCESS;
 }
 AWS_TEST_CASE(test_exponential_max_backoff_retry_no_jitter, s_test_exponential_max_backoff_retry_no_jitter_fn)
@@ -353,8 +338,6 @@ static int s_test_exponential_backoff_retry_invalid_options_fn(struct aws_alloca
     aws_event_loop_group_release(el_group);
 
     aws_io_library_clean_up();
-
-    s_sleep_for_dispatch_queue();
 
     return AWS_OP_SUCCESS;
 }

--- a/tests/socket_handler_test.c
+++ b/tests/socket_handler_test.c
@@ -82,13 +82,6 @@ static int s_socket_common_tester_init(struct aws_allocator *allocator, struct s
     return AWS_OP_SUCCESS;
 }
 
-static void s_sleep_for_dispatch_queue(void) {
-#ifdef AWS_USE_APPLE_NETWORK_FRAMEWORK
-    // DEBUG WIP: SLEEP TO MAKE SURE THE EVENT LOOP IS DESTROYED
-    aws_thread_current_sleep(2000000000);
-#endif
-}
-
 static int s_socket_common_tester_clean_up(struct socket_common_tester *tester) {
     aws_host_resolver_release(tester->resolver);
     aws_event_loop_group_release(tester->el_group);
@@ -96,8 +89,6 @@ static int s_socket_common_tester_clean_up(struct socket_common_tester *tester) 
     aws_mutex_clean_up(&tester->mutex);
 
     aws_io_library_clean_up();
-
-    s_sleep_for_dispatch_queue();
 
     return AWS_OP_SUCCESS;
 }

--- a/tests/socket_test.c
+++ b/tests/socket_test.c
@@ -32,13 +32,6 @@ struct local_listener_args {
     bool shutdown_complete;
 };
 
-static void s_sleep_for_dispatch_queue(void) {
-#ifdef AWS_USE_APPLE_NETWORK_FRAMEWORK
-    // DEBUG WIP: SLEEP TO MAKE SURE THE EVENT LOOP IS DESTROYED
-    aws_thread_current_sleep(2000000000);
-#endif
-}
-
 static void s_local_listener_shutdown_complete(void *user_data) {
     struct local_listener_args *listener_args = (struct local_listener_args *)user_data;
 
@@ -513,8 +506,6 @@ static int s_test_socket_ex(
     aws_event_loop_group_release(el_group);
     aws_io_library_clean_up();
 
-    s_sleep_for_dispatch_queue();
-
     return 0;
 }
 
@@ -686,7 +677,6 @@ static int s_test_socket_udp_dispatch_queue(
     aws_event_loop_group_release(el_group);
     aws_io_library_clean_up();
 
-    s_sleep_for_dispatch_queue();
     return 0;
 }
 
@@ -1061,8 +1051,6 @@ static int s_test_connect_timeout(struct aws_allocator *allocator, void *ctx) {
 
     aws_io_library_clean_up();
 
-    s_sleep_for_dispatch_queue();
-
     return 0;
 }
 
@@ -1164,7 +1152,6 @@ static int s_test_connect_timeout_cancellation(struct aws_allocator *allocator, 
     ASSERT_SUCCESS(aws_mutex_unlock(outgoing_args.mutex));
 
     aws_io_library_clean_up();
-    s_sleep_for_dispatch_queue();
 
     return 0;
 }
@@ -1243,8 +1230,6 @@ static int s_test_outgoing_local_sock_errors(struct aws_allocator *allocator, vo
     aws_event_loop_group_release(el_group);
     aws_io_library_clean_up();
 
-    s_sleep_for_dispatch_queue();
-
     return 0;
 }
 
@@ -1320,7 +1305,6 @@ cleanup:
     aws_event_loop_group_release(el_group);
     aws_io_library_clean_up();
 
-    s_sleep_for_dispatch_queue();
     return result;
 }
 AWS_TEST_CASE(outgoing_tcp_sock_error, s_test_outgoing_tcp_sock_error)
@@ -1370,8 +1354,6 @@ static int s_test_incoming_tcp_sock_errors(struct aws_allocator *allocator, void
 
         aws_event_loop_group_release(el_group);
         aws_io_library_clean_up();
-
-        s_sleep_for_dispatch_queue();
     }
     return 0;
 }
@@ -1415,7 +1397,6 @@ static int s_test_incoming_duplicate_tcp_bind_errors(struct aws_allocator *alloc
     aws_socket_clean_up(&incoming);
     aws_event_loop_group_release(el_group);
     aws_io_library_clean_up();
-    s_sleep_for_dispatch_queue();
     return 0;
 }
 
@@ -1671,8 +1652,6 @@ static int s_test_wrong_thread_read_write_fails(struct aws_allocator *allocator,
     aws_socket_clean_up(&socket);
     aws_event_loop_group_release(el_group);
     aws_io_library_clean_up();
-
-    s_sleep_for_dispatch_queue();
 
     return 0;
 }
@@ -1946,8 +1925,6 @@ static int s_cleanup_in_accept_doesnt_explode(struct aws_allocator *allocator, v
     aws_event_loop_group_release(el_group);
     aws_io_library_clean_up();
 
-    s_sleep_for_dispatch_queue();
-
     return 0;
 }
 AWS_TEST_CASE(cleanup_in_accept_doesnt_explode, s_cleanup_in_accept_doesnt_explode)
@@ -2120,8 +2097,6 @@ static int s_cleanup_in_write_cb_doesnt_explode(struct aws_allocator *allocator,
 
     aws_event_loop_group_release(el_group);
     aws_io_library_clean_up();
-
-    s_sleep_for_dispatch_queue();
 
     return 0;
 }
@@ -2377,7 +2352,6 @@ static int s_sock_write_cb_is_async(struct aws_allocator *allocator, void *ctx) 
     aws_event_loop_group_release(el_group);
     aws_io_library_clean_up();
 
-    s_sleep_for_dispatch_queue();
     return 0;
 }
 AWS_TEST_CASE(sock_write_cb_is_async, s_sock_write_cb_is_async)


### PR DESCRIPTION
Applies the changes in https://github.com/awslabs/aws-c-io/pull/708 to the nw_socket branch.  Removes all dispatch queue sleep invocations in tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
