### PR TITLE
Fix Windows server-side for TLS 1.3

### DIFF
--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -2090,7 +2090,7 @@ static DWORD s_get_disabled_protocols(
                 break;
         }
 #if defined(SP_PROT_TLS1_3_SERVER)
-        if (!disable_tls13) {
+        if (disable_tls13) {
             bit_disabled_protocols |= SP_PROT_TLS1_3_SERVER;
         }
 #endif


### PR DESCRIPTION
*Issue #, if available:*

TLS 1.3 is incorrectly disabled for server on Windows platforms.

*Description of changes:*

Fix the check in the function determining TLS versions to enable/disable.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
