### PR TITLE
AWS_IO_TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05 is not supported now.

### DIFF
--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -1539,9 +1539,6 @@ static struct aws_tls_ctx *s_tls_ctx_new(
             /* The specific PQ policy used here may change over time. */
             security_policy = "AWS-CRT-SDK-TLSv1.2-2023-PQ";
             break;
-        case AWS_IO_TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05:
-            security_policy = "PQ-TLS-1-0-2021-05-26";
-            break;
         case AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10:
             security_policy = "AWS-CRT-SDK-TLSv1.2-2023-PQ";
             break;

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -268,8 +268,6 @@ bool aws_tls_is_cipher_pref_supported(enum aws_tls_cipher_pref cipher_pref) {
             return true;
             /* PQ Crypto no-ops on android for now */
 #ifndef ANDROID
-        case AWS_IO_TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05:
-            return true;
         case AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10:
             return true;
         case AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT:


### PR DESCRIPTION
*Issue #, if available:*

- https://github.com/awslabs/aws-c-io/blob/9392c7b06673db4751940a695a60dad8796d67bf/include/aws/io/tls_channel_handler.h#L37 marks the `AWS_IO_TLS_CIPHER_PREF_PQ_TLSv1_0_2021_05` deprecated
- There was a plan for S2N to keep this policies around with graceful fallback, but S2N decided to fully deprecated the policy, [here](https://github.com/aws/s2n-tls/pull/5194/commits/e8a0710b3fcd02145c9cda7402d437259b0d3473#diff-13800ddfa8b6bc9cd94fd97a635ade9381addd21a700125683901b74a4c7471e), so, it's not supported now.
- Remove the cipher from the supported list.

*Description of changes:*


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
