### PR TITLE
Fix casing on Windows header files

### DIFF
--- a/include/aws/io/private/event_loop_impl.h
+++ b/include/aws/io/private/event_loop_impl.h
@@ -25,8 +25,8 @@ typedef void(aws_event_loop_on_completion_fn)(
     size_t num_bytes_transferred);
 
 /**
- * The aws_win32_OVERLAPPED struct is layout-compatible with OVERLAPPED as defined in <Windows.h>. It is used
- * here to avoid pulling in a dependency on <Windows.h> which would also bring along a lot of bad macros, such
+ * The aws_win32_OVERLAPPED struct is layout-compatible with OVERLAPPED as defined in <windows.h>. It is used
+ * here to avoid pulling in a dependency on <windows.h> which would also bring along a lot of bad macros, such
  * as redefinitions of GetMessage and GetObject. Note that the OVERLAPPED struct layout in the Windows SDK can
  * never be altered without breaking binary compatibility for every existing third-party executable, so there
  * is no need to worry about keeping this definition in sync.

--- a/include/aws/io/private/pki_utils.h
+++ b/include/aws/io/private/pki_utils.h
@@ -9,7 +9,7 @@
 #ifdef _WIN32
 /* It's ok to include external headers because this is a PRIVATE header file
  * (it is usually a crime to include windows.h from header file) */
-#    include <Windows.h>
+#    include <windows.h>
 #endif /* _WIN32 */
 
 #ifdef AWS_OS_APPLE

--- a/source/windows/host_resolver.c
+++ b/source/windows/host_resolver.c
@@ -3,7 +3,7 @@
  * SPDX-License-Identifier: Apache-2.0.
  */
 
-/* don't move this below the Windows.h include!!!!*/
+/* don't move this below the windows.h include!!!!*/
 #include <winsock2.h>
 #include <ws2tcpip.h>
 

--- a/source/windows/iocp/iocp_event_loop.c
+++ b/source/windows/iocp/iocp_event_loop.c
@@ -13,7 +13,7 @@
 #include <aws/io/logging.h>
 #include <aws/io/private/event_loop_impl.h>
 
-#include <Windows.h>
+#include <windows.h>
 
 /* The next set of struct definitions are taken directly from the
     windows documentation. We can't include the header files directly

--- a/source/windows/iocp/pipe.c
+++ b/source/windows/iocp/pipe.c
@@ -12,7 +12,7 @@
 #include <stdbool.h>
 #include <stdio.h>
 
-#include <Windows.h>
+#include <windows.h>
 
 enum read_end_state {
     /* Pipe is open. */

--- a/source/windows/iocp/socket.c
+++ b/source/windows/iocp/socket.c
@@ -9,9 +9,9 @@ keep the bellow includes where they are. Also, sorry about the C++ style comment
 below, clang-format doesn't work (at least on my version) with the c-style comments.*/
 
 // clang-format off
-#include <WS2tcpip.h>
-#include <MSWSock.h>
-#include <Mstcpip.h>
+#include <ws2tcpip.h>
+#include <mswsock.h>
+#include <mstcpip.h>
 // clang-format on
 
 #include <aws/io/private/socket_impl.h>

--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -18,7 +18,7 @@
 #include <aws/io/private/tls_channel_handler_shared.h>
 #include <aws/io/statistics.h>
 
-#include <Windows.h>
+#include <windows.h>
 
 #include <schannel.h>
 #include <security.h>

--- a/source/windows/shared_library.c
+++ b/source/windows/shared_library.c
@@ -4,7 +4,7 @@
  */
 
 // clang-format off
-#include <Windows.h>
+#include <windows.h>
 #include <libloaderapi.h>
 // clang-format on
 

--- a/source/windows/windows_pki_utils.c
+++ b/source/windows/windows_pki_utils.c
@@ -10,9 +10,9 @@
 
 #include <aws/io/logging.h>
 
-#include <windows.h>
 #include <stdio.h>
 #include <string.h>
+#include <windows.h>
 
 #ifdef _MSC_VER
 #    pragma warning(disable : 4221) /* aggregate initializer using local variable addresses */

--- a/source/windows/windows_pki_utils.c
+++ b/source/windows/windows_pki_utils.c
@@ -10,7 +10,7 @@
 
 #include <aws/io/logging.h>
 
-#include <Windows.h>
+#include <windows.h>
 #include <stdio.h>
 #include <string.h>
 

--- a/source/windows/winsock_init.c
+++ b/source/windows/winsock_init.c
@@ -8,9 +8,9 @@ go around re-ordering windows header files. Also, sorry about the C++ style comm
 below, clang-format doesn't work (at least on my version) with the c-style comments. */
 
 // clang-format off
-#include <WinSock2.h>
-#include <WS2tcpip.h>
-#include <MSWSock.h>
+#include <winsock2.h>
+#include <ws2tcpip.h>
+#include <mswsock.h>
 // clang-format on
 
 #include <aws/io/logging.h>


### PR DESCRIPTION
*Description of changes:*
Follow up to #728 to fix lint. 

This change corrects Windows-specific header names to use canonical casing, which helps with cross-compilation on non-Windows hosts.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
