### PR TITLE
Fix warnings in iOS Cross Compile CI

### DIFF
--- a/source/darwin/nw_socket.c
+++ b/source/darwin/nw_socket.c
@@ -526,7 +526,7 @@ static void s_setup_tcp_options(nw_protocol_options_t tcp_options, const struct 
     }
 
     if (g_aws_channel_max_fragment_size < KB_16) {
-        nw_tcp_options_set_maximum_segment_size(tcp_options, g_aws_channel_max_fragment_size);
+        nw_tcp_options_set_maximum_segment_size(tcp_options, (uint32_t) g_aws_channel_max_fragment_size);
     }
 }
 
@@ -625,7 +625,7 @@ static void s_tls_verification_block(
     } else {
         char description_buffer[256];
         s_get_error_description(error, description_buffer, sizeof(description_buffer));
-        int crt_error_code = s_determine_socket_error(CFErrorGetCode(error));
+        int crt_error_code = s_determine_socket_error((int) CFErrorGetCode(error));
         AWS_LOGF_DEBUG(
             AWS_LS_IO_TLS,
             "nw_socket=%p: nw_socket SecTrustEvaluateWithError failed with crt error code: %d : %s translated from CF "

--- a/source/darwin/nw_socket.c
+++ b/source/darwin/nw_socket.c
@@ -526,7 +526,7 @@ static void s_setup_tcp_options(nw_protocol_options_t tcp_options, const struct 
     }
 
     if (g_aws_channel_max_fragment_size < KB_16) {
-        nw_tcp_options_set_maximum_segment_size(tcp_options, (uint32_t) g_aws_channel_max_fragment_size);
+        nw_tcp_options_set_maximum_segment_size(tcp_options, (uint32_t)g_aws_channel_max_fragment_size);
     }
 }
 
@@ -625,7 +625,7 @@ static void s_tls_verification_block(
     } else {
         char description_buffer[256];
         s_get_error_description(error, description_buffer, sizeof(description_buffer));
-        int crt_error_code = s_determine_socket_error((int) CFErrorGetCode(error));
+        int crt_error_code = s_determine_socket_error((int)CFErrorGetCode(error));
         AWS_LOGF_DEBUG(
             AWS_LS_IO_TLS,
             "nw_socket=%p: nw_socket SecTrustEvaluateWithError failed with crt error code: %d : %s translated from CF "


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- iOS cross compile CI is failing in aws-crt-cpp with lint warnings 
```
     /usr/bin/clang -x c -fmessage-length\=0 -fdiagnostics-show-note-include-stack -fmacro-backtrace-limit\=0 -fno-color-diagnostics -Wno-trigraphs -Wno-missing-field-initializers -Wno-missing-prototypes -Wno-return-type -Wno-missing-braces -Wparentheses -Wswitch -Wno-unused-function -Wno-unused-label -Wno-unused-parameter -Wno-unused-variable -Wunused-value -Wno-empty-body -Wno-uninitialized -Wno-unknown-pragmas -Wno-shadow -Wno-four-char-constants -Wno-conversion -Wno-constant-conversion -Wno-int-conversion -Wno-bool-conversion -Wno-enum-conversion -Wno-float-conversion -Wno-non-literal-null-conversion -Wno-objc-literal-conversion -Wshorten-64-to-32 -Wpointer-sign -Wno-newline-eof -Wno-implicit-fallthrough -fstrict-aliasing -Wdeprecated-declarations -Wno-sign-conversion -Wno-infinite-recursion -Wno-comma -Wno-block-capture-autoreleasing -Wno-strict-prototypes -Wno-semicolon-before-method-body -Wall -Wstrict-prototypes -Werror -Wextra -Wno-long-long -Wgnu -Wno-gnu-zero-variadic-macro-arguments @/Users/runner/work/aws-crt-cpp/aws-crt-cpp/aws-crt-cpp/build/aws-crt-cpp/build/aws-c-io.build/RelWithDebInfo-iphoneos/Objects-normal/arm64/7187679823f38a2a940e0043cdf9d637-common-args.resp -MMD -MT dependencies -MF /Users/runner/work/aws-crt-cpp/aws-crt-cpp/aws-crt-cpp/build/aws-crt-cpp/build/aws-c-io.build/RelWithDebInfo-iphoneos/Objects-normal/arm64/nw_socket.d --serialize-diagnostics /Users/runner/work/aws-crt-cpp/aws-crt-cpp/aws-crt-cpp/build/aws-crt-cpp/build/aws-c-io.build/RelWithDebInfo-iphoneos/Objects-normal/arm64/nw_socket.dia -c /Users/runner/work/aws-crt-cpp/aws-crt-cpp/aws-crt-cpp/crt/aws-c-io/source/darwin/nw_socket.c -o /Users/runner/work/aws-crt-cpp/aws-crt-cpp/aws-crt-cpp/build/aws-crt-cpp/build/aws-c-io.build/RelWithDebInfo-iphoneos/Objects-normal/arm64/nw_socket.o
/Users/runner/work/aws-crt-cpp/aws-crt-cpp/aws-crt-cpp/crt/aws-c-io/source/darwin/nw_socket.c:520:62: error: implicit conversion loses integer precision: 'size_t' (aka 'unsigned long') to 'uint32_t' (aka 'unsigned int') [-Werror,-Wshorten-64-to-32]
        nw_tcp_options_set_maximum_segment_size(tcp_options, g_aws_channel_max_fragment_size);
        ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~              ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
/Users/runner/work/aws-crt-cpp/aws-crt-cpp/aws-crt-cpp/crt/aws-c-io/source/darwin/nw_socket.c:619:55: error: implicit conversion loses integer precision: 'CFIndex' (aka 'long') to 'int' [-Werror,-Wshorten-64-to-32]
        int crt_error_code = s_determine_socket_error(CFErrorGetCode(error));
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
