### PR TITLE
Support s2n security policy for TLS 1.2 and FIPS

### DIFF
--- a/include/aws/io/tls_channel_handler.h
+++ b/include/aws/io/tls_channel_handler.h
@@ -46,6 +46,11 @@ enum aws_tls_cipher_pref {
     /* Recommended default policy with post-quantum algorithm support. This policy may change over time. */
     AWS_IO_TLS_CIPHER_PREF_PQ_DEFAULT = 8,
 
+    /* This security policy is based on AWS-CRT-SDK-TLSv1.2-2023 (the default when a minimum TLS version is TLS 1.2),
+     * with tightened security. This security policy is FIPS-complaint.
+     */
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_2_FIPS = 9,
+
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 0xFFFF
 };
 

--- a/include/aws/io/tls_channel_handler.h
+++ b/include/aws/io/tls_channel_handler.h
@@ -49,7 +49,7 @@ enum aws_tls_cipher_pref {
     /* This security policy is based on AWS-CRT-SDK-TLSv1.2-2023 (the default when a minimum TLS version is TLS 1.2),
      * with tightened security. This security policy is FIPS-complaint.
      */
-    AWS_IO_TLS_CIPHER_PREF_TLSV1_2_FIPS = 9,
+    AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07 = 9,
 
     AWS_IO_TLS_CIPHER_PREF_END_RANGE = 0xFFFF
 };

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -1554,6 +1554,14 @@ static struct aws_tls_ctx *s_tls_ctx_new(
     }
 
     AWS_ASSERT(security_policy != NULL);
+
+    AWS_LOGF_DEBUG(
+        AWS_LS_IO_TLS,
+        "Set security policy to %s (minimum_tls_version: %d; cipher_pref: %d)",
+        security_policy,
+        (int)options->minimum_tls_version,
+        (int)options->cipher_pref);
+
     if (s2n_config_set_cipher_preferences(s2n_ctx->s2n_config, security_policy)) {
         AWS_LOGF_ERROR(
             AWS_LS_IO_TLS,

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -274,6 +274,8 @@ bool aws_tls_is_cipher_pref_supported(enum aws_tls_cipher_pref cipher_pref) {
             return true;
 #endif
 
+        case AWS_IO_TLS_CIPHER_PREF_TLSV1_2_FIPS:
+            return true;
         default:
             return false;
     }
@@ -1541,6 +1543,9 @@ static struct aws_tls_ctx *s_tls_ctx_new(
             break;
         case AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10:
             security_policy = "AWS-CRT-SDK-TLSv1.2-2023-PQ";
+            break;
+        case AWS_IO_TLS_CIPHER_PREF_TLSV1_2_FIPS:
+            security_policy = "AWS-CRT-SDK-TLSv1.2-2025";
             break;
         default:
             AWS_LOGF_ERROR(AWS_LS_IO_TLS, "Unrecognized TLS Cipher Preference: %d", options->cipher_pref);

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -274,7 +274,7 @@ bool aws_tls_is_cipher_pref_supported(enum aws_tls_cipher_pref cipher_pref) {
             return true;
 #endif
 
-        case AWS_IO_TLS_CIPHER_PREF_TLSV1_2_FIPS:
+        case AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07:
             return true;
         default:
             return false;
@@ -1544,7 +1544,7 @@ static struct aws_tls_ctx *s_tls_ctx_new(
         case AWS_IO_TLS_CIPHER_PREF_PQ_TLSV1_2_2024_10:
             security_policy = "AWS-CRT-SDK-TLSv1.2-2023-PQ";
             break;
-        case AWS_IO_TLS_CIPHER_PREF_TLSV1_2_FIPS:
+        case AWS_IO_TLS_CIPHER_PREF_TLSV1_2_2025_07:
             security_policy = "AWS-CRT-SDK-TLSv1.2-2025";
             break;
         default:


### PR DESCRIPTION
Support a new [s2n security policy](https://github.com/aws/s2n-tls/pull/5375), which provides better security settings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
