### PR TITLE
stop packing future variable to avoid tsan data race warnings

### DIFF
--- a/source/future.c
+++ b/source/future.c
@@ -48,6 +48,7 @@ struct aws_future_impl {
     } result_dtor;
     int error_code;
 
+    unsigned int sizeof_result;
     enum aws_future_type type;
     bool is_done;
     bool owns_result;

--- a/source/future.c
+++ b/source/future.c
@@ -47,12 +47,10 @@ struct aws_future_impl {
         aws_future_impl_result_release_fn *release;
     } result_dtor;
     int error_code;
-    /* sum of bit fields should be 32 */
-#define BIT_COUNT_FOR_SIZEOF_RESULT 27
-    unsigned int sizeof_result : BIT_COUNT_FOR_SIZEOF_RESULT;
-    unsigned int type : 3; /* aws_future_type */
-    unsigned int is_done : 1;
-    unsigned int owns_result : 1;
+
+    enum aws_future_type type;
+    bool is_done;
+    bool owns_result;
 };
 
 static void s_future_impl_result_dtor(struct aws_future_impl *future, void *result_addr) {
@@ -186,7 +184,7 @@ bool aws_future_impl_is_done(const struct aws_future_impl *future) {
 
     /* BEGIN CRITICAL SECTION */
     aws_mutex_lock(mutable_lock);
-    bool is_done = future->is_done != 0;
+    bool is_done = future->is_done;
     aws_mutex_unlock(mutable_lock);
     /* END CRITICAL SECTION */
 
@@ -216,14 +214,7 @@ void aws_future_impl_get_result_by_move(struct aws_future_impl *future, void *ds
     void *result_addr = aws_future_impl_get_result_address(future);
     memcpy(dst_address, result_addr, future->sizeof_result);
     memset(result_addr, 0, future->sizeof_result);
-
-    /* BEGIN CRITICAL SECTION */
-    aws_mutex_lock(&future->lock);
-
     future->owns_result = false;
-
-    aws_mutex_unlock(&future->lock);
-    /* END CRITICAL SECTION */
 }
 
 /* Data for invoking callback as a task on an event-loop */
@@ -369,7 +360,7 @@ static bool s_future_impl_register_callback(
 
     AWS_FATAL_ASSERT(future->callback.fn == NULL && "Future done callback must only be set once");
 
-    bool already_done = future->is_done != 0;
+    bool already_done = future->is_done;
 
     /* if not done, store callback for later */
     if (!already_done) {
@@ -463,7 +454,7 @@ void aws_future_impl_register_channel_callback(
 
 static bool s_future_impl_is_done_pred(void *user_data) {
     struct aws_future_impl *future = user_data;
-    return future->is_done != 0;
+    return future->is_done;
 }
 
 bool aws_future_impl_wait(const struct aws_future_impl *future, uint64_t timeout_ns) {

--- a/source/future.c
+++ b/source/future.c
@@ -216,7 +216,14 @@ void aws_future_impl_get_result_by_move(struct aws_future_impl *future, void *ds
     void *result_addr = aws_future_impl_get_result_address(future);
     memcpy(dst_address, result_addr, future->sizeof_result);
     memset(result_addr, 0, future->sizeof_result);
+
+    /* BEGIN CRITICAL SECTION */
+    aws_mutex_lock(&future->lock);
+
     future->owns_result = false;
+
+    aws_mutex_unlock(&future->lock);
+    /* END CRITICAL SECTION */
 }
 
 /* Data for invoking callback as a task on an event-loop */

--- a/source/future.c
+++ b/source/future.c
@@ -48,7 +48,7 @@ struct aws_future_impl {
     } result_dtor;
     int error_code;
 
-    unsigned int sizeof_result;
+    size_t sizeof_result;
     enum aws_future_type type;
     bool is_done;
     bool owns_result;
@@ -107,9 +107,7 @@ static struct aws_future_impl *s_future_impl_new(struct aws_allocator *alloc, si
     struct aws_future_impl *future = aws_mem_calloc(alloc, 1, total_size);
     future->alloc = alloc;
 
-    /* we store sizeof_result in a bit field, ensure the number will fit */
-    AWS_ASSERT(sizeof_result <= (UINT_MAX >> (32 - BIT_COUNT_FOR_SIZEOF_RESULT)));
-    future->sizeof_result = (unsigned int)sizeof_result;
+    future->sizeof_result = sizeof_result;
 
     aws_ref_count_init(&future->ref_count, future, s_future_impl_destroy);
     aws_mutex_init(&future->lock);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
future bitpacks several variables into uint32
https://github.com/awslabs/aws-c-io/blob/main/source/future.c#L54

tsan will complain if those variables are accessed from different threads.
this pr fixes the data race from aws_future_impl_get_result_by_move updating owns_data variable and aws_future_impl_set_error reading is_done, by unpacking the variables.

https://github.com/awslabs/aws-c-io/blob/25faa8d6df108b0214345549c44ab6b75ad31e65/source/future.c#L219
https://github.com/awslabs/aws-c-io/blob/25faa8d6df108b0214345549c44ab6b75ad31e65/source/future.c#L302

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
