### PR TITLE
Fix warnings found by the Undefined Behavior Sanitizer

### DIFF
--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -216,7 +216,8 @@ static void s_event_loop_destroy_async_thread_fn(void *thread_data) {
     aws_thread_current_at_exit(s_event_loop_group_thread_exit, el_group);
 }
 
-static void s_aws_event_loop_group_shutdown_async(struct aws_event_loop_group *el_group) {
+static void s_aws_event_loop_group_shutdown_async(void *user_data) {
+    struct aws_event_loop_group *el_group = user_data;
 
     /* It's possible that the last refcount was released on an event-loop thread,
      * so we would deadlock if we waited here for all the event-loop threads to shut down.

--- a/source/host_resolver.c
+++ b/source/host_resolver.c
@@ -1496,7 +1496,8 @@ static struct aws_host_resolver_vtable s_vtable = {
     .purge_host_cache = s_resolver_purge_host_cache,
 };
 
-static void s_aws_host_resolver_destroy(struct aws_host_resolver *resolver) {
+static void s_aws_host_resolver_destroy(void *user_data) {
+    struct aws_host_resolver *resolver = user_data;
     AWS_ASSERT(resolver->vtable && resolver->vtable->destroy);
     resolver->vtable->destroy(resolver);
 }

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -1405,7 +1405,8 @@ struct aws_channel_handler *aws_tls_server_handler_new(
     return s_new_tls_handler(allocator, options, slot, S2N_SERVER);
 }
 
-static void s_s2n_ctx_destroy(struct s2n_ctx *s2n_ctx) {
+static void s_s2n_ctx_destroy(void *user_data) {
+    struct s2n_ctx *s2n_ctx = user_data;
     if (s2n_ctx != NULL) {
         if (s2n_ctx->s2n_config) {
             s2n_config_free(s2n_ctx->s2n_config);

--- a/source/stream.c
+++ b/source/stream.c
@@ -188,7 +188,8 @@ static int s_aws_input_stream_byte_cursor_get_length(struct aws_input_stream *st
     return AWS_OP_SUCCESS;
 }
 
-static void s_aws_input_stream_byte_cursor_destroy(struct aws_input_stream_byte_cursor_impl *impl) {
+static void s_aws_input_stream_byte_cursor_destroy(void *user_data) {
+    struct aws_input_stream_byte_cursor_impl *impl = user_data;
     aws_mem_release(impl->allocator, impl);
 }
 
@@ -271,7 +272,8 @@ static int s_aws_input_stream_file_get_length(struct aws_input_stream *stream, i
     return aws_file_get_length(impl->file, length);
 }
 
-static void s_aws_input_stream_file_destroy(struct aws_input_stream_file_impl *impl) {
+static void s_aws_input_stream_file_destroy(void *user_data) {
+    struct aws_input_stream_file_impl *impl = user_data;
 
     if (impl->close_on_clean_up && impl->file) {
         fclose(impl->file);


### PR DESCRIPTION
Fixes a large number of warnings found when running the tests with the undefined behavior sanitizer enabled during build. (116 warnings)
The warnings are recoverable by the sanitizer and will therefor not fail the CI build.

All warnings are like:
```
aws-c-common/source/ref_count.c:29:9: runtime error: call to function s_aws_host_resolver_destroy through pointer to incorrect function type 'void (*)(void *)'
aws-c-common/source/ref_count.c:29:9: runtime error: call to function s_client_connection_args_destroy through pointer to incorrect function type 'void (*)(void *)'
...
```

The warnings are also found when a user incorporates `aws-sdk-cpp` into a project and build it using a UB sanitizer.

The issues corrected can be reproduced with the following:
```
INSTALL_PATH=/tmp/aws-install

git clone git@github.com:awslabs/aws-lc.git
CC=clang-18 CXX=clang++-18 cmake -G Ninja -S aws-lc -B aws-lc/build -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH} -DUBSAN=ON
ninja -vv -C aws-lc/build install

git clone git@github.com:aws/s2n-tls.git
CC=clang-18 CXX=clang++-18 cmake -G Ninja -S s2n-tls -B s2n-tls/build -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH} -DCMAKE_PREFIX_PATH=${INSTALL_PATH} -DUBSAN=ON
ninja -vv -C s2n-tls/build install

git clone git@github.com:awslabs/aws-c-common.git
CC=clang-18 CXX=clang++-18 cmake -G Ninja -S aws-c-common -B aws-c-common/build -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH} -DENABLE_SANITIZERS=ON -DSANITIZERS="undefined"
ninja -vv -C aws-c-common/build install

git clone git@github.com:awslabs/aws-c-cal.git
CC=clang-18 CXX=clang++-18 cmake -G Ninja -S aws-c-cal -B aws-c-cal/build -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH} -DCMAKE_PREFIX_PATH=${INSTALL_PATH} -DENABLE_SANITIZERS=ON -DSANITIZERS="undefined"
ninja -vv -C aws-c-cal/build install

git clone git@github.com:awslabs/aws-c-io.git
CC=clang-18 CXX=clang++-18 cmake -G Ninja -S aws-c-io -B aws-c-io/build -DCMAKE_INSTALL_PREFIX=${INSTALL_PATH} -DCMAKE_PREFIX_PATH=${INSTALL_PATH} -DENABLE_SANITIZERS=ON -DSANITIZERS="undefined"
ninja -C aws-c-io/build all
ninja -C aws-c-io/build test

grep "runtime error" aws-c-io/build/Testing/Temporary/LastTest.log
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
