### PR TITLE
Scheduled Iteration Mem-release Order

### DIFF
--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -171,7 +171,8 @@ static void s_scheduled_iteration_entry_destroy(struct scheduled_iteration_entry
         return;
     }
 
-    struct aws_dispatch_loop *dispatch_loop_for_release = entry->dispatch_loop aws_mem_release(entry->allocator, entry);
+    struct aws_dispatch_loop *dispatch_loop_for_release = entry->dispatch_loop;
+    aws_mem_release(entry->allocator, entry);
     s_dispatch_loop_release(dispatch_loop_for_release);
 }
 

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -171,8 +171,8 @@ static void s_scheduled_iteration_entry_destroy(struct scheduled_iteration_entry
         return;
     }
 
-    s_dispatch_loop_release(entry->dispatch_loop);
-    aws_mem_release(entry->allocator, entry);
+    struct aws_dispatch_loop *dispatch_loop_for_release = entry->dispatch_loop aws_mem_release(entry->allocator, entry);
+    s_dispatch_loop_release(dispatch_loop_for_release);
 }
 
 /* Manually called to destroy an aws_event_loop */


### PR DESCRIPTION
Just to be overly safe in memory release timing, release the memory for a run iteration before releasing the dispatch loop.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
