### PR TITLE
Serialized scheduling

### DIFF
--- a/.github/workflows/proof-alarm.yml
+++ b/.github/workflows/proof-alarm.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Check
       run: |
         TMPFILE=$(mktemp)
-        echo "5109c3b2748a98621ebdc05756fdfa51 source/linux/epoll_event_loop.c" > $TMPFILE
+        echo "42e574284e4e0c4af33bf3ab16114bcc source/linux/epoll_event_loop.c" > $TMPFILE
         md5sum --check $TMPFILE
 
     # No further steps if successful

--- a/include/aws/io/event_loop.h
+++ b/include/aws/io/event_loop.h
@@ -35,6 +35,7 @@ struct aws_event_loop_vtable {
     int (*stop)(struct aws_event_loop *event_loop);
     int (*wait_for_stop_completion)(struct aws_event_loop *event_loop);
     void (*schedule_task_now)(struct aws_event_loop *event_loop, struct aws_task *task);
+    void (*schedule_task_now_serialized)(struct aws_event_loop *event_loop, struct aws_task *task);
     void (*schedule_task_future)(struct aws_event_loop *event_loop, struct aws_task *task, uint64_t run_at_nanos);
     void (*cancel_task)(struct aws_event_loop *event_loop, struct aws_task *task);
     int (*connect_to_io_completion_port)(struct aws_event_loop *event_loop, struct aws_io_handle *handle);
@@ -115,6 +116,15 @@ AWS_EXTERN_C_BEGIN
  */
 AWS_IO_API
 void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct aws_task *task);
+
+/**
+ * Variant of aws_event_loop_schedule_task_now that forces all tasks to go through the cross thread task queue,
+ * guaranteeing that order-of-submission is order-of-execution.  If you need this guarantee, you must use this
+ * function; the base function contains short-circuiting logic that breaks ordering invariants.  Beyond that, all
+ * properties of aws_event_loop_schedule_task_now apply to this function as well.
+ */
+AWS_IO_API
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
 
 /**
  * The event loop will schedule the task and run it at the specified time.

--- a/include/aws/io/event_loop.h
+++ b/include/aws/io/event_loop.h
@@ -122,6 +122,9 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
  * guaranteeing that order-of-submission is order-of-execution.  If you need this guarantee, you must use this
  * function; the base function contains short-circuiting logic that breaks ordering invariants.  Beyond that, all
  * properties of aws_event_loop_schedule_task_now apply to this function as well.
+ *
+ * Serialization guarantee does not apply to task cancellation (which can occur out-of-order or even out-of-thread in
+ * certain cases).
  */
 AWS_IO_API
 void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -32,6 +32,7 @@ static int s_run(struct aws_event_loop *event_loop);
 static int s_stop(struct aws_event_loop *event_loop);
 static int s_wait_for_stop_completion(struct aws_event_loop *event_loop);
 static void s_schedule_task_now(struct aws_event_loop *event_loop, struct aws_task *task);
+static void s_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
 static void s_schedule_task_future(struct aws_event_loop *event_loop, struct aws_task *task, uint64_t run_at_nanos);
 static void s_cancel_task(struct aws_event_loop *event_loop, struct aws_task *task);
 static int s_connect_to_io_completion_port(struct aws_event_loop *event_loop, struct aws_io_handle *handle);
@@ -73,6 +74,7 @@ static struct aws_event_loop_vtable s_vtable = {
     .stop = s_stop,
     .wait_for_stop_completion = s_wait_for_stop_completion,
     .schedule_task_now = s_schedule_task_now,
+    .schedule_task_now_serialized = s_schedule_task_now_serialized,
     .schedule_task_future = s_schedule_task_future,
     .cancel_task = s_cancel_task,
     .connect_to_io_completion_port = s_connect_to_io_completion_port,
@@ -687,6 +689,11 @@ static void s_schedule_task_common(struct aws_event_loop *event_loop, struct aws
 }
 
 static void s_schedule_task_now(struct aws_event_loop *event_loop, struct aws_task *task) {
+    s_schedule_task_common(event_loop, task, 0 /* zero denotes "now" task */);
+}
+
+/* dispatch queue event loop impl does not have any short-circuiting, so just use the base scheduling logic */
+static void s_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task) {
     s_schedule_task_common(event_loop, task, 0 /* zero denotes "now" task */);
 }
 

--- a/source/darwin/dispatch_queue_event_loop.c
+++ b/source/darwin/dispatch_queue_event_loop.c
@@ -32,7 +32,6 @@ static int s_run(struct aws_event_loop *event_loop);
 static int s_stop(struct aws_event_loop *event_loop);
 static int s_wait_for_stop_completion(struct aws_event_loop *event_loop);
 static void s_schedule_task_now(struct aws_event_loop *event_loop, struct aws_task *task);
-static void s_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task);
 static void s_schedule_task_future(struct aws_event_loop *event_loop, struct aws_task *task, uint64_t run_at_nanos);
 static void s_cancel_task(struct aws_event_loop *event_loop, struct aws_task *task);
 static int s_connect_to_io_completion_port(struct aws_event_loop *event_loop, struct aws_io_handle *handle);
@@ -74,7 +73,8 @@ static struct aws_event_loop_vtable s_vtable = {
     .stop = s_stop,
     .wait_for_stop_completion = s_wait_for_stop_completion,
     .schedule_task_now = s_schedule_task_now,
-    .schedule_task_now_serialized = s_schedule_task_now_serialized,
+    /* dispatch queue event loop impl does not have any short-circuiting, so just use the base scheduling logic */
+    .schedule_task_now_serialized = s_schedule_task_now,
     .schedule_task_future = s_schedule_task_future,
     .cancel_task = s_cancel_task,
     .connect_to_io_completion_port = s_connect_to_io_completion_port,
@@ -689,11 +689,6 @@ static void s_schedule_task_common(struct aws_event_loop *event_loop, struct aws
 }
 
 static void s_schedule_task_now(struct aws_event_loop *event_loop, struct aws_task *task) {
-    s_schedule_task_common(event_loop, task, 0 /* zero denotes "now" task */);
-}
-
-/* dispatch queue event loop impl does not have any short-circuiting, so just use the base scheduling logic */
-static void s_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task) {
     s_schedule_task_common(event_loop, task, 0 /* zero denotes "now" task */);
 }
 

--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -625,6 +625,12 @@ void aws_event_loop_schedule_task_now(struct aws_event_loop *event_loop, struct 
     event_loop->vtable->schedule_task_now(event_loop, task);
 }
 
+void aws_event_loop_schedule_task_now_serialized(struct aws_event_loop *event_loop, struct aws_task *task) {
+    AWS_ASSERT(task);
+    AWS_ASSERT(event_loop->vtable && event_loop->vtable->schedule_task_now_serialized);
+    event_loop->vtable->schedule_task_now_serialized(event_loop, task);
+}
+
 void aws_event_loop_schedule_task_future(
     struct aws_event_loop *event_loop,
     struct aws_task *task,

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -59,6 +59,7 @@ add_test_case(event_loop_epoll_creation)
 add_test_case(event_loop_iocp_creation)
 add_test_case(event_loop_kqueue_creation)
 add_test_case(event_loop_dispatch_queue_creation)
+add_test_case(event_loop_serialized_scheduling)
 
 add_test_case(io_testing_channel)
 

--- a/tests/event_loop_test.c
+++ b/tests/event_loop_test.c
@@ -1529,7 +1529,12 @@ static void s_in_event_loop_scheduling_task(struct aws_task *task, void *arg, en
 
 /*
  * Test that verifies serialized scheduling by running two concurrent executions, one on the target event loop, one
- * on an external thread, so that
+ * on an external thread.  The two submit tasks as fast as they can (although the event loop thread must yield
+ * occasionally in order for the scheduled tasks to get serviced) and we verify that order-of-execution matches
+ * order-of-submission.
+ *
+ * There are a couple of sleep(0)s in the logic to help achieve some approximate mutex-locking fairness.  Without them,
+ * the external thread was successfully taking the lock at a much higher rate (30x) than the in-event-loop execution.
  */
 static int s_test_event_loop_serialized_scheduling(struct aws_allocator *allocator, void *ctx) {
 

--- a/tests/event_loop_test.c
+++ b/tests/event_loop_test.c
@@ -1550,7 +1550,7 @@ static int s_test_event_loop_serialized_scheduling(struct aws_allocator *allocat
     struct aws_event_loop *event_loop = aws_event_loop_group_get_next_loop(event_loop_group);
 
     struct serialized_scheduling_context context;
-    s_serialized_scheduling_context_init(&context, allocator, event_loop, 1000000);
+    s_serialized_scheduling_context_init(&context, allocator, event_loop, 100000);
 
     struct aws_thread external_thread;
     aws_thread_init(&external_thread, allocator);

--- a/tests/event_loop_test.c
+++ b/tests/event_loop_test.c
@@ -1372,8 +1372,8 @@ static void s_process_serialized_scheduling_task(struct aws_task *task, void *ar
 
     test_task->test_context->synced_data.last_processed_id = test_task->id;
 
-    aws_mutex_unlock(&test_task->test_context->lock);
     aws_condition_variable_notify_all(&test_task->test_context->signal);
+    aws_mutex_unlock(&test_task->test_context->lock);
 
     aws_mem_release(test_task->allocator, test_task);
 }

--- a/tests/event_loop_test.c
+++ b/tests/event_loop_test.c
@@ -1560,6 +1560,9 @@ static int s_test_event_loop_serialized_scheduling(struct aws_allocator *allocat
     ASSERT_TRUE(context.synced_data.external_schedules_processed > 0);
     ASSERT_TRUE(context.synced_data.event_loop_schedules_processed > 0);
 
+    aws_thread_join(&external_thread);
+    aws_thread_clean_up(&external_thread);
+
     s_serialized_scheduling_context_clean_up(&context);
     aws_event_loop_group_release(event_loop_group);
 


### PR DESCRIPTION
* Adds a separate API to event loop scheduling that does not do the short-circuit optimization when called from the same event loop.  This guarantees task order-of-submission is order-of-execution and is crucial when using tasks as io write events.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
