### PR TITLE
Correct PQ-opt-out s2n policy

### DIFF
--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -1539,7 +1539,7 @@ static struct aws_tls_ctx *s_tls_ctx_new(
             security_policy = "AWS-CRT-SDK-TLSv1.2-2025";
             break;
         case AWS_IO_TLS_CIPHER_PREF_TLSV1_0_2023_06:
-            security_policy = "AWS-CRT-SDK-TLSv1.2-2025";
+            security_policy = "AWS-CRT-SDK-TLSv1.0-2023";
             break;
         default:
             AWS_LOGF_ERROR(AWS_LS_IO_TLS, "Unrecognized TLS Cipher Preference: %d", options->cipher_pref);


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

`"AWS-CRT-SDK-TLSv1.0-2023"` [was](https://github.com/awslabs/aws-c-io/blob/9b8d716b3b12de435fbabed834ef435fd3f153c2/source/s2n/s2n_tls_channel_handler.c#L1529) the default prior to PR 740. Correct the PQ-opt-out policy to point to that prior default.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
