### PR TITLE
CI Race Condition Fix

### DIFF
--- a/tests/event_loop_test.c
+++ b/tests/event_loop_test.c
@@ -1521,6 +1521,7 @@ static void s_in_event_loop_scheduling_task(struct aws_task *task, void *arg, en
         aws_mutex_lock(&scheduling_task->test_context->lock);
         scheduling_task->test_context->synced_data.el_scheduling_finished = true;
         aws_mutex_unlock(&scheduling_task->test_context->lock);
+        aws_thread_current_sleep(2000000000);
         aws_condition_variable_notify_all(&scheduling_task->test_context->signal);
     }
 

--- a/tests/event_loop_test.c
+++ b/tests/event_loop_test.c
@@ -1568,8 +1568,10 @@ static int s_test_event_loop_serialized_scheduling(struct aws_allocator *allocat
     aws_thread_join(&external_thread);
     aws_thread_clean_up(&external_thread);
 
-    s_serialized_scheduling_context_clean_up(&context);
+    /* Ensure event loop group is released before cleaning up context to avoid race */
     aws_event_loop_group_release(event_loop_group);
+
+    s_serialized_scheduling_context_clean_up(&context);
 
     aws_io_library_clean_up();
 

--- a/tests/event_loop_test.c
+++ b/tests/event_loop_test.c
@@ -1569,10 +1569,9 @@ static int s_test_event_loop_serialized_scheduling(struct aws_allocator *allocat
     aws_thread_join(&external_thread);
     aws_thread_clean_up(&external_thread);
 
+    s_serialized_scheduling_context_clean_up(&context);
     /* Ensure event loop group is released before cleaning up context to avoid race */
     aws_event_loop_group_release(event_loop_group);
-
-    s_serialized_scheduling_context_clean_up(&context);
 
     aws_io_library_clean_up();
 


### PR DESCRIPTION
A test on event loop serialized scheduling was encountering a race condition in which a conditional variable was being used after it was cleaned up. Reordering the release of the event loop group before cleaning up the context should resolve this issue.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
