### PR TITLE
[bugfix][trivial] thread name too long on CPU with more than 100 cores

### DIFF
--- a/source/event_loop.c
+++ b/source/event_loop.c
@@ -308,7 +308,7 @@ struct aws_event_loop_group *aws_event_loop_group_new_internal(
 
             /* Thread name should be <= 15 characters */
             char thread_name[32] = {0};
-            int thread_name_len = snprintf(thread_name, sizeof(thread_name), "AwsEventLoop %d", (int)i + 1);
+            int thread_name_len = snprintf(thread_name, sizeof(thread_name), "AwsEventLoop%d", (int)i + 1);
             if (thread_name_len > AWS_THREAD_NAME_RECOMMENDED_STRLEN) {
                 snprintf(thread_name, sizeof(thread_name), "AwsEventLoop");
             }


### PR DESCRIPTION
Hello,

I am currently debugging some software that is creating too many threads, one per core, due to using this AWS library.

While debugging, I noticed the thread name is getting truncated when reaching 100.
We have servers with more than 100 cores now, pretty much every server since the last 2 years or so.

Trivial fix, can we adjust the naming to save one character?

FYI: The limit is 16 characters on POSIX kernels, 15 character if that includes the null terminating character (not sure). 

thread dump:
```
154046  155719 root     AwsEventLoop 95 00:00:00 ray::IDLE
 154046  155720 root     AwsEventLoop 96 00:00:00 ray::IDLE
 154046  155726 root     AwsEventLoop 97 00:00:00 ray::IDLE
 154046  155727 root     AwsEventLoop 98 00:00:00 ray::IDLE
 154046  155728 root     AwsEventLoop 99 00:00:00 ray::IDLE
 154046  155729 root     AwsEventLoop    00:00:00 ray::IDLE
 154046  155730 root     AwsEventLoop    00:00:00 ray::IDLE
 154046  155731 root     AwsEventLoop    00:00:00 ray::IDLE
 ...
```

The AWS SDK shouldn't be creating one thread per core, but that's a story for another ticket.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
