### PR TITLE
Disable clang-9 CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,7 +63,9 @@ jobs:
         compiler:
           - name: clang-6
           - name: clang-8
-          - name: clang-9
+          # crt-builder v0.9.72 has some issues there with asan. Updating crt-builder resolves the issue with clang-9,
+          # but introduces issues with other CI jobs. Disable this CI job to unblock CI.
+          # - name: clang-9
           - name: clang-10
           - name: clang-11
           - name: clang-15


### PR DESCRIPTION
crt-builder v0.9.72 has some issues with asan in the `clang-9` CI job.

Updating crt-builder to v0.9.88 resolves the issue with clang-9, but at the same time breaks the `al2` (probably because of https://github.com/awslabs/aws-crt-builder/pull/313) and `downstream` (https://github.com/awslabs/aws-crt-builder/pull/334 and https://github.com/awslabs/aws-crt-builder/pull/337 seem relevant) CI jobs.

So, disable clang-9 job to unblock CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
