### PR TITLE
builder -> v0.9.92 and clang-latest

### DIFF
--- a/.builder/actions/pkcs11_test_setup.py
+++ b/.builder/actions/pkcs11_test_setup.py
@@ -61,6 +61,12 @@ class Pkcs11TestSetup(Builder.Action):
         # print SoftHSM version
         self._exec_softhsm2_util('--version')
 
+        # bail out if softhsm is too old
+        # 2.1.0 is a known offender that crashes on exit if C_Finalize() isn't called
+        if self._get_softhsm2_version() < (2, 2, 0):
+            print("WARNING: SoftHSM2 installation is too old. PKCS#11 tests are disabled")
+            return
+        
         # sanity check SoftHSM is working
         self._exec_softhsm2_util('--show-slots')
 
@@ -109,3 +115,8 @@ class Pkcs11TestSetup(Builder.Action):
         """
         self.env.shell.setenv(var, value)
         self.env.project.config['test_env'][var] = value
+
+    def _get_softhsm2_version(self):
+        output = self._exec_softhsm2_util('--version').output
+        match = re.match(r'([0-9+])\.([0-9]+).([0-9]+)', output)
+        return (int(match.group(1)), int(match.group(2)), int(match.group(3)))

--- a/.builder/actions/pkcs11_test_setup.py
+++ b/.builder/actions/pkcs11_test_setup.py
@@ -46,6 +46,15 @@ class Pkcs11TestSetup(Builder.Action):
             print("WARNING: libsofthsm2.so not found. PKCS#11 tests are disabled")
             return
 
+        # print SoftHSM version
+        self._exec_softhsm2_util('--version')
+
+        # bail out if softhsm is too old
+        # 2.1.0 is a known offender that crashes on exit if C_Finalize() isn't called
+        if self._get_softhsm2_version() < (2, 2, 0):
+            print("WARNING: SoftHSM2 installation is too old. PKCS#11 tests are disabled")
+            return
+
         # set cmake flag so PKCS#11 tests are enabled
         env.project.config['cmake_args'].append('-DENABLE_PKCS11_TESTS=ON')
 
@@ -58,15 +67,6 @@ class Pkcs11TestSetup(Builder.Action):
         with open(conf_path, 'w') as conf_file:
             conf_file.write(f"directories.tokendir = {token_dir}\n")
 
-        # print SoftHSM version
-        self._exec_softhsm2_util('--version')
-
-        # bail out if softhsm is too old
-        # 2.1.0 is a known offender that crashes on exit if C_Finalize() isn't called
-        if self._get_softhsm2_version() < (2, 2, 0):
-            print("WARNING: SoftHSM2 installation is too old. PKCS#11 tests are disabled")
-            return
-        
         # sanity check SoftHSM is working
         self._exec_softhsm2_util('--show-slots')
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.72
+  BUILDER_VERSION: v0.9.92
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-io
@@ -70,6 +70,7 @@ jobs:
           - name: clang-11
           - name: clang-15
           - name: clang-17
+          - name: clang-latest
           - name: gcc-4.8
           - name: gcc-5
           - name: gcc-6


### PR DESCRIPTION
Update builder version to v0.9.92.
Add clang-latest to linux-compiler-compat matrix.

pkcs11_test_setup.py has been updated to follow the same version check pattern used in aws-crt-builder for softhsm2. AL2 currently installs softhsm2 v2.2.1 (it's what's available to AL2) which has an issue that causes a memory leak when run in CI.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
