### PR TITLE
Handle s2n on macos-x64 in CMake config

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -272,7 +272,7 @@ jobs:
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
-        ./builder build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DCMAKE_NO_SYSTEM_FROM_IMPORTED=ON
+        ./builder build -p ${{ env.PACKAGE_NAME }}
 
   macos-x64-s2n:
     runs-on: macos-14-large # latest
@@ -287,7 +287,7 @@ jobs:
       run: |
         python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
         chmod a+x builder
-        ./builder build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DCMAKE_NO_SYSTEM_FROM_IMPORTED=ON
+        ./builder build -p ${{ env.PACKAGE_NAME }}
 
   macos-s2n-debug:
     runs-on: macos-14 # latest

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -139,6 +139,13 @@ if (BYO_CRYPTO)
 endif()
 
 if (USE_S2N)
+        # On macOS x64, prevent s2n's imported targets from using -isystem for OpenSSL headers,
+        # which would cause the system OpenSSL to shadow s2n's bundled copy.
+        if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+            set(_old_CMAKE_NO_SYSTEM_FROM_IMPORTED ${CMAKE_NO_SYSTEM_FROM_IMPORTED})
+            set(CMAKE_NO_SYSTEM_FROM_IMPORTED ON)
+        endif()
+
         file(GLOB AWS_IO_TLS_SRC
                 "source/s2n/*.c"
                 )
@@ -153,6 +160,10 @@ if (USE_S2N)
             # Set flag to use in-source path to  <s2n/unstable/*.h> headers if we do an IN_SOURCE_BUILD.
             aws_use_package(s2n)
             add_definitions(-DAWS_S2N_INSOURCE_PATH)
+        endif()
+
+        if (CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+            set(CMAKE_NO_SYSTEM_FROM_IMPORTED ${_old_CMAKE_NO_SYSTEM_FROM_IMPORTED})
         endif()
 endif()
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -181,6 +181,12 @@ file(GLOB IO_SRC
 
 add_library(${PROJECT_NAME} ${LIBTYPE} ${IO_HEADERS} ${IO_SRC})
 aws_set_common_properties(${PROJECT_NAME})
+
+# On macOS x64, prevent imported targets from using -isystem for OpenSSL headers,
+# which would cause the system OpenSSL to shadow s2n's bundled copy.
+if (USE_S2N AND CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND CMAKE_SYSTEM_PROCESSOR STREQUAL "x86_64")
+    set_target_properties(${PROJECT_NAME} PROPERTIES NO_SYSTEM_FROM_IMPORTED ON)
+endif()
 aws_prepare_symbol_visibility_args(${PROJECT_NAME} "AWS_IO")
 aws_check_headers(${PROJECT_NAME} ${AWS_IO_HEADERS})
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*

- Remove CMAKE_NO_SYSTEM_FROM_IMPORTED from CI config

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
