### PR TITLE
Option to disable revocation check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,6 +59,7 @@ jobs:
   linux-compiler-compat:
     runs-on: ubuntu-24.04 # latest
     strategy:
+      fail-fast: false
       matrix:
         compiler:
           - name: clang-6

--- a/include/aws/io/tls_channel_handler.h
+++ b/include/aws/io/tls_channel_handler.h
@@ -305,9 +305,10 @@ struct aws_tls_ctx_options {
      *
      * On Apple platforms, this is a no-op as revocation checking is not enabled by default.
      *
-     * Default is false (revocation checking enabled).
+     * Default is false (Windows makes a best-effort certificate revocation check to CRL/OCSP and Linux (s2n)
+     * checks against stapled responses).
      */
-    bool disable_certificate_revocation_check;
+    bool no_certificate_revocation;
 };
 
 struct aws_tls_negotiated_protocol_message {
@@ -695,15 +696,17 @@ AWS_IO_API void aws_tls_ctx_options_set_verify_peer(struct aws_tls_ctx_options *
 /**
  * Enables or disables certificate revocation checking during TLS negotiation.
  *
- * On Windows (SChannel), when enabled (the default), the TLS handshake will make outbound network calls
- * to CRL/OCSP revocation endpoints. In environments without internet access, this can cause the handshake
- * to block for minutes while waiting for network timeouts.
+ * On Windows (SChannel), the TLS handshake will make outbound network calls to CRL/OCSP revocation endpoints and makes
+ * a best-effort check. In environments without internet access, this can cause the handshake to block for minutes while
+ * waiting for network timeouts.
+ *
+ * On Linux (s2n) checks against stapled responses
  *
  * Set this to true to skip revocation checking entirely.
  */
-AWS_IO_API void aws_tls_ctx_options_set_certificate_revocation_check_disabled(
+AWS_IO_API void aws_tls_ctx_options_set_no_certificate_revocation(
     struct aws_tls_ctx_options *options,
-    bool disabled);
+    bool no_revocation);
 
 /**
  * Sets preferred TLS Cipher List

--- a/include/aws/io/tls_channel_handler.h
+++ b/include/aws/io/tls_channel_handler.h
@@ -293,6 +293,21 @@ struct aws_tls_ctx_options {
      * cipher preferences that allow TLS 1.3. If this is set, we will always use non TLS 1.3 preferences.
      */
     struct aws_custom_key_op_handler *custom_key_op_handler;
+
+    /**
+     * Set to true to disable certificate revocation checking during TLS negotiation.
+     *
+     * On Windows (SChannel), this prevents the TLS handshake from making outbound network calls
+     * to CRL/OCSP revocation endpoints, which can block for minutes when the endpoints are unreachable
+     * (e.g., in private subnets without internet access).
+     *
+     * On Linux (s2n), this disables validation of OCSP stapled responses provided by the server.
+     *
+     * On Apple platforms, this is a no-op as revocation checking is not enabled by default.
+     *
+     * Default is false (revocation checking enabled).
+     */
+    bool disable_certificate_revocation_check;
 };
 
 struct aws_tls_negotiated_protocol_message {
@@ -676,6 +691,19 @@ AWS_IO_API int aws_tls_ctx_options_set_alpn_list(struct aws_tls_ctx_options *opt
  * set verify_peer to true.
  */
 AWS_IO_API void aws_tls_ctx_options_set_verify_peer(struct aws_tls_ctx_options *options, bool verify_peer);
+
+/**
+ * Enables or disables certificate revocation checking during TLS negotiation.
+ *
+ * On Windows (SChannel), when enabled (the default), the TLS handshake will make outbound network calls
+ * to CRL/OCSP revocation endpoints. In environments without internet access, this can cause the handshake
+ * to block for minutes while waiting for network timeouts.
+ *
+ * Set this to true to skip revocation checking entirely.
+ */
+AWS_IO_API void aws_tls_ctx_options_set_certificate_revocation_check_disabled(
+    struct aws_tls_ctx_options *options,
+    bool disabled);
 
 /**
  * Sets preferred TLS Cipher List

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -1698,17 +1698,20 @@ static struct aws_tls_ctx *s_tls_ctx_new(
     }
 
     if (options->verify_peer) {
-        if (s2n_config_set_check_stapled_ocsp_response(s2n_ctx->s2n_config, 1) == S2N_SUCCESS) {
-            if (s2n_config_set_status_request_type(s2n_ctx->s2n_config, S2N_STATUS_REQUEST_OCSP) != S2N_SUCCESS) {
-                s_log_and_raise_s2n_errno("ctx: ocsp status request cannot be set");
-                goto cleanup_s2n_config;
-            }
-        } else {
-            if (s2n_error_get_type(s2n_errno) == S2N_ERR_T_USAGE) {
-                AWS_LOGF_INFO(AWS_LS_IO_TLS, "ctx: cannot enable ocsp stapling: %s", s2n_strerror(s2n_errno, "EN"));
+
+        if (!options->disable_certificate_revocation_check) {
+            if (s2n_config_set_check_stapled_ocsp_response(s2n_ctx->s2n_config, 1) == S2N_SUCCESS) {
+                if (s2n_config_set_status_request_type(s2n_ctx->s2n_config, S2N_STATUS_REQUEST_OCSP) != S2N_SUCCESS) {
+                    s_log_and_raise_s2n_errno("ctx: ocsp status request cannot be set");
+                    goto cleanup_s2n_config;
+                }
             } else {
-                s_log_and_raise_s2n_errno("ctx: cannot enable ocsp stapling");
-                goto cleanup_s2n_config;
+                if (s2n_error_get_type(s2n_errno) == S2N_ERR_T_USAGE) {
+                    AWS_LOGF_INFO(AWS_LS_IO_TLS, "ctx: cannot enable ocsp stapling: %s", s2n_strerror(s2n_errno, "EN"));
+                } else {
+                    s_log_and_raise_s2n_errno("ctx: cannot enable ocsp stapling");
+                    goto cleanup_s2n_config;
+                }
             }
         }
 

--- a/source/s2n/s2n_tls_channel_handler.c
+++ b/source/s2n/s2n_tls_channel_handler.c
@@ -1699,7 +1699,7 @@ static struct aws_tls_ctx *s_tls_ctx_new(
 
     if (options->verify_peer) {
 
-        if (!options->disable_certificate_revocation_check) {
+        if (!options->no_certificate_revocation) {
             if (s2n_config_set_check_stapled_ocsp_response(s2n_ctx->s2n_config, 1) == S2N_SUCCESS) {
                 if (s2n_config_set_status_request_type(s2n_ctx->s2n_config, S2N_STATUS_REQUEST_OCSP) != S2N_SUCCESS) {
                     s_log_and_raise_s2n_errno("ctx: ocsp status request cannot be set");

--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -511,8 +511,8 @@ void aws_tls_ctx_options_set_verify_peer(struct aws_tls_ctx_options *options, bo
     options->verify_peer = verify_peer;
 }
 
-void aws_tls_ctx_options_set_certificate_revocation_check_disabled(struct aws_tls_ctx_options *options, bool disabled) {
-    options->disable_certificate_revocation_check = disabled;
+void aws_tls_ctx_options_set_no_certificate_revocation(struct aws_tls_ctx_options *options, bool no_revocation) {
+    options->no_certificate_revocation = no_revocation;
 }
 
 void aws_tls_ctx_options_set_minimum_tls_version(

--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -511,9 +511,7 @@ void aws_tls_ctx_options_set_verify_peer(struct aws_tls_ctx_options *options, bo
     options->verify_peer = verify_peer;
 }
 
-void aws_tls_ctx_options_set_certificate_revocation_check_disabled(
-    struct aws_tls_ctx_options *options,
-    bool disabled) {
+void aws_tls_ctx_options_set_certificate_revocation_check_disabled(struct aws_tls_ctx_options *options, bool disabled) {
     options->disable_certificate_revocation_check = disabled;
 }
 

--- a/source/tls_channel_handler.c
+++ b/source/tls_channel_handler.c
@@ -511,6 +511,12 @@ void aws_tls_ctx_options_set_verify_peer(struct aws_tls_ctx_options *options, bo
     options->verify_peer = verify_peer;
 }
 
+void aws_tls_ctx_options_set_certificate_revocation_check_disabled(
+    struct aws_tls_ctx_options *options,
+    bool disabled) {
+    options->disable_certificate_revocation_check = disabled;
+}
+
 void aws_tls_ctx_options_set_minimum_tls_version(
     struct aws_tls_ctx_options *options,
     enum aws_tls_versions minimum_tls_version) {

--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -2424,7 +2424,7 @@ struct aws_tls_ctx *s_ctx_new(
         dw_flags |= SCH_CRED_IGNORE_NO_REVOCATION_CHECK | SCH_CRED_IGNORE_REVOCATION_OFFLINE |
                     SCH_CRED_NO_SERVERNAME_CHECK | SCH_CRED_MANUAL_CRED_VALIDATION;
     } else if (is_client_mode) {
-        if (!options->disable_certificate_revocation_check) {
+        if (!options->no_certificate_revocation) {
             dw_flags |= SCH_CRED_REVOCATION_CHECK_CHAIN | SCH_CRED_IGNORE_REVOCATION_OFFLINE;
         }
     }

--- a/source/windows/secure_channel_tls_handler.c
+++ b/source/windows/secure_channel_tls_handler.c
@@ -2424,7 +2424,9 @@ struct aws_tls_ctx *s_ctx_new(
         dw_flags |= SCH_CRED_IGNORE_NO_REVOCATION_CHECK | SCH_CRED_IGNORE_REVOCATION_OFFLINE |
                     SCH_CRED_NO_SERVERNAME_CHECK | SCH_CRED_MANUAL_CRED_VALIDATION;
     } else if (is_client_mode) {
-        dw_flags |= SCH_CRED_REVOCATION_CHECK_CHAIN | SCH_CRED_IGNORE_REVOCATION_OFFLINE;
+        if (!options->disable_certificate_revocation_check) {
+            dw_flags |= SCH_CRED_REVOCATION_CHECK_CHAIN | SCH_CRED_IGNORE_REVOCATION_OFFLINE;
+        }
     }
 
     /* if someone wants to use broken algorithms like rc4/md5/des they'll need to ask for a special control */

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -237,13 +237,15 @@ if(NOT BYO_CRYPTO)
     add_net_test_case(tls_client_channel_negotiation_no_verify_self_signed)
     add_net_test_case(tls_client_channel_negotiation_no_verify_untrusted_root)
 
-    # Badssl - Certificate Revocation suite (Windows only)
+    # Badssl - Certificate Revocation (Windows only)
     # On Windows, SChannel performs CRL/OCSP revocation checks by default.
-    # These tests verify that our disable_certificate_revocation_check option works.
     if(WIN32)
         add_net_test_case(tls_client_channel_negotiation_error_revoked)
-        add_net_test_case(tls_client_channel_negotiation_revoked_no_check)
     endif()
+
+    # This test will verify that our disable_certificate_revocation_check option works
+    # as expected.
+    add_net_test_case(tls_client_channel_negotiation_revoked_no_check)
 
     # Badssl - Broken Crypto endpoint suite
     # We don't include dh1024 as it succeeds on the windows baseline configuration and there does not seem

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -243,9 +243,12 @@ if(NOT BYO_CRYPTO)
         add_net_test_case(tls_client_channel_negotiation_error_revoked)
     endif()
 
-    # This test will verify that our no_certificate_revocation option works
-    # as expected.
-    add_net_test_case(tls_client_channel_negotiation_revoked_no_check)
+    # This test verifies that our no_certificate_revocation option works.
+    # Runs on Windows (proves revocation is skipped) and Linux (proves option doesn't break s2n).
+    # Skipped on Apple where revocation is never checked and cert validity issues cause false failures.
+    if(NOT APPLE)
+        add_net_test_case(tls_client_channel_negotiation_revoked_no_check)
+    endif()
 
     # Badssl - Broken Crypto endpoint suite
     # We don't include dh1024 as it succeeds on the windows baseline configuration and there does not seem

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -237,6 +237,14 @@ if(NOT BYO_CRYPTO)
     add_net_test_case(tls_client_channel_negotiation_no_verify_self_signed)
     add_net_test_case(tls_client_channel_negotiation_no_verify_untrusted_root)
 
+    # Badssl - Certificate Revocation suite (Windows only)
+    # On Windows, SChannel performs CRL/OCSP revocation checks by default.
+    # These tests verify that our disable_certificate_revocation_check option works.
+    if(WIN32)
+        add_net_test_case(tls_client_channel_negotiation_error_revoked)
+        add_net_test_case(tls_client_channel_negotiation_revoked_no_check)
+    endif()
+
     # Badssl - Broken Crypto endpoint suite
     # We don't include dh1024 as it succeeds on the windows baseline configuration and there does not seem
     # to be a way to disable it

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -243,7 +243,7 @@ if(NOT BYO_CRYPTO)
         add_net_test_case(tls_client_channel_negotiation_error_revoked)
     endif()
 
-    # This test will verify that our disable_certificate_revocation_check option works
+    # This test will verify that our no_certificate_revocation option works
     # as expected.
     add_net_test_case(tls_client_channel_negotiation_revoked_no_check)
 

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -1794,7 +1794,7 @@ AWS_TEST_CASE(tls_client_channel_negotiation_error_revoked, s_tls_client_channel
 #    endif /* _WIN32 */
 
 static void s_disable_revocation_check(struct aws_tls_ctx_options *options) {
-    aws_tls_ctx_options_set_certificate_revocation_check_disabled(options, true);
+    aws_tls_ctx_options_set_no_certificate_revocation(options, true);
 }
 
 /* On Windows, connecting to a revoked cert should succeed when revocation checking is disabled */

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -1781,9 +1781,9 @@ AWS_TEST_CASE(
     tls_client_channel_negotiation_no_verify_untrusted_root,
     s_tls_client_channel_negotiation_no_verify_untrusted_root_fn)
 
-#    ifdef _WIN32
 AWS_STATIC_STRING_FROM_LITERAL(s_revoked_host_name, "revoked.badssl.com");
 
+#    ifdef _WIN32
 /* On Windows, connecting to a revoked cert should fail with default options (revocation check enabled) */
 static int s_tls_client_channel_negotiation_error_revoked_fn(struct aws_allocator *allocator, void *ctx) {
     (void)ctx;
@@ -1791,6 +1791,7 @@ static int s_tls_client_channel_negotiation_error_revoked_fn(struct aws_allocato
 }
 
 AWS_TEST_CASE(tls_client_channel_negotiation_error_revoked, s_tls_client_channel_negotiation_error_revoked_fn)
+#    endif /* _WIN32 */
 
 static void s_disable_revocation_check(struct aws_tls_ctx_options *options) {
     aws_tls_ctx_options_set_certificate_revocation_check_disabled(options, true);
@@ -1803,7 +1804,6 @@ static int s_tls_client_channel_negotiation_revoked_no_check_fn(struct aws_alloc
 }
 
 AWS_TEST_CASE(tls_client_channel_negotiation_revoked_no_check, s_tls_client_channel_negotiation_revoked_no_check_fn)
-#    endif /* _WIN32 */
 
 static void s_lower_tls_version_to_tls10(struct aws_tls_ctx_options *options) {
     aws_tls_ctx_options_set_minimum_tls_version(options, AWS_IO_TLSv1);

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -1781,7 +1781,7 @@ AWS_TEST_CASE(
     tls_client_channel_negotiation_no_verify_untrusted_root,
     s_tls_client_channel_negotiation_no_verify_untrusted_root_fn)
 
-#ifdef _WIN32
+#    ifdef _WIN32
 AWS_STATIC_STRING_FROM_LITERAL(s_revoked_host_name, "revoked.badssl.com");
 
 /* On Windows, connecting to a revoked cert should fail with default options (revocation check enabled) */
@@ -1802,10 +1802,8 @@ static int s_tls_client_channel_negotiation_revoked_no_check_fn(struct aws_alloc
     return s_verify_good_host(allocator, s_revoked_host_name, 443, &s_disable_revocation_check);
 }
 
-AWS_TEST_CASE(
-    tls_client_channel_negotiation_revoked_no_check,
-    s_tls_client_channel_negotiation_revoked_no_check_fn)
-#endif /* _WIN32 */
+AWS_TEST_CASE(tls_client_channel_negotiation_revoked_no_check, s_tls_client_channel_negotiation_revoked_no_check_fn)
+#    endif /* _WIN32 */
 
 static void s_lower_tls_version_to_tls10(struct aws_tls_ctx_options *options) {
     aws_tls_ctx_options_set_minimum_tls_version(options, AWS_IO_TLSv1);

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -1781,6 +1781,32 @@ AWS_TEST_CASE(
     tls_client_channel_negotiation_no_verify_untrusted_root,
     s_tls_client_channel_negotiation_no_verify_untrusted_root_fn)
 
+#ifdef _WIN32
+AWS_STATIC_STRING_FROM_LITERAL(s_revoked_host_name, "revoked.badssl.com");
+
+/* On Windows, connecting to a revoked cert should fail with default options (revocation check enabled) */
+static int s_tls_client_channel_negotiation_error_revoked_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+    return s_verify_negotiation_fails(allocator, s_revoked_host_name, 443, NULL);
+}
+
+AWS_TEST_CASE(tls_client_channel_negotiation_error_revoked, s_tls_client_channel_negotiation_error_revoked_fn)
+
+static void s_disable_revocation_check(struct aws_tls_ctx_options *options) {
+    aws_tls_ctx_options_set_certificate_revocation_check_disabled(options, true);
+}
+
+/* On Windows, connecting to a revoked cert should succeed when revocation checking is disabled */
+static int s_tls_client_channel_negotiation_revoked_no_check_fn(struct aws_allocator *allocator, void *ctx) {
+    (void)ctx;
+    return s_verify_good_host(allocator, s_revoked_host_name, 443, &s_disable_revocation_check);
+}
+
+AWS_TEST_CASE(
+    tls_client_channel_negotiation_revoked_no_check,
+    s_tls_client_channel_negotiation_revoked_no_check_fn)
+#endif /* _WIN32 */
+
 static void s_lower_tls_version_to_tls10(struct aws_tls_ctx_options *options) {
     aws_tls_ctx_options_set_minimum_tls_version(options, AWS_IO_TLSv1);
 }


### PR DESCRIPTION
Revocation checks done on Windows uses an outbound network call that operates on an OS timeout that doesn't respect the tls timeout that we set. This is due to the TLS handling thread being blocked while Windows attempts to complete the network call to check revocation via CRL/OCSP endpoints. When a network is unavailable, this causes a huge delay during the TLS handshake.

Adding `disable_certificate_revocation_check` option to `aws_tls_ctx_options` which allows revocation checks to be turned off. This bypasses the issue outlined above for Windows.

In Linux, we only check the "Server-stapled" OCSP and this is also bypassed if the `disable_certificate_revocation_check` is set to true.

In Apple, this is a no-op as revocation checks were never done.

This commit also adds two tests against badssl.com. One that confirms that the revocation check fails, and one that confirms that if the revocation check is disabled, we connect even with a bad revocation check.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
