### PR TITLE
Unsetting USE_S2N disables s2n on macOS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -38,8 +38,6 @@ file(GLOB AWS_IO_SRC
         "source/*.c"
         )
 
-set(USE_S2N OFF)
-
 if (WIN32)
     option(USE_IO_COMPLETION_PORTS
             "Use I/O Completion Ports to drive event-loops. \
@@ -110,10 +108,17 @@ elseif (APPLE)
         list(APPEND EVENT_LOOP_DEFINES "DISPATCH_QUEUE")
     endif ()
 
-    # Enable KQUEUE and s2n-tls on MacOS only if AWS_USE_SECITEM is not declared. SecItem requires Dispatch Queue.
+    # Enable KQUEUE on MacOS only if AWS_USE_SECITEM is not declared. SecItem requires Dispatch Queue.
     if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT DEFINED AWS_USE_SECITEM)
         list(APPEND EVENT_LOOP_DEFINES "KQUEUE")
-        set(USE_S2N ON)
+    endif()
+
+    # On MacOS s2n-tls is optional (the Apple SecItem/Security framework provides a TLS implementation).
+    # Default to using s2n-tls only when SecItem is not requested. Users can override with -DUSE_S2N=ON/OFF.
+    if (${CMAKE_SYSTEM_NAME} MATCHES "Darwin" AND NOT DEFINED AWS_USE_SECITEM)
+        option(USE_S2N "Use s2n-tls as the TLS implementation." ON)
+    else()
+        option(USE_S2N "Use s2n-tls as the TLS implementation." OFF)
     endif()
 
 elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "NetBSD" OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")

--- a/README.md
+++ b/README.md
@@ -783,7 +783,7 @@ The following CMake options control how aws-c-io is built:
 Option | Platform | Description | Default
 --- | --- | --- | ---
 `USE_S2N` | Linux | Enables s2n-tls as the TLS implementation. Automatically enabled on Linux. | ON
-`USE_S2N` | macOS | Enables s2n-tls as the TLS implementation. Automatically enabled when `AWS_USE_SECITEM` is not defined. | ON (when `AWS_USE_SECITEM` is not defined)
+`USE_S2N` | macOS | Compiles s2n-tls in as an available TLS implementation. User-overridable via `-DUSE_S2N=ON/OFF`. Note that Apple Secure Transport remains the default backend even when `ON` (s2n-tls is only selected when `AWS_CRT_USE_NON_FIPS_TLS_13` is set); setting `OFF` removes s2n-tls from the macOS build entirely. | ON when `AWS_USE_SECITEM` is not defined, otherwise OFF
 `AWS_USE_SECITEM` | Apple | Uses Apple's SecItem/Secure Transport API instead of s2n-tls. When defined (regardless of value), the Apple Dispatch Queue event loop is used instead of kqueue. | Not defined
 `USE_VSOCK` | Linux | Enables VSOCK socket domain support. Requires an appropriate VSOCK kernel driver. | OFF
 `BYO_CRYPTO` | Linux/Non-Apple Unix | Disables the built-in TLS implementation and crypto linkage. Your application must provide its own `aws_tls_ctx` and `aws_channel_handler` implementations. | OFF


### PR DESCRIPTION
`USE_S2N` CMake option controls whether to enable s2n-tls on macOS.

On Linux, BSD, and Android, s2n-tls is still always forced as only available TLS implementation.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
