### PR TITLE
Fix OpenBSD CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -378,7 +378,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       id: test
-      uses: cross-platform-actions/action@v0.23.0
+      uses: cross-platform-actions/action@v1.3.0
       with:
         operating_system: openbsd
         architecture: x86-64

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -370,6 +370,11 @@ jobs:
 
   openbsd:
     runs-on: ubuntu-24.04 # latest
+    strategy:
+      fail-fast: false
+      matrix:
+        # OpenBSD only supports the two most recent releases
+        version: ['7.8', '7.9']
     steps:
     - uses: aws-actions/configure-aws-credentials@v4
       with:
@@ -382,7 +387,7 @@ jobs:
       with:
         operating_system: openbsd
         architecture: x86-64
-        version: '7.8'
+        version: ${{ matrix.version }}
         cpu_count: 4
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
 
 env:
-  BUILDER_VERSION: v0.9.92
+  BUILDER_VERSION: v0.9.96
   BUILDER_SOURCE: releases
   BUILDER_HOST: https://d19elf31gohf1l.cloudfront.net
   PACKAGE_NAME: aws-c-io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -382,7 +382,7 @@ jobs:
       with:
         operating_system: openbsd
         architecture: x86-64
-        version: '7.4'
+        version: '7.8'
         cpu_count: 4
         shell: bash
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -355,7 +355,7 @@ jobs:
     - uses: actions/checkout@v4
     - name: Build ${{ env.PACKAGE_NAME }} + consumers
       id: test
-      uses: cross-platform-actions/action@v0.23.0
+      uses: cross-platform-actions/action@v1.3.0
       with:
         operating_system: freebsd
         architecture: x86-64


### PR DESCRIPTION
*Issue #, if available:*
OpenBSD 7.4 packages were removed from mirrors, breaking CI with "no such dir" errors.

*Description of changes:*
- Use two latest OpenBSD versions: 7.8 and 7.9
- Update cross-platform-actions/action to v1.3.0 (both OpenBSD and FreeBSD jobs)
- Bump aws-crt-builder to v0.9.96

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
