### PR TITLE
Handle optional s2n-tls in the install CMake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,12 @@ elseif (APPLE)
         option(USE_S2N "Use s2n-tls as the TLS implementation." OFF)
     endif()
 
+    # Force USE_S2N OFF to avoid pulling in an unused s2n dependency.
+    if (DEFINED AWS_USE_SECITEM AND USE_S2N)
+        message(WARNING "AWS_USE_SECITEM takes precedence over s2n-tls; forcing USE_S2N=OFF to avoid linking unused s2n.")
+        set(USE_S2N OFF CACHE BOOL "Use s2n-tls as the TLS implementation." FORCE)
+    endif()
+
 elseif (CMAKE_SYSTEM_NAME STREQUAL "FreeBSD" OR CMAKE_SYSTEM_NAME STREQUAL "NetBSD" OR CMAKE_SYSTEM_NAME STREQUAL "OpenBSD")
     file(GLOB AWS_IO_OS_HEADERS
             )

--- a/README.md
+++ b/README.md
@@ -780,13 +780,12 @@ Writes to the socket. This call is non-blocking and will return `AWS_IO_SOCKET_W
 
 The following CMake options control how aws-c-io is built:
 
-Option | Platform | Description | Default
---- | --- | --- | ---
-`USE_S2N` | Linux | Enables s2n-tls as the TLS implementation. Automatically enabled on Linux. | ON
-`USE_S2N` | macOS | Compiles s2n-tls in as an available TLS implementation. User-overridable via `-DUSE_S2N=ON/OFF`. Note that Apple Secure Transport remains the default backend even when `ON` (s2n-tls is only selected when `AWS_CRT_USE_NON_FIPS_TLS_13` is set); setting `OFF` removes s2n-tls from the macOS build entirely. | ON when `AWS_USE_SECITEM` is not defined, otherwise OFF
-`AWS_USE_SECITEM` | Apple | Uses Apple's SecItem/Secure Transport API instead of s2n-tls. When defined (regardless of value), the Apple Dispatch Queue event loop is used instead of kqueue. | Not defined
-`USE_VSOCK` | Linux | Enables VSOCK socket domain support. Requires an appropriate VSOCK kernel driver. | OFF
-`BYO_CRYPTO` | Linux/Non-Apple Unix | Disables the built-in TLS implementation and crypto linkage. Your application must provide its own `aws_tls_ctx` and `aws_channel_handler` implementations. | OFF
+Option | Platform | Description                                                                                                                                                                                                                                                                                                        | Default
+--- | --- |--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------| ---
+`USE_S2N` | macOS | Compiles s2n-tls in as an available TLS implementation. User-overridable via `-DUSE_S2N=ON/OFF`.<br>Note that Apple Secure Transport remains the default backend even when `ON` (s2n-tls is only selected when `AWS_CRT_USE_NON_FIPS_TLS_13` is set); setting `OFF` removes s2n-tls from the macOS build entirely.<br>If `AWS_USE_SECITEM` is defined, s2n-tls is never used at runtime, so `USE_S2N` is forced to `OFF` (with a warning) even if explicitly set to `ON`, to avoid linking an unused s2n dependency. | ON when `AWS_USE_SECITEM` is not defined, otherwise OFF
+`AWS_USE_SECITEM` | Apple | Uses Apple's SecItem/Secure Transport API instead of s2n-tls. When defined (regardless of value), the Apple Dispatch Queue event loop is used instead of kqueue.                                                                                                                                                   | Not defined
+`USE_VSOCK` | Linux | Enables VSOCK socket domain support. Requires an appropriate VSOCK kernel driver.                                                                                                                                                                                                                                  | OFF
+`BYO_CRYPTO` | Linux/Non-Apple Unix | Disables the built-in TLS implementation and crypto linkage. Your application must provide its own `aws_tls_ctx` and `aws_channel_handler` implementations.                                                                                                                                                        | OFF
 
 ### Runtime Environment Variables
 
@@ -794,7 +793,7 @@ The following environment variables influence runtime behavior:
 
 Variable | Platform | Description
 --- | --- | ---
-`AWS_CRT_USE_NON_FIPS_TLS_13` | macOS | When set to any non-empty value, the TLS implementation uses s2n-tls instead of Apple Secure Transport. This enables TLS 1.3 support but uses a non-FIPS-validated TLS implementation. If unset or empty, Apple Secure Transport is used by default (which provides FIPS-validated TLS but lacks TLS 1.3 support). Requires `USE_S2N` at build time.
+`AWS_CRT_USE_NON_FIPS_TLS_13` | macOS | Requires `USE_S2N=ON` at build time.<br>When set to any non-empty value, the TLS implementation uses s2n-tls instead of Apple Secure Transport. This enables TLS 1.3 support but uses a non-FIPS-validated TLS implementation. If unset or empty, Apple Secure Transport is used by default (which provides FIPS-validated TLS but lacks TLS 1.3 support).
 
 ### TLS Backend Selection
 

--- a/cmake/aws-c-io-config.cmake
+++ b/cmake/aws-c-io-config.cmake
@@ -1,6 +1,8 @@
 include(CMakeFindDependencyMacro)
 
-if (UNIX AND NOT BYO_CRYPTO)
+# USE_S2N is substituted at aws-c-io configure time (configure_file @ONLY) with the
+# actual build decision, so this matches whether aws-c-io was really linked against s2n.
+if (@USE_S2N@)
     find_dependency(s2n)
 endif()
 

--- a/tests/tls_handler_test.c
+++ b/tests/tls_handler_test.c
@@ -48,14 +48,17 @@ bool s_is_badssl_being_flaky(const struct aws_string *host_name, int error_code)
 
 bool s_is_apple_with_secure_transport(struct aws_allocator *allocator) {
     (void)allocator;
-#    ifdef __APPLE__
+#    if defined(__APPLE__) && defined(USE_S2N)
+    /* When s2n is compiled in, AWS_CRT_USE_NON_FIPS_TLS_13 selects s2n over Secure Transport. */
     struct aws_string *use_non_fips_13 = aws_get_env_nonempty(allocator, "AWS_CRT_USE_NON_FIPS_TLS_13");
     if (use_non_fips_13) {
         aws_string_destroy(use_non_fips_13);
         return false;
-    } else {
-        return true;
     }
+    return true;
+#    elif defined(__APPLE__)
+    /* Without s2n compiled in, Secure Transport is always used and the env var has no effect. */
+    return true;
 #    else
     return false;
 #    endif


### PR DESCRIPTION
*Issue #, if available:*
The install config always run `find_dependency(s2n)` on Unix, forcing consumers to have s2n even when aws-c-io was built without it.

*Description of changes:*
- gate `find_dependency(s2n)` on the actual build decision via `@USE_S2N@` substitution, so s2n is only required when it was really linked in.
- Force `USE_S2N=OFF` when `AWS_USE_SECITEM` is set, to avoid linking an unused s2n dependency.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
