### PR TITLE
feat: keychain-less macOS identity mode

### DIFF
--- a/.github/workflows/block-needs-review.yml
+++ b/.github/workflows/block-needs-review.yml
@@ -9,4 +9,4 @@ permissions:
 
 jobs:
   gate:
-    uses: awslabs/aws-crt-builder/.github/workflows/block-needs-review-label.yml@main
+    uses: awslabs/aws-crt-builder/.github/workflows/block-needs-review-label.yml@label-on-push

--- a/.github/workflows/check-abi.yml
+++ b/.github/workflows/check-abi.yml
@@ -36,7 +36,7 @@ jobs:
           fetch-depth: 0
 
       - name: Check ABI
-        uses: awslabs/aws-crt-builder/.github/actions/check-abi@main
+        uses: awslabs/aws-crt-builder/.github/actions/check-abi@label-on-push
         with:
           lib-name: ${{ env.PACKAGE_NAME }}
           builder-version: latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,6 +345,23 @@ jobs:
         chmod a+x builder
         ./builder build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DAWS_USE_SECITEM=ON --cmake-extra=-DAWS_USE_APPLE_NETWORK_FRAMEWORK=ON --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS="${{ matrix.sanitizers }}"
 
+  macos-secitem-no-keychain:
+    runs-on: macos-14 # latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizers: [",thread", ",address,undefined"]
+    steps:
+    - uses: aws-actions/configure-aws-credentials@v4
+      with:
+        role-to-assume: ${{ env.CRT_CI_ROLE }}
+        aws-region: ${{ env.AWS_DEFAULT_REGION }}
+    - name: Build ${{ env.PACKAGE_NAME }} + consumers
+      run: |
+        python3 -c "from urllib.request import urlretrieve; urlretrieve('${{ env.BUILDER_HOST }}/${{ env.BUILDER_SOURCE }}/${{ env.BUILDER_VERSION }}/builder.pyz?run=${{ env.RUN }}', 'builder')"
+        chmod a+x builder
+        ./builder build -p ${{ env.PACKAGE_NAME }} --cmake-extra=-DAWS_USE_SECITEM=ON --cmake-extra=-DAWS_DONOT_USE_KEYCHAIN=ON --cmake-extra=-DAWS_USE_APPLE_NETWORK_FRAMEWORK=ON --cmake-extra=-DENABLE_SANITIZERS=ON --cmake-extra=-DSANITIZERS="${{ matrix.sanitizers }}"
+
   freebsd:
     runs-on: ubuntu-24.04  # latest
     steps:

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -215,6 +215,10 @@ if (AWS_USE_SECITEM)
     target_compile_definitions(${PROJECT_NAME} PUBLIC "-DAWS_USE_SECITEM")
 endif()
 
+if (AWS_DONOT_USE_KEYCHAIN)
+    target_compile_definitions(${PROJECT_NAME} PUBLIC "-DAWS_DONOT_USE_KEYCHAIN")
+endif()
+
 if (BYO_CRYPTO)
     target_compile_definitions(${PROJECT_NAME} PUBLIC "-DBYO_CRYPTO")
 endif()

--- a/source/darwin/darwin_pki_utils.c
+++ b/source/darwin/darwin_pki_utils.c
@@ -798,6 +798,26 @@ int aws_secitem_import_cert_and_key(
         goto done;
     }
 
+#ifdef AWS_DONOT_USE_KEYCHAIN
+    SecIdentityRef  identity_ref    = NULL;
+    sec_identity_t  identity        = NULL;
+
+    if((identity_ref = SecIdentityCreate(cf_alloc, cert_ref, key_ref)) == NULL) {
+        AWS_LOGF_ERROR(
+            AWS_LS_IO_PKI, "SecIdentityCreate failed to create a SecIdentityRef from provided certificate and private key.");
+    } else if((identity = sec_identity_create(identity_ref)) == NULL) {
+        AWS_LOGF_ERROR(
+            AWS_LS_IO_PKI, "sec_identity_create failed to create a sec_identity_t from provided SecIdentityRef.");
+    } else {
+        AWS_LOGF_INFO(AWS_LS_IO_PKI, "Successfully created identity using SecIdentityCreate.");
+        *secitem_identity = identity;
+        result = AWS_OP_SUCCESS;
+    }
+
+    if (identity_ref != NULL) {
+        aws_cf_release(identity_ref);
+    }
+#else
     // Add the certificate and private key to keychain then retrieve identity
 
     if (s_aws_secitem_add_certificate_to_keychain(cf_alloc, cert_ref, cert_serial_data, cert_label_ref)) {
@@ -813,6 +833,7 @@ int aws_secitem_import_cert_and_key(
     }
 
     result = AWS_OP_SUCCESS;
+#endif
 
 done:
     // cleanup


### PR DESCRIPTION
*Issue #, if available:* N/A

*Description of changes:*

Adds an opt-in `AWS_DONOT_USE_KEYCHAIN` build option for Apple platforms. When
enabled, the mTLS `SecIdentityRef` is built in memory directly from the provided
certificate and private key via `SecIdentityCreate` (wrapped with
`sec_identity_create`), instead of adding them to the shared macOS Keychain and
reading the identity back out. This suits products whose security requirements
forbid persisting the certificate and private key in the system Keychain.

The existing Keychain-based path is preserved under `#else`, so the option is
off by default and existing consumers are unaffected.

- `CMakeLists.txt`: define `-DAWS_DONOT_USE_KEYCHAIN` when the option is set.
- `source/darwin/darwin_pki_utils.c`: `#ifdef AWS_DONOT_USE_KEYCHAIN` branch in
  `aws_secitem_import_cert_and_key`.

Draft: no tests yet, and `SecIdentityCreate` availability on the supported
deployment targets should be confirmed before this is marked ready.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
