### PR TITLE
chore: Clarifying comment for SecIdentityCreate Api

### DIFF
--- a/source/darwin/darwin_pki_utils.c
+++ b/source/darwin/darwin_pki_utils.c
@@ -364,7 +364,8 @@ void aws_cf_release(CFTypeRef obj) {
 }
 
 #ifdef AWS_SECITEM_NO_KEYCHAIN
-/* SecIdentityCreate is a private (SPI) function not exposed in the public Security.framework headers. */
+/* SecIdentityCreate became a public documented security API in the macOS 26 SDK (in October 2025).Earlier SDKs do not
+ * declare it in the Security.framework headers, so we forward-declare it here to build against them.*/
 extern SecIdentityRef SecIdentityCreate(CFAllocatorRef allocator, SecCertificateRef certificate, SecKeyRef privateKey);
 #else
 static int s_aws_secitem_add_certificate_to_keychain(


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
On recent addition of `AWS_SECITEM_NO_KEYCHAIN` flag, SecIdentityCreate api was documented as private API , however it become public API with macOS 26.0 SDK hence documented it properly for future reference

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
